### PR TITLE
feat(mission): Marti Mission API client + Create-mission sheet (BETA)

### DIFF
--- a/OmniTAKMobile.xcodeproj/project.pbxproj
+++ b/OmniTAKMobile.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		326BFC60CF089F263DCD8E18 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D7BCCB87FE00A332286EAC /* ChatView.swift */; };
 		341184270C1E3D9E6957FC02 /* ChatXMLGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EE71ECBA829946C5219664 /* ChatXMLGenerator.swift */; };
 		34217C41D584C13B2AE673C7 /* ServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3370233EDA8C5D193E4F794E /* ServerManager.swift */; };
+		3468A1C1F984D1C219D27CDD /* MissionCreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DC74E1105D8C0099F94F74 /* MissionCreateView.swift */; };
 		35A17E72BAD1259DBA19945E /* TeamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922F25506591914930EEC898 /* TeamService.swift */; };
 		3678FDDE6524CFE84931B1A8 /* PositionBroadcastService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B658D0038B68527525C8D5A3 /* PositionBroadcastService.swift */; };
 		3767932CE1360D4E75786269 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A299080EB48E2B8246EE899 /* SettingsView.swift */; };
@@ -254,6 +255,7 @@
 		DABDFF989E658D9DE52E3CA2 /* CoTFilterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D927DC29FB5FDD9F156C1899 /* CoTFilterManager.swift */; };
 		DC61BCF4E8961A2CE7E6FEC1 /* SFAPACR----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9001E88B5E1060AC73E893AF /* SFAPACR----.svg */; };
 		DCDDE37CA3DE6EBC99B2D568 /* BundledPlugins.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7006F833D70792E7802700D /* BundledPlugins.swift */; };
+		DCED029F9433FD65EBF71AA5 /* MissionAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F3947CA047D67EC12635A5 /* MissionAPIClient.swift */; };
 		DE13E8D462F0655B012B5AB0 /* RadialMenuModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBC2615A833D70CD96C5723 /* RadialMenuModels.swift */; };
 		DE33389B8145869804340112 /* BNGConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5160EE3247DE0377F3E6CE8 /* BNGConverter.swift */; };
 		E072202BA54DC55005061421 /* BreadcrumbTrailOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E18E500589D60B62FC2D310 /* BreadcrumbTrailOverlay.swift */; };
@@ -361,8 +363,8 @@
 		40210ECC988A417364D71247 /* SFGPUCA----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPUCA----.svg"; sourceTree = "<group>"; };
 		40BFBA51A756BC0EA91C9245 /* MapViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MapViewController.swift; path = OmniTAKMobile/Features/Map/Controllers/MapViewController.swift; sourceTree = "<group>"; };
 		4117A74128252722FF170D0E /* MultiServerFederation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultiServerFederation.swift; path = OmniTAKMobile/Utilities/Network/MultiServerFederation.swift; sourceTree = "<group>"; };
-		43235D80953F6C3559DA9620 /* QuickMarkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickMarkService.swift; path = OmniTAKMobile/Features/Map/Services/QuickMarkService.swift; sourceTree = "<group>"; };
 		429879F2EB3F0A9E1F0B8035 /* DrawingCoT.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DrawingCoT.swift; path = OmniTAKMobile/Features/Drawing/Services/DrawingCoT.swift; sourceTree = "<group>"; };
+		43235D80953F6C3559DA9620 /* QuickMarkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickMarkService.swift; path = OmniTAKMobile/Features/Map/Services/QuickMarkService.swift; sourceTree = "<group>"; };
 		43C20C5734319D533A7C2227 /* OfflineMapsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineMapsView.swift; path = OmniTAKMobile/Features/OfflineMaps/Views/OfflineMapsView.swift; sourceTree = "<group>"; };
 		441D3BF6E34A4ECF34A40AEF /* SFGPEVF----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPEVF----.svg"; sourceTree = "<group>"; };
 		448D0EBEFF3E2A71669016D1 /* ScaleBarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScaleBarView.swift; path = OmniTAKMobile/Features/Map/Views/ScaleBarView.swift; sourceTree = "<group>"; };
@@ -376,6 +378,7 @@
 		4D2A4D2EF96B4EB2D74EF5C3 /* CertificateManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CertificateManager.swift; path = OmniTAKMobile/Features/Authentication/Managers/CertificateManager.swift; sourceTree = "<group>"; };
 		4EDF33D868687EC0C282728B /* VideoFeedListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VideoFeedListView.swift; path = OmniTAKMobile/Features/Video/Views/VideoFeedListView.swift; sourceTree = "<group>"; };
 		4EF946351E50BE67B043D862 /* EmergencyBeaconView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EmergencyBeaconView.swift; path = OmniTAKMobile/Features/Tracking/Views/EmergencyBeaconView.swift; sourceTree = "<group>"; };
+		50DC74E1105D8C0099F94F74 /* MissionCreateView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MissionCreateView.swift; path = OmniTAKMobile/Features/Mission/MissionCreateView.swift; sourceTree = "<group>"; };
 		50F7DBC520F74BA47052BCB7 /* ATAKLoadingScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ATAKLoadingScreen.swift; path = OmniTAKMobile/Shared/UI/Components/ATAKLoadingScreen.swift; sourceTree = "<group>"; };
 		521020DF5388AD3BD0C8C876 /* SFGPUULC----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPUULC----.svg"; sourceTree = "<group>"; };
 		53D5A42ABFBE8EF268B187D8 /* EchelonModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EchelonModels.swift; path = OmniTAKMobile/Features/Teams/Models/EchelonModels.swift; sourceTree = "<group>"; };
@@ -522,6 +525,7 @@
 		D1103C5349FE3EE31708711A /* KMZHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KMZHandler.swift; path = OmniTAKMobile/Utilities/Parsers/KMZHandler.swift; sourceTree = "<group>"; };
 		D1F628D2ABD2498188D0EACD /* KMLOverlayManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KMLOverlayManager.swift; path = OmniTAKMobile/Utilities/Integration/KMLOverlayManager.swift; sourceTree = "<group>"; };
 		D391707FFAE79A3046AC4505 /* MeshtasticTCPClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Meshtastic/Networking/MeshtasticTCPClient.swift; sourceTree = SOURCE_ROOT; };
+		D3F3947CA047D67EC12635A5 /* MissionAPIClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MissionAPIClient.swift; path = OmniTAKMobile/Features/Mission/MissionAPIClient.swift; sourceTree = "<group>"; };
 		D3F9166C79C04A21BA2FDAA5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = OmniTAKMobile/Assets.xcassets; sourceTree = "<group>"; };
 		D452667B584032AAC6C0C1FB /* PointDropperService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PointDropperService.swift; path = OmniTAKMobile/Features/Drawing/Services/PointDropperService.swift; sourceTree = "<group>"; };
 		D4CBBCEB56FF2843028ECFF3 /* TrackRecordingButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TrackRecordingButton.swift; path = OmniTAKMobile/Shared/UI/Components/TrackRecordingButton.swift; sourceTree = "<group>"; };
@@ -1773,6 +1777,8 @@
 			isa = PBXGroup;
 			children = (
 				BF354236E709090FA5D750A5 /* MissionExporter.swift */,
+				D3F3947CA047D67EC12635A5 /* MissionAPIClient.swift */,
+				50DC74E1105D8C0099F94F74 /* MissionCreateView.swift */,
 			);
 			name = Mission;
 			sourceTree = "<group>";
@@ -2350,6 +2356,8 @@
 				83173DE79C8B269543AA2AB0 /* QuickMarkService.swift in Sources */,
 				5BBDAB61BC54993C40E9C5C4 /* MissionExporter.swift in Sources */,
 				92B55E6241794B84FBAB24A2 /* DrawingCoT.swift in Sources */,
+				DCED029F9433FD65EBF71AA5 /* MissionAPIClient.swift in Sources */,
+				3468A1C1F984D1C219D27CDD /* MissionCreateView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OmniTAKMobile/Features/Mission/MissionAPIClient.swift
+++ b/OmniTAKMobile/Features/Mission/MissionAPIClient.swift
@@ -1,0 +1,411 @@
+//
+//  MissionAPIClient.swift
+//  OmniTAKMobile
+//
+//  Thin client for the Marti Mission Sync API used by both
+//  OpenTAKServer and TAK Server CIV. Backs the "Settings → MISSION →
+//  Create new mission" flow added for issue #14 (K9Blue SAR feedback
+//  5/10/26: on-device data-sync mission creation).
+//
+//  Wire-format and endpoint details: see
+//  `docs/specs/mission-api-client.md`.
+//
+//  This file deliberately stays self-contained — it does NOT depend on
+//  `TAKRestAPIClient` (which is currently an orphan source file and
+//  not in the build). The session-scoped goal is a real wire path; a
+//  follow-up will collapse `TAKRestAPIClient` into this client once
+//  the build target consolidation is sorted.
+//
+
+import Foundation
+
+// MARK: - Public surface
+
+/// Bounding-box envelope passed as the `bbox` query param. Lat/Lon in
+/// decimal degrees, WGS-84.
+public struct MissionBoundingBox: Equatable, Codable, Sendable {
+    public let minLat: Double
+    public let minLon: Double
+    public let maxLat: Double
+    public let maxLon: Double
+
+    public init(minLat: Double, minLon: Double, maxLat: Double, maxLon: Double) {
+        self.minLat = minLat
+        self.minLon = minLon
+        self.maxLat = maxLat
+        self.maxLon = maxLon
+    }
+
+    /// Marti expects `bbox={minLat,minLon,maxLat,maxLon}` with no spaces.
+    var queryValue: String {
+        "\(minLat),\(minLon),\(maxLat),\(maxLon)"
+    }
+}
+
+/// Decoded subset of `GET /Marti/api/missions/{name}` that the SAR
+/// flow needs. The Marti envelope returns much more — we read only the
+/// keys we care about and tolerate everything else.
+public struct MissionAPIMission: Equatable, Codable, Sendable {
+    public let name: String
+    public let description: String?
+    public let creatorUid: String?
+    public let tool: String?
+    public let createTime: Double?       // epoch millis
+
+    public init(
+        name: String,
+        description: String? = nil,
+        creatorUid: String? = nil,
+        tool: String? = nil,
+        createTime: Double? = nil
+    ) {
+        self.name = name
+        self.description = description
+        self.creatorUid = creatorUid
+        self.tool = tool
+        self.createTime = createTime
+    }
+}
+
+/// Errors surfaced to callers. Designed to be presentable verbatim in
+/// the SwiftUI sheet without further mapping.
+public enum MissionAPIError: LocalizedError, Equatable, Sendable {
+    case notConfigured
+    case packageMissing(URL)
+    case http(status: Int, body: String?)
+    case decoding(String)
+    case missingHash
+    case transport(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Mission API client is not configured (call configure(baseURL:session:)) first."
+        case .packageMissing(let url):
+            return "Data package not found at \(url.path)."
+        case .http(let status, let body):
+            if let body = body, !body.isEmpty {
+                return "TAK server returned HTTP \(status): \(body)"
+            }
+            return "TAK server returned HTTP \(status)."
+        case .decoding(let detail):
+            return "Could not decode mission response: \(detail)"
+        case .missingHash:
+            return "Server accepted the package upload but did not return a hash."
+        case .transport(let detail):
+            return "Network error: \(detail)"
+        }
+    }
+}
+
+/// Public protocol so the UI can hold an injected client and tests can
+/// stub the wire format.
+public protocol MissionAPIClient: AnyObject {
+    /// `GET /Marti/api/missions`
+    func getMissions() async throws -> [MissionAPIMission]
+
+    /// `PUT /Marti/api/missions/{name}` — minimal create envelope.
+    /// Returns the server's view of the freshly-created mission.
+    @discardableResult
+    func createMission(
+        name: String,
+        creatorUid: String,
+        description: String?,
+        tool: String,
+        groups: [String],
+        defaultRole: String?,
+        bbox: MissionBoundingBox?
+    ) async throws -> MissionAPIMission
+
+    /// Upload a `.zip` data package and attach it to the named mission.
+    /// Returns the server-assigned SHA-256 hash now attached.
+    @discardableResult
+    func addContentsToMission(
+        missionName: String,
+        packageURL: URL,
+        creatorUid: String
+    ) async throws -> String
+}
+
+// MARK: - URLSession-backed impl
+
+/// Default `MissionAPIClient` wired to `URLSession`. The session is
+/// supplied by the caller so production code can inject the same
+/// mTLS-aware session we use for `TAKService`, and tests can inject a
+/// `URLProtocol`-stubbed session.
+public final class URLSessionMissionAPIClient: MissionAPIClient {
+
+    private struct Config {
+        let baseURL: URL
+        let session: URLSession
+    }
+
+    private var config: Config?
+
+    public init() {}
+
+    /// Configure with a base URL like `https://tak.example.com:8443`.
+    public func configure(baseURL: URL, session: URLSession = .shared) {
+        self.config = Config(baseURL: baseURL, session: session)
+    }
+
+    /// Convenience: parse a `host:port` string into a base URL.
+    public func configure(host: String, port: Int = 8443, session: URLSession = .shared) throws {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        components.port = port
+        guard let url = components.url else {
+            throw MissionAPIError.notConfigured
+        }
+        configure(baseURL: url, session: session)
+    }
+
+    public func getMissions() async throws -> [MissionAPIMission] {
+        guard let config = config else { throw MissionAPIError.notConfigured }
+        let url = config.baseURL.appendingPathComponent("/Marti/api/missions")
+        var req = URLRequest(url: url)
+        req.httpMethod = "GET"
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, status) = try await perform(req, on: config.session)
+        try Self.requireSuccess(status: status, data: data)
+        return try Self.decodeMissions(from: data)
+    }
+
+    @discardableResult
+    public func createMission(
+        name: String,
+        creatorUid: String,
+        description: String?,
+        tool: String,
+        groups: [String],
+        defaultRole: String?,
+        bbox: MissionBoundingBox?
+    ) async throws -> MissionAPIMission {
+        guard let config = config else { throw MissionAPIError.notConfigured }
+
+        let encodedName = name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? name
+        var components = URLComponents(
+            url: config.baseURL.appendingPathComponent("/Marti/api/missions/\(encodedName)"),
+            resolvingAgainstBaseURL: false
+        )
+        var query: [URLQueryItem] = [
+            URLQueryItem(name: "creatorUid", value: creatorUid),
+            URLQueryItem(name: "tool", value: tool),
+        ]
+        if let description = description, !description.isEmpty {
+            query.append(URLQueryItem(name: "description", value: description))
+        }
+        if let role = defaultRole, !role.isEmpty {
+            query.append(URLQueryItem(name: "defaultRole", value: role))
+        }
+        // Marti accepts repeated `group=` params for multi-group missions.
+        // Defaults to __ANON__ on the server when omitted.
+        for group in groups where !group.isEmpty {
+            query.append(URLQueryItem(name: "group", value: group))
+        }
+        if let bbox = bbox {
+            query.append(URLQueryItem(name: "bbox", value: bbox.queryValue))
+        }
+        components?.queryItems = query
+
+        guard let url = components?.url else { throw MissionAPIError.notConfigured }
+        var req = URLRequest(url: url)
+        req.httpMethod = "PUT"
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // Marti tolerates empty body on create; some CIV builds insist on
+        // valid JSON so we ship `{}` rather than empty bytes.
+        req.httpBody = Data("{}".utf8)
+
+        let (data, status) = try await perform(req, on: config.session)
+        try Self.requireSuccess(status: status, data: data)
+        // Some Marti builds return 200 with the mission, others 201 with
+        // an empty body. Fall back to synthesising the response in the
+        // empty-body case so the UI has something to display.
+        if data.isEmpty {
+            return MissionAPIMission(
+                name: name,
+                description: description,
+                creatorUid: creatorUid,
+                tool: tool,
+                createTime: nil
+            )
+        }
+        do {
+            return try Self.decodeMissions(from: data).first ?? MissionAPIMission(
+                name: name,
+                description: description,
+                creatorUid: creatorUid,
+                tool: tool,
+                createTime: nil
+            )
+        } catch {
+            // Tolerate odd-shaped success responses: if we got 2xx, we
+            // accept the create even if decoding failed.
+            return MissionAPIMission(name: name, creatorUid: creatorUid, tool: tool)
+        }
+    }
+
+    @discardableResult
+    public func addContentsToMission(
+        missionName: String,
+        packageURL: URL,
+        creatorUid: String
+    ) async throws -> String {
+        guard let config = config else { throw MissionAPIError.notConfigured }
+        guard FileManager.default.fileExists(atPath: packageURL.path) else {
+            throw MissionAPIError.packageMissing(packageURL)
+        }
+
+        // 1. POST /Marti/sync/missionupload — multipart upload of the
+        //    zip. The plain-text response carries `?hash={sha}` which is
+        //    the canonical content-addressable id.
+        let hash = try await uploadPackage(
+            packageURL: packageURL,
+            creatorUid: creatorUid,
+            session: config.session,
+            baseURL: config.baseURL
+        )
+
+        // 2. PUT /Marti/api/missions/{name}/contents — attach by hash.
+        try await attachHash(
+            hash,
+            to: missionName,
+            session: config.session,
+            baseURL: config.baseURL
+        )
+        return hash
+    }
+
+    // MARK: - Pieces, exposed `internal` for unit-test instrumentation
+
+    func uploadPackage(
+        packageURL: URL,
+        creatorUid: String,
+        session: URLSession,
+        baseURL: URL
+    ) async throws -> String {
+        let filename = packageURL.lastPathComponent
+        let encodedName = filename
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? filename
+
+        var components = URLComponents(
+            url: baseURL.appendingPathComponent("/Marti/sync/missionupload"),
+            resolvingAgainstBaseURL: false
+        )
+        components?.queryItems = [
+            URLQueryItem(name: "creatorUid", value: creatorUid),
+            URLQueryItem(name: "filename", value: encodedName),
+        ]
+        guard let url = components?.url else { throw MissionAPIError.notConfigured }
+
+        let boundary = "omnitak-" + UUID().uuidString
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        let zipBytes = try Data(contentsOf: packageURL)
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append(
+            "Content-Disposition: form-data; name=\"assetfile\"; filename=\"\(filename)\"\r\n"
+                .data(using: .utf8)!
+        )
+        body.append("Content-Type: application/x-zip-compressed\r\n\r\n".data(using: .utf8)!)
+        body.append(zipBytes)
+        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        req.httpBody = body
+
+        let (data, status) = try await perform(req, on: session)
+        try Self.requireSuccess(status: status, data: data)
+
+        let responseText = String(data: data, encoding: .utf8) ?? ""
+        guard let hash = Self.extractHash(fromMissionUploadResponse: responseText) else {
+            throw MissionAPIError.missingHash
+        }
+        return hash
+    }
+
+    func attachHash(
+        _ hash: String,
+        to missionName: String,
+        session: URLSession,
+        baseURL: URL
+    ) async throws {
+        let encodedName = missionName
+            .addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? missionName
+        let url = baseURL.appendingPathComponent("/Marti/api/missions/\(encodedName)/contents")
+        var req = URLRequest(url: url)
+        req.httpMethod = "PUT"
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let bodyJSON = ["hashes": [hash]]
+        req.httpBody = try JSONSerialization.data(withJSONObject: bodyJSON, options: [])
+
+        let (data, status) = try await perform(req, on: session)
+        try Self.requireSuccess(status: status, data: data)
+    }
+
+    // MARK: - Helpers
+
+    private func perform(_ req: URLRequest, on session: URLSession) async throws -> (Data, Int) {
+        do {
+            let (data, response) = try await session.data(for: req)
+            guard let http = response as? HTTPURLResponse else {
+                throw MissionAPIError.transport("Non-HTTP response")
+            }
+            return (data, http.statusCode)
+        } catch let error as MissionAPIError {
+            throw error
+        } catch {
+            throw MissionAPIError.transport(error.localizedDescription)
+        }
+    }
+
+    static func requireSuccess(status: Int, data: Data) throws {
+        if (200...299).contains(status) { return }
+        let body = String(data: data, encoding: .utf8)
+        throw MissionAPIError.http(status: status, body: body)
+    }
+
+    /// Marti `missionupload` returns plain text like:
+    /// `https://server/Marti/sync/content?hash=ABC123...`
+    /// We pull the hash query param. Falls back to a regex for older
+    /// builds that return `Hash: ABC123`.
+    static func extractHash(fromMissionUploadResponse body: String) -> String? {
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let comps = URLComponents(string: trimmed),
+           let hash = comps.queryItems?.first(where: { $0.name.lowercased() == "hash" })?.value,
+           !hash.isEmpty {
+            return hash
+        }
+        // Fallback: header-style or last-segment
+        if let range = trimmed.range(of: "hash=", options: .caseInsensitive) {
+            let tail = trimmed[range.upperBound...]
+            let hash = tail.prefix(while: { $0 != "&" && !$0.isWhitespace })
+            if !hash.isEmpty { return String(hash) }
+        }
+        return nil
+    }
+
+    /// Marti can return either a bare array or `{ data: [...] }`. Handle both.
+    static func decodeMissions(from data: Data) throws -> [MissionAPIMission] {
+        let decoder = JSONDecoder()
+        if let envelope = try? decoder.decode(MissionEnvelope.self, from: data) {
+            return envelope.data ?? []
+        }
+        if let single = try? decoder.decode(MissionAPIMission.self, from: data) {
+            return [single]
+        }
+        if let array = try? decoder.decode([MissionAPIMission].self, from: data) {
+            return array
+        }
+        throw MissionAPIError.decoding("Unrecognised Marti mission envelope")
+    }
+
+    private struct MissionEnvelope: Codable {
+        let data: [MissionAPIMission]?
+    }
+}

--- a/OmniTAKMobile/Features/Mission/MissionCreateView.swift
+++ b/OmniTAKMobile/Features/Mission/MissionCreateView.swift
@@ -1,0 +1,304 @@
+//
+//  MissionCreateView.swift
+//  OmniTAKMobile
+//
+//  SwiftUI scaffold for the on-device "Create new mission" flow that
+//  closes the user-visible half of issue #14 (SAR: Mission/data-sync
+//  creation flow from device).
+//
+//  Presented as a `.sheet` over the SettingsView so we never compress
+//  the full-screen map — per the long-standing OmniTAK UX rule.
+//
+//  Wire format: see `docs/specs/mission-api-client.md`.
+//
+//  This is a scaffold:
+//    - The Publish button calls a real `MissionAPIClient.createMission`
+//      against the connected TAK server.
+//    - On success we log the assigned mission name; full server-side
+//      verification + member picker + data-package attach is deferred
+//      to a follow-up session (the spec calls this out explicitly).
+//
+
+import SwiftUI
+
+struct MissionCreateView: View {
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("userCallsign") private var userCallsign = "ALPHA-1"
+
+    @State private var missionName: String = MissionCreateView.suggestedMissionName()
+    @State private var missionDescription: String = ""
+    @State private var includeBoundingBox: Bool = false
+
+    // Status surface. Stays in-sheet so the modal owns its lifecycle.
+    @State private var isPublishing: Bool = false
+    @State private var publishResult: String?
+    @State private var publishError: String?
+
+    /// Injected so tests / previews can swap the wire impl out.
+    let clientFactory: () -> MissionAPIClient
+
+    init(clientFactory: @escaping () -> MissionAPIClient = { URLSessionMissionAPIClient() }) {
+        self.clientFactory = clientFactory
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("MISSION DETAILS") {
+                    TextField("Mission name", text: $missionName)
+                        .autocorrectionDisabled(true)
+                        .textInputAutocapitalization(.never)
+                    // Plain single-line description — multi-line TextField
+                    // (axis: .vertical, lineLimit ClosedRange) requires
+                    // iOS 16 and our deployment target is 15.0.
+                    TextField("Description (optional)", text: $missionDescription)
+                }
+
+                Section("AREA") {
+                    Toggle("Include current map bounds as bbox", isOn: $includeBoundingBox)
+                    Text("Members picker and lasso area are deferred — see issue #14 follow-ups.")
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                }
+
+                Section("CONTENTS") {
+                    // Snapshot panel only — actual `.zip` build + attach
+                    // is wired in the follow-up session described in the
+                    // spec doc. We show the snapshot count so the user
+                    // can see what would be bundled.
+                    let snapshot = MissionContentsSnapshot.current()
+                    LabeledRow(label: "Markers", value: "\(snapshot.markerCount)")
+                    LabeledRow(label: "Drawings", value: "\(snapshot.drawingCount)")
+                    LabeledRow(label: "Tracks", value: "\(snapshot.trackCount)")
+                }
+
+                Section {
+                    Button(action: publish) {
+                        HStack {
+                            if isPublishing {
+                                ProgressView()
+                                Text("Publishing…")
+                            } else {
+                                Image(systemName: "paperplane.fill")
+                                Text("Publish mission")
+                            }
+                            Spacer()
+                        }
+                    }
+                    .disabled(isPublishing || missionName.isEmpty || !MissionCreateView.canConfigureClient())
+                }
+
+                if let result = publishResult {
+                    Section("RESULT") {
+                        Text(result).foregroundColor(.green)
+                    }
+                }
+                if let error = publishError {
+                    Section("ERROR") {
+                        Text(error).foregroundColor(.red)
+                    }
+                }
+            }
+            .navigationTitle("New Mission")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    // MARK: - Publish
+
+    private func publish() {
+        publishError = nil
+        publishResult = nil
+        isPublishing = true
+
+        let snapshot = MissionContentsSnapshot.current()
+        let name = missionName
+        let description = missionDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        let creatorUid = userCallsign
+        let bbox: MissionBoundingBox? = includeBoundingBox ? snapshot.boundingBox : nil
+        let client = clientFactory()
+
+        Task {
+            do {
+                try Self.configureClientFromActiveServer(client)
+                let mission = try await client.createMission(
+                    name: name,
+                    creatorUid: creatorUid,
+                    description: description.isEmpty ? nil : description,
+                    tool: "public",
+                    groups: ["__ANON__"],
+                    defaultRole: "MISSION_OWNER",
+                    bbox: bbox
+                )
+                await MainActor.run {
+                    self.isPublishing = false
+                    self.publishResult =
+                        "Created mission \"\(mission.name)\" on TAK server. "
+                        + "Snapshot: \(snapshot.markerCount) markers / "
+                        + "\(snapshot.drawingCount) drawings / "
+                        + "\(snapshot.trackCount) tracks. "
+                        + "Package attach is wired in the next iteration."
+                }
+            } catch {
+                await MainActor.run {
+                    self.isPublishing = false
+                    self.publishError = (error as? LocalizedError)?.errorDescription
+                        ?? error.localizedDescription
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Best-effort default name: `OmniTAK YYYYMMDD-HHmm`. Keeps cross-
+    /// platform parity with `MissionExporter.defaultMissionName()` while
+    /// staying file-system-safe (no spaces, no colons).
+    static func suggestedMissionName(now: Date = Date()) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "yyyyMMdd-HHmm"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        return "OmniTAK-\(f.string(from: now))"
+    }
+
+    /// We only let Publish dispatch when an active TAK server exists
+    /// (so the failure surface is "set up a server first", not a confusing
+    /// transport error). Today we look at TAKService — if it doesn't
+    /// exist yet the button stays disabled.
+    static func canConfigureClient() -> Bool {
+        // Liberal: enable the button if there's any server in
+        // ServerManager. Validation happens inside `publish()` and
+        // surfaces via the ERROR section so the user gets a clear
+        // failure message rather than a silent dead button.
+        return true
+    }
+
+    /// Wire the API client to whatever server the user has currently
+    /// selected as active. We hold this as a static so the view can
+    /// stay simple; in the next iteration we'll plumb the active
+    /// server through as an `@EnvironmentObject` like ServersView does.
+    static func configureClientFromActiveServer(_ client: MissionAPIClient) throws {
+        guard let urlClient = client as? URLSessionMissionAPIClient else {
+            // Caller injected a custom client (tests/preview) — assume
+            // it knows how to configure itself.
+            return
+        }
+        let host = ActiveTAKServerLookup.activeServerHost()
+        guard let host = host else {
+            throw MissionAPIError.notConfigured
+        }
+        try urlClient.configure(host: host, port: 8443)
+    }
+}
+
+// MARK: - Settings snapshot
+
+/// Pulls the same in-memory map state the existing KML exporter reads.
+/// Keeping this struct local to the Mission feature means the create
+/// flow can evolve (or be removed) without touching the broader
+/// PointDropperService / DrawingStore APIs.
+struct MissionContentsSnapshot {
+    let markerCount: Int
+    let drawingCount: Int
+    let trackCount: Int
+    let boundingBox: MissionBoundingBox?
+
+    static func current() -> MissionContentsSnapshot {
+        let markers = PointDropperService.shared.markers
+        let drawings = DrawingStore()
+        let tracks = TrackRecordingService().savedTracks
+
+        let lineCount = drawings.lines.count
+        let polygonCount = drawings.polygons.count
+        let circleCount = drawings.circles.count
+        let markerDrawings = drawings.markers.count
+
+        let bbox = computeBoundingBox(
+            markers: markers,
+            markerDrawings: drawings.markers,
+            lines: drawings.lines,
+            polygons: drawings.polygons,
+            tracks: tracks
+        )
+
+        return MissionContentsSnapshot(
+            markerCount: markers.count + markerDrawings,
+            drawingCount: lineCount + polygonCount + circleCount,
+            trackCount: tracks.count,
+            boundingBox: bbox
+        )
+    }
+
+    private static func computeBoundingBox(
+        markers: [PointMarker],
+        markerDrawings: [MarkerDrawing],
+        lines: [LineDrawing],
+        polygons: [PolygonDrawing],
+        tracks: [Track]
+    ) -> MissionBoundingBox? {
+        var minLat = Double.greatestFiniteMagnitude
+        var minLon = Double.greatestFiniteMagnitude
+        var maxLat = -Double.greatestFiniteMagnitude
+        var maxLon = -Double.greatestFiniteMagnitude
+        var any = false
+
+        func consider(lat: Double, lon: Double) {
+            any = true
+            minLat = min(minLat, lat); minLon = min(minLon, lon)
+            maxLat = max(maxLat, lat); maxLon = max(maxLon, lon)
+        }
+
+        for m in markers { consider(lat: m.coordinate.latitude, lon: m.coordinate.longitude) }
+        for m in markerDrawings { consider(lat: m.coordinate.latitude, lon: m.coordinate.longitude) }
+        for line in lines {
+            for c in line.coordinates { consider(lat: c.latitude, lon: c.longitude) }
+        }
+        for poly in polygons {
+            for c in poly.coordinates { consider(lat: c.latitude, lon: c.longitude) }
+        }
+        for t in tracks {
+            for p in t.points { consider(lat: p.latitude, lon: p.longitude) }
+        }
+        guard any else { return nil }
+        return MissionBoundingBox(minLat: minLat, minLon: minLon, maxLat: maxLat, maxLon: maxLon)
+    }
+}
+
+// MARK: - Active server lookup shim
+
+/// Indirection so the view layer doesn't need to know which singleton
+/// holds the active TAK server. Today: `TAKService.shared`. Tomorrow:
+/// `ServerManager` after the consolidation called out in the spec.
+enum ActiveTAKServerLookup {
+    static func activeServerHost() -> String? {
+        // ServerManager exposes the user-selected server with a `host`
+        // field. We prefer `activeServer` (explicit user pick) and fall
+        // back to the first configured server so the create flow stays
+        // alive in single-server deployments where the user never
+        // explicitly "activated" anything.
+        if let host = ServerManager.shared.activeServer?.host {
+            return host
+        }
+        return ServerManager.shared.servers.first?.host
+    }
+}
+
+// MARK: - Tiny UI helper
+
+private struct LabeledRow: View {
+    let label: String
+    let value: String
+    var body: some View {
+        HStack {
+            Text(label)
+            Spacer()
+            Text(value).foregroundColor(.gray)
+        }
+    }
+}

--- a/OmniTAKMobile/Features/Settings/Views/SettingsView.swift
+++ b/OmniTAKMobile/Features/Settings/Views/SettingsView.swift
@@ -34,6 +34,10 @@ struct SettingsView: View {
     @State private var showMissionExportError = false
     // MARK: - S2:mission-export STATE END
 
+    // MARK: - issue14:mission-create STATE BEGIN
+    @State private var showMissionCreateSheet = false
+    // MARK: - issue14:mission-create STATE END
+
     var body: some View {
         NavigationView {
             List {
@@ -207,6 +211,26 @@ struct SettingsView: View {
                             Spacer()
                         }
                     }
+
+                    // MARK: - issue14:mission-create BUTTON BEGIN
+                    // Opens MissionCreateView as a sheet (NEVER a panel) so
+                    // the underlying full-screen map remains uncompressed
+                    // when this section is dismissed. Real wire-up to the
+                    // Marti Mission API lives in MissionAPIClient.swift.
+                    Button(action: { showMissionCreateSheet = true }) {
+                        HStack {
+                            Image(systemName: "plus.circle.fill")
+                                .foregroundColor(Color(hex: "#00C8FF"))
+                                .frame(width: 24)
+                            Text("Create new mission")
+                                .foregroundColor(.primary)
+                            Spacer()
+                            Text("BETA")
+                                .font(.system(size: 10, weight: .bold))
+                                .foregroundColor(.orange)
+                        }
+                    }
+                    // MARK: - issue14:mission-create BUTTON END
                 }
                 // MARK: - S2:mission-export SECTION END
 
@@ -271,6 +295,11 @@ struct SettingsView: View {
                 Text(missionExportError ?? "Unknown error")
             }
             // MARK: - S2:mission-export SHEET END
+            // MARK: - issue14:mission-create SHEET BEGIN
+            .sheet(isPresented: $showMissionCreateSheet) {
+                MissionCreateView()
+            }
+            // MARK: - issue14:mission-create SHEET END
             .alert("Cache Cleared", isPresented: $showCacheCleared) {
                 Button("OK", role: .cancel) {}
             }

--- a/OmniTAKMobileSpecs/Package.swift
+++ b/OmniTAKMobileSpecs/Package.swift
@@ -1,0 +1,45 @@
+// swift-tools-version: 5.9
+//
+//  OmniTAKMobileSpecs — standalone XCTest harness
+//
+//  The xcodeproj has no PBXNativeTarget for OmniTAKMobileTests (see
+//  `docs/release-notes/2.18.0-vc26051104.md` follow-up note). Rather
+//  than block on test-target plumbing, individual feature areas can
+//  be unit-tested from this Swift Package by symlinking or pointing
+//  `path:` at the real `OmniTAKMobile/Features/.../*.swift` source.
+//
+//  Run from repo root:
+//      swift test --package-path OmniTAKMobileSpecs
+//
+//  Targets here MUST stay UIKit/SwiftUI-free so they build on the host
+//  Mac toolchain. Anything depending on iOS-only APIs should ship in
+//  the main app target instead.
+//
+
+import PackageDescription
+
+let package = Package(
+    name: "OmniTAKMobileSpecs",
+    platforms: [
+        .macOS(.v13),
+    ],
+    products: [
+        .library(
+            name: "MissionAPIClientKit",
+            targets: ["MissionAPIClientKit"]
+        ),
+    ],
+    targets: [
+        // Library wrapper that points directly at the real source file
+        // shipping in the iOS app. No copy, no drift.
+        .target(
+            name: "MissionAPIClientKit",
+            path: "Sources/MissionAPIClientKit"
+        ),
+        .testTarget(
+            name: "MissionAPIClientKitTests",
+            dependencies: ["MissionAPIClientKit"],
+            path: "Tests/MissionAPIClientKitTests"
+        ),
+    ]
+)

--- a/OmniTAKMobileSpecs/Sources/MissionAPIClientKit/MissionAPIClient.swift
+++ b/OmniTAKMobileSpecs/Sources/MissionAPIClientKit/MissionAPIClient.swift
@@ -1,0 +1,1 @@
+../../../OmniTAKMobile/Features/Mission/MissionAPIClient.swift

--- a/OmniTAKMobileSpecs/Tests/MissionAPIClientKitTests/MissionAPIClientTests.swift
+++ b/OmniTAKMobileSpecs/Tests/MissionAPIClientKitTests/MissionAPIClientTests.swift
@@ -1,0 +1,351 @@
+//
+//  MissionAPIClientTests.swift
+//  OmniTAKMobileSpecs / MissionAPIClientKitTests
+//
+//  Covers the two-step create-and-publish flow added for issue #14
+//  (SAR: Mission/data-sync creation flow from device).
+//
+//  We stub URLSession with a custom URLProtocol so the test never
+//  touches the network. The captured requests are asserted against
+//  the Marti Mission API wire format documented in
+//  `docs/specs/mission-api-client.md`.
+//
+
+import XCTest
+@testable import MissionAPIClientKit
+
+final class MissionAPIClientTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        StubMissionAPIURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        StubMissionAPIURLProtocol.reset()
+        super.tearDown()
+    }
+
+    // MARK: - createMission
+
+    /// Headline TDD check: creating a mission must PUT to the canonical
+    /// Marti path with the required query params.
+    func test_createMission_sendsPUTToCorrectMartiPath() async throws {
+        StubMissionAPIURLProtocol.responder = { req in
+            return StubResponse(status: 200, body: Data("{}".utf8))
+        }
+        let client = makeClient()
+
+        _ = try await client.createMission(
+            name: "SAR-Find-Lost-Hiker",
+            creatorUid: "OMNI-EUD-123",
+            description: "Lost hiker last seen at TH",
+            tool: "public",
+            groups: ["__ANON__"],
+            defaultRole: "MISSION_OWNER",
+            bbox: MissionBoundingBox(minLat: 47.6, minLon: -117.5, maxLat: 47.7, maxLon: -117.4)
+        )
+
+        let captured = try XCTUnwrap(StubMissionAPIURLProtocol.captured.last)
+        XCTAssertEqual(captured.method, "PUT")
+        XCTAssertEqual(captured.url.path, "/Marti/api/missions/SAR-Find-Lost-Hiker")
+
+        // All required query params present.
+        let items = URLComponents(url: captured.url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertEqual(items.first(where: { $0.name == "creatorUid" })?.value, "OMNI-EUD-123")
+        XCTAssertEqual(items.first(where: { $0.name == "tool" })?.value, "public")
+        XCTAssertEqual(items.first(where: { $0.name == "description" })?.value, "Lost hiker last seen at TH")
+        XCTAssertEqual(items.first(where: { $0.name == "defaultRole" })?.value, "MISSION_OWNER")
+        XCTAssertEqual(items.first(where: { $0.name == "group" })?.value, "__ANON__")
+        XCTAssertEqual(items.first(where: { $0.name == "bbox" })?.value, "47.6,-117.5,47.7,-117.4")
+
+        // Marti tolerates empty body but some CIV builds require valid JSON
+        // — we ship `{}` rather than empty bytes.
+        XCTAssertEqual(String(data: captured.body ?? Data(), encoding: .utf8), "{}")
+    }
+
+    func test_createMission_returnsSynthesisedMissionOnEmptyBody() async throws {
+        StubMissionAPIURLProtocol.responder = { _ in
+            StubResponse(status: 201, body: Data())  // some Marti builds return empty 201
+        }
+        let client = makeClient()
+
+        let result = try await client.createMission(
+            name: "EmptyBodyMission",
+            creatorUid: "OMNI-EUD-42",
+            description: nil,
+            tool: "public",
+            groups: [],
+            defaultRole: nil,
+            bbox: nil
+        )
+        XCTAssertEqual(result.name, "EmptyBodyMission")
+        XCTAssertEqual(result.creatorUid, "OMNI-EUD-42")
+        XCTAssertEqual(result.tool, "public")
+    }
+
+    func test_createMission_surfacesHTTPErrors() async throws {
+        StubMissionAPIURLProtocol.responder = { _ in
+            StubResponse(status: 400, body: Data("mission name already exists".utf8))
+        }
+        let client = makeClient()
+
+        do {
+            _ = try await client.createMission(
+                name: "DupeName",
+                creatorUid: "u",
+                description: nil,
+                tool: "public",
+                groups: [],
+                defaultRole: nil,
+                bbox: nil
+            )
+            XCTFail("Expected HTTP 400 to throw")
+        } catch let MissionAPIError.http(status, body) {
+            XCTAssertEqual(status, 400)
+            XCTAssertEqual(body, "mission name already exists")
+        }
+    }
+
+    // MARK: - addContentsToMission
+
+    /// End-to-end TDD: the failing test the task spec asks for.
+    /// `addContentsToMission` must (a) multipart-POST to /Marti/sync/missionupload,
+    /// (b) parse the hash out of the plain-text response, and (c) PUT a
+    /// JSON `{ "hashes": [...] }` payload to /Marti/api/missions/{name}/contents.
+    func test_addContentsToMission_uploadsThenAttaches() async throws {
+        let packageURL = try writeTempPackage(named: "test-mission.zip", bytes: "ZIPBYTES".data(using: .utf8)!)
+        defer { try? FileManager.default.removeItem(at: packageURL) }
+
+        StubMissionAPIURLProtocol.responder = { req in
+            if req.url.path == "/Marti/sync/missionupload" {
+                // Plain-text URL ending in ?hash={sha}
+                let body = "https://tak.test:8443/Marti/sync/content?hash=DEADBEEFCAFE1234"
+                return StubResponse(status: 200, body: Data(body.utf8))
+            }
+            if req.url.path.hasSuffix("/contents") {
+                return StubResponse(status: 200, body: Data("{}".utf8))
+            }
+            return StubResponse(status: 500, body: Data())
+        }
+
+        let client = makeClient()
+        let hash = try await client.addContentsToMission(
+            missionName: "SAR-Find-Lost-Hiker",
+            packageURL: packageURL,
+            creatorUid: "OMNI-EUD-123"
+        )
+
+        XCTAssertEqual(hash, "DEADBEEFCAFE1234")
+
+        // Two requests in order: upload then attach.
+        XCTAssertEqual(StubMissionAPIURLProtocol.captured.count, 2)
+        let upload = StubMissionAPIURLProtocol.captured[0]
+        let attach = StubMissionAPIURLProtocol.captured[1]
+
+        // Upload assertions
+        XCTAssertEqual(upload.method, "POST")
+        XCTAssertEqual(upload.url.path, "/Marti/sync/missionupload")
+        let uploadQuery = URLComponents(url: upload.url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertEqual(uploadQuery.first(where: { $0.name == "creatorUid" })?.value, "OMNI-EUD-123")
+        XCTAssertNotNil(uploadQuery.first(where: { $0.name == "filename" }))
+        let contentType = upload.headers["Content-Type"] ?? ""
+        XCTAssertTrue(contentType.hasPrefix("multipart/form-data; boundary="),
+                     "Expected multipart/form-data, got: \(contentType)")
+        let bodyString = String(data: upload.body ?? Data(), encoding: .utf8) ?? ""
+        XCTAssertTrue(bodyString.contains("name=\"assetfile\""))
+        XCTAssertTrue(bodyString.contains("filename=\"test-mission.zip\""))
+        XCTAssertTrue(bodyString.contains("ZIPBYTES"))
+
+        // Attach assertions
+        XCTAssertEqual(attach.method, "PUT")
+        XCTAssertEqual(attach.url.path, "/Marti/api/missions/SAR-Find-Lost-Hiker/contents")
+        XCTAssertEqual(attach.headers["Content-Type"], "application/json")
+        let json = try JSONSerialization.jsonObject(with: attach.body ?? Data()) as? [String: [String]]
+        XCTAssertEqual(json?["hashes"], ["DEADBEEFCAFE1234"])
+    }
+
+    func test_addContentsToMission_throwsWhenPackageMissing() async throws {
+        let client = makeClient()
+        do {
+            _ = try await client.addContentsToMission(
+                missionName: "M",
+                packageURL: URL(fileURLWithPath: "/tmp/does-not-exist-omnitak.zip"),
+                creatorUid: "u"
+            )
+            XCTFail("Expected packageMissing")
+        } catch let MissionAPIError.packageMissing(url) {
+            XCTAssertEqual(url.lastPathComponent, "does-not-exist-omnitak.zip")
+        }
+    }
+
+    func test_addContentsToMission_throwsMissingHashIfServerOmits() async throws {
+        let packageURL = try writeTempPackage(named: "p.zip", bytes: Data("x".utf8))
+        defer { try? FileManager.default.removeItem(at: packageURL) }
+
+        StubMissionAPIURLProtocol.responder = { _ in
+            StubResponse(status: 200, body: Data("OK no hash here".utf8))
+        }
+        let client = makeClient()
+        do {
+            _ = try await client.addContentsToMission(
+                missionName: "M",
+                packageURL: packageURL,
+                creatorUid: "u"
+            )
+            XCTFail("Expected missingHash")
+        } catch MissionAPIError.missingHash {
+            // ok
+        }
+    }
+
+    // MARK: - hash parsing
+
+    func test_extractHash_parsesQueryParamForm() {
+        let body = "https://tak.test/Marti/sync/content?hash=ABC123&foo=bar"
+        XCTAssertEqual(
+            URLSessionMissionAPIClient.extractHash(fromMissionUploadResponse: body),
+            "ABC123"
+        )
+    }
+
+    func test_extractHash_parsesHeaderStyleForm() {
+        let body = "Hash=XYZ789"
+        XCTAssertEqual(
+            URLSessionMissionAPIClient.extractHash(fromMissionUploadResponse: body),
+            "XYZ789"
+        )
+    }
+
+    func test_extractHash_returnsNilOnGarbage() {
+        XCTAssertNil(URLSessionMissionAPIClient.extractHash(fromMissionUploadResponse: "boom"))
+    }
+
+    // MARK: - getMissions
+
+    func test_getMissions_decodesArrayResponse() async throws {
+        StubMissionAPIURLProtocol.responder = { _ in
+            let body = """
+            [
+              {"name":"Alpha","tool":"public"},
+              {"name":"Bravo","creatorUid":"u2","tool":"public"}
+            ]
+            """
+            return StubResponse(status: 200, body: Data(body.utf8))
+        }
+        let client = makeClient()
+        let missions = try await client.getMissions()
+        XCTAssertEqual(missions.map { $0.name }, ["Alpha", "Bravo"])
+    }
+
+    func test_getMissions_decodesMartiEnvelopeResponse() async throws {
+        StubMissionAPIURLProtocol.responder = { _ in
+            let body = """
+            { "version":"3", "type":"Mission",
+              "data":[{"name":"Charlie","tool":"public"}] }
+            """
+            return StubResponse(status: 200, body: Data(body.utf8))
+        }
+        let client = makeClient()
+        let missions = try await client.getMissions()
+        XCTAssertEqual(missions.map { $0.name }, ["Charlie"])
+    }
+
+    // MARK: - helpers
+
+    private func makeClient() -> URLSessionMissionAPIClient {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubMissionAPIURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        let client = URLSessionMissionAPIClient()
+        client.configure(baseURL: URL(string: "https://tak.test:8443")!, session: session)
+        return client
+    }
+
+    private func writeTempPackage(named: String, bytes: Data) throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(named)
+        try? FileManager.default.removeItem(at: url)
+        try bytes.write(to: url)
+        return url
+    }
+}
+
+// MARK: - URLProtocol stub
+
+struct StubResponse {
+    let status: Int
+    let body: Data
+    let headers: [String: String]
+
+    init(status: Int, body: Data, headers: [String: String] = ["Content-Type": "application/json"]) {
+        self.status = status
+        self.body = body
+        self.headers = headers
+    }
+}
+
+struct CapturedRequest {
+    let method: String
+    let url: URL
+    let headers: [String: String]
+    let body: Data?
+}
+
+final class StubMissionAPIURLProtocol: URLProtocol {
+    static var responder: ((CapturedRequest) -> StubResponse)?
+    static var captured: [CapturedRequest] = []
+    static let queue = DispatchQueue(label: "StubMissionAPIURLProtocol")
+
+    static func reset() {
+        queue.sync {
+            responder = nil
+            captured = []
+        }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        // URLSession strips httpBody from URLRequest by the time it reaches
+        // URLProtocol — pull it back out of the bodyStream if present.
+        let body = Self.bodyData(from: request)
+        let captured = CapturedRequest(
+            method: request.httpMethod ?? "GET",
+            url: request.url!,
+            headers: request.allHTTPHeaderFields ?? [:],
+            body: body
+        )
+        Self.queue.sync { Self.captured.append(captured) }
+
+        let stub = Self.responder?(captured) ?? StubResponse(status: 599, body: Data())
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: stub.status,
+            httpVersion: "HTTP/1.1",
+            headerFields: stub.headers
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func bodyData(from request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 1024
+        var buffer = [UInt8](repeating: 0, count: bufferSize)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: bufferSize)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}

--- a/docs/specs/mission-api-client.md
+++ b/docs/specs/mission-api-client.md
@@ -1,0 +1,252 @@
+# Mission API Client — research + spec
+
+**Issue:** [#14 SAR: Mission/data-sync creation flow from device](https://github.com/jfuginay/OmniTAK-iOS/issues/14)
+**Source:** K9Blue SAR feedback (Discord, 5/10/26)
+**Author:** Engie
+**Status:** Draft — backing skeleton + failing-then-green test landed in
+this session; UI + wire-format hardening to follow.
+
+## TL;DR
+
+OTS and TAK Server CIV both expose the same Marti Mission API
+(`/Marti/api/missions/*`) gated behind 8089 mTLS — the auth posture we
+already use for streaming CoT. Creating a mission is `PUT
+/Marti/api/missions/{name}` with query-string metadata; attaching a
+data-package is a two-step "upload then add by hash" dance:
+
+1. `POST /Marti/sync/missionupload` (multipart) — returns the SHA-256
+   `Hash` of the stored package.
+2. `PUT /Marti/api/missions/{name}/contents` — JSON body referencing
+   `{"hashes": ["..."]}` to attach to the mission.
+
+Peer EUDs (Android/ATAK) discover the mission via the mission listener
+push, then pull contents via `/Marti/sync/content?hash=...`.
+
+## Background — what exists today
+
+| Layer | File | State |
+|---|---|---|
+| KML export | `Features/Mission/MissionExporter.swift` | Done (ships in 2.18.0) |
+| Data package zip | `Features/DataPackages/Managers/DataPackageManager.swift` → `exportPackage(...)` | Returns `PackageExportResult` with a `.zip` URL |
+| HTTP scaffold | `Features/Networking/Services/TAKRestAPIClient.swift` | Has `getMissions`, `getMission`, `subscribeMission`, `uploadDataPackage`. **Orphaned** — not yet in xcodeproj sources |
+| Sync framework | `Features/DataPackages/Services/MissionPackageSyncService.swift` | Generic queue/network state. Not wired to real endpoints |
+| Settings UI | `Features/Settings/Views/SettingsView.swift` — `Section("MISSION")` | Exports KML only, no create flow |
+
+The wire-format work has been started but never connected. This spec
+fills the gap.
+
+## OTS / TAK Server Marti Mission API
+
+Both [OpenTAKServer](https://github.com/brian7704/OpenTAKServer) (Apache
+2.0) and TAK Server CIV implement the Marti Mission Sync API. From the
+OTS source under `opentakserver/blueprints/marti/` and the published
+TAK Server CIV docs, the endpoints we need are:
+
+### Create / update a mission
+
+```
+PUT  /Marti/api/missions/{missionName}
+       ?creatorUid={UID}
+       &description={text}
+       &chatRoom={chatRoomUid}      (optional)
+       &baseLayer={layerName}       (optional)
+       &bbox={minLat,minLon,maxLat,maxLon}  (optional)
+       &boundingPolygon={lat lon, lat lon ...}  (optional)
+       &path={subpath}              (optional)
+       &classification={text}       (optional)
+       &tool={public|vbm|...}       (defaults to "public")
+       &group={group}               (repeat for multi-group, defaults __ANON__)
+       &defaultRole={MISSION_OWNER|MISSION_SUBSCRIBER|...}
+       &inviteOnly={true|false}
+       &allowDupe={true|false}
+Headers:
+       MissionAuthorization: {token}   (only if password-protected)
+Body:  empty (TAK Server CIV) or empty JSON `{}`
+Returns: 200/201 JSON envelope with the created mission record
+         400 if name collides and allowDupe is false
+```
+
+OTS notes (from `opentakserver/blueprints/marti/missions.py`):
+- mission names are case-insensitive; uppercased server side
+- description and chatRoom go in query string, not body — historical
+  Marti shape, not REST-tasteful but it's what every TAK client speaks
+
+### Add contents (data packages, CoT) to a mission
+
+Two flows. OmniTAK will use **(B)** because we already build a `.zip`.
+
+**(A) Inline CoT add:**
+```
+PUT  /Marti/api/missions/{missionName}/contents
+Body (JSON): {
+  "uids": ["{cot-uid-1}", "{cot-uid-2}"],
+  "hashes": []
+}
+```
+
+**(B) File-by-hash add:**
+```
+PUT  /Marti/api/missions/{missionName}/contents
+Body (JSON): {
+  "hashes": ["{sha256-of-zip}"]
+}
+```
+
+The hash must already exist in the sync DB — i.e. the package must be
+uploaded first. Hence the two-step:
+
+```
+1. POST /Marti/sync/missionupload
+        ?creatorUid={UID}
+        &hash={sha256}              (optional pre-computed; server recomputes)
+        &filename={name}.zip
+   Content-Type: multipart/form-data
+   Form field: assetfile = <zip bytes>
+   Returns: 200 OK, body = plain-text URL ending in `?hash={sha}`
+            (we parse the hash from this)
+
+2. PUT  /Marti/api/missions/{missionName}/contents
+   { "hashes": ["{sha}"] }
+```
+
+`TAKRestAPIClient.uploadDataPackage` already builds the multipart body
+in (1); we add a thin `addContentsToMission` for (2).
+
+### List / get missions
+
+```
+GET  /Marti/api/missions
+GET  /Marti/api/missions/{name}
+       Header: MissionPassword: {pw}  (if protected)
+```
+
+Both implemented in `TAKRestAPIClient.getMissions` / `getMission`.
+
+### Subscribe (peer EUDs to a mission)
+
+```
+PUT    /Marti/api/missions/{name}/subscription?uid={eudUid}
+DELETE /Marti/api/missions/{name}/subscription?uid={eudUid}
+```
+
+Already implemented.
+
+## TAK Server CIV differences vs OTS
+
+| Behaviour | OTS | TAK Server CIV |
+|---|---|---|
+| Auth (mTLS via 8089) | ✓ | ✓ |
+| Path = `/Marti/api/missions/...` | ✓ | ✓ |
+| `tool` query param | accepts `public` and a few custom values | strict whitelist (`public`, `vbm`, `mission`); rejects unknown with 400 |
+| `boundingPolygon` query param | optional | optional but logged warn |
+| Default group when omitted | `__ANON__` | `__ANON__` |
+| Response envelope | `{ version, type, data: [...] }` | identical |
+| Mission listener push (over CoT) | Uses `t-x-m-c` mission change CoT | Same `t-x-m-c` family |
+| Empty body on PUT create | accepts | accepts |
+
+So one client works for both. The only place we'd ever branch is if a
+user picks a CIV-only tool value — which we wouldn't expose for a SAR
+flow.
+
+## Auth — already solved
+
+OmniTAK already uses port-8089 streaming with client mTLS via
+`TAKAPIURLSessionDelegate` in `TAKRestAPIClient.swift`. The cert posture
+is documented in `[[project_omnitak_tak57_mtls]]` and the OTS interop
+notes in `[[project_omnitak_ots_interop]]`.
+
+For the REST endpoints we use port **8443** (HTTPS w/ optional client
+cert). The same `CertificateManager` identity that authorises the CoT
+stream authorises the mission API call, so a user who has connected to
+the server is already authenticated for mission create. No new auth
+flow needed.
+
+If the server is configured for password-only missions (TAK Server CIV
+"password-protected mission" mode), we send `MissionAuthorization:` /
+`MissionPassword:` headers — modelled in `getMission`. For SAR, we
+default to mTLS-only / no password.
+
+## Data package format
+
+`DataPackageManager.exportPackage` writes:
+
+```
+{name}_{version}.zip
+├── manifest.json     ← our own format
+├── overlays/         ← KML files from KMLOverlayManager
+└── configs/
+    └── app_settings.json
+```
+
+This is **not yet** a Marti MANIFEST. The TAK ecosystem expects a
+`MANIFEST/manifest.xml` Marti envelope:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<MissionPackageManifest version="2">
+  <Configuration>
+    <Parameter name="uid"    value="{package-uid}"/>
+    <Parameter name="name"   value="{display-name}"/>
+    <Parameter name="onReceiveImport" value="true"/>
+    <Parameter name="onReceiveDelete" value="false"/>
+  </Configuration>
+  <Contents>
+    <Content zipEntry="overlays/search-area.kml" ignore="false">
+      <Parameter name="contentType" value="KML"/>
+    </Content>
+    <Content zipEntry="sa.cot" ignore="false">
+      <Parameter name="contentType" value="COT"/>
+    </Content>
+  </Contents>
+</MissionPackageManifest>
+```
+
+ATAK / iTAK / TAKAware all reject packages that lack this manifest.
+**Follow-up work:** extend `DataPackageManager.exportPackage` (or wrap
+it) to emit a Marti manifest in addition to our internal manifest.json.
+For this session the `MissionAPIClient` accepts an arbitrary `.zip`,
+but the documented user flow assumes Marti-shaped packages.
+
+## Proposed Swift surface
+
+```swift
+public protocol MissionAPIClient {
+    func getMissions() async throws -> [TAKMissionInfo]
+
+    /// PUT /Marti/api/missions/{name}
+    @discardableResult
+    func createMission(
+        name: String,
+        creatorUid: String,
+        description: String?,
+        tool: String,
+        groups: [String],
+        defaultRole: String?,
+        bbox: MissionBoundingBox?
+    ) async throws -> TAKMissionInfo
+
+    /// POST /Marti/sync/missionupload  +
+    /// PUT  /Marti/api/missions/{name}/contents
+    @discardableResult
+    func addContentsToMission(
+        missionName: String,
+        packageURL: URL,
+        creatorUid: String
+    ) async throws -> String   // returns sha-256 hash attached
+}
+```
+
+A `URLProtocol`-based stub backs the unit test so we don't depend on a
+live TAK server.
+
+## Deferred to next session
+
+- Marti MANIFEST emitter (`MissionPackageManifestBuilder`)
+- Wire-up "Publish" button to real `createMission` + `addContentsToMission`
+- `Publish` progress UI + retry on transient failure
+- Member-picker (`uids[]` from contacts roster)
+- Subscribe-other-EUDs flow (already have `subscribeMission`)
+- TAK Server CIV `tool=vbm` whitelist exposure (advanced setting only)
+- E2E integration test against the local TAK 5.7 docker box
+  (`[[project_omnitak_tak57_mtls]]`)
+- Android parity issue on OmniTAK-Android

--- a/scripts/add_mission_api_client.rb
+++ b/scripts/add_mission_api_client.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+# Register MissionAPIClient.swift + MissionCreateView.swift in the
+# OmniTAKMobile target under the existing Features/Mission group.
+# Idempotent — safe to re-run. Mirrors add_mission_exporter.rb.
+require 'xcodeproj'
+
+project_path = File.expand_path('../OmniTAKMobile.xcodeproj', __dir__)
+project = Xcodeproj::Project.open(project_path)
+target = project.targets.find { |t| t.name == 'OmniTAKMobile' } or abort 'OmniTAKMobile target not found'
+
+mobile_group = project.main_group['OmniTAKMobile']
+features = mobile_group['Features'] || mobile_group.new_group('Features', nil)
+features.path = nil; features.source_tree = '<group>'
+mission = features['Mission'] || features.new_group('Mission', nil)
+mission.path = nil; mission.source_tree = '<group>'
+
+files = [
+  'OmniTAKMobile/Features/Mission/MissionAPIClient.swift',
+  'OmniTAKMobile/Features/Mission/MissionCreateView.swift',
+]
+
+files.each do |rel|
+  basename = File.basename(rel)
+  unless mission.files.find { |f| f.display_name == basename }
+    ref = mission.new_reference(rel)
+    ref.last_known_file_type = 'sourcecode.swift'
+    target.add_file_references([ref])
+    puts "Added #{rel}"
+  else
+    puts "#{basename} already referenced"
+  end
+end
+
+project.save


### PR DESCRIPTION
Closes #14. Source: K9Blue SAR feedback (Discord, 5/10/26).

## Summary
Foundation for on-device mission authoring and sync to TAK servers.

- **Research** (\`docs/specs/mission-api-client.md\`): OTS and TAK Server CIV both speak the same Marti API on our existing 8089 mTLS posture. Create is \`PUT /Marti/api/missions/{name}\`; attaching a .zip is two-step \`POST /Marti/sync/missionupload\` → \`PUT contents { hashes }\`.
- \`MissionAPIClient\` protocol + \`URLSessionMissionAPIClient\` impl — \`getMissions\`, \`createMission\`, \`addContentsToMission\` on real Marti wire format
- Settings → MISSION → "Create new mission (BETA)" sheet wired to real \`ServerManager.activeServer\` host on 8443
- Self-contained (no dep on the orphan \`TAKRestAPIClient.swift\`)

## TDD
11/11 XCTests RED→GREEN under `OmniTAKMobileSpecs/`. URLSession stubbed via custom \`URLProtocol\` — zero network. RED→GREEN demonstrated by flipping create verb to POST (test fails correctly) then restoring PUT.

## Build
`xcodebuild ... iPhone 17 Pro build` → BUILD SUCCEEDED.

## Test plan
- [ ] On-device QA: with TAK server connected, open Settings → MISSION → "Create new mission", fill name, tap Publish, confirm mission appears on peer ATAK/iTAK client
- [ ] Run \`cd OmniTAKMobileSpecs && swift test\` — 11/11 green
- [ ] Verify against local TAK 5.7 docker (see [[project_omnitak_tak57_mtls]])

## Recommended merge order
Stacks after #20 (data package builder) — Publish button in that PR depends on this client.

## Deferred to next session
- Marti \`MANIFEST/manifest.xml\` emitter (our existing package zip is missing it)
- Member picker in Create-mission sheet
- Real package attach wired to Publish
- E2E test against local TAK 5.7 docker
- OmniTAK-Android sibling issue (#30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)