### PR TITLE
feat(fema): FEMA / IC symbology catalog + marker palette

### DIFF
--- a/OmniTAKMobile.xcodeproj/project.pbxproj
+++ b/OmniTAKMobile.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		1A2B3C4D5E6F70801A2B3C4D /* SelfPositionMarkerImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70801A2B3C4E /* SelfPositionMarkerImage.swift */; };
 		1BE25DA5B44BA5AD28D90C82 /* RadialMenuMapCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628B317671CF6452847569CB /* RadialMenuMapCoordinator.swift */; };
 		1C19F979C95BE9B5CB8C75E2 /* demo-package.zip in Resources */ = {isa = PBXBuildFile; fileRef = 6CD96D4C13C8FF8B3F53B240 /* demo-package.zip */; };
+		2051E5BD105C01009ED13071 /* FEMAMarkerPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBE755BAFBDDC7231C50361 /* FEMAMarkerPaletteView.swift */; };
 		20CAAB4409715F7431C1DEAB /* AppPreviewRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786486F562966ED005A6E978 /* AppPreviewRecordingTests.swift */; };
 		21F8CB94928A130D0CC47B88 /* CompassOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7C9A85F883C8B6FBEDC4EA /* CompassOverlay.swift */; };
 		225E69B4E6B06F8CFCCC70CD /* DataPackageModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A282FADB8ACF4795AB133B /* DataPackageModels.swift */; };
@@ -181,6 +182,7 @@
 		A6CEA9E02F31C917002D96E2 /* MapLibre in Frameworks */ = {isa = PBXBuildFile; productRef = 7D6348C4CBB3428FBD5FF5CC /* MapLibre */; };
 		A7AC00010000000000B00001 /* ATAKPluginParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7AC00010000000000A00001 /* ATAKPluginParser.swift */; };
 		A7AC00010000000000B00002 /* ATAKPluginSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7AC00010000000000A00002 /* ATAKPluginSerializer.swift */; };
+		A8A9B8A4A5BD78248F290DCA /* FEMAIconCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E111E46C08EC3F84BB2CBC1C /* FEMAIconCatalog.swift */; };
 		A9321E0EC74569E8473691D6 /* CompassOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D240A72682F8C0E3253BA1F /* CompassOverlayView.swift */; };
 		A9C171AE7DA5913A5B2D5C9C /* MGRSGridToggleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92EDCFDBF0D0ECD7A414CE6 /* MGRSGridToggleView.swift */; };
 		AA0554C2EB313E2B73BE40C0 /* DrawingModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA5EECEC92A0D864B030870 /* DrawingModels.swift */; };
@@ -361,8 +363,8 @@
 		40210ECC988A417364D71247 /* SFGPUCA----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPUCA----.svg"; sourceTree = "<group>"; };
 		40BFBA51A756BC0EA91C9245 /* MapViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MapViewController.swift; path = OmniTAKMobile/Features/Map/Controllers/MapViewController.swift; sourceTree = "<group>"; };
 		4117A74128252722FF170D0E /* MultiServerFederation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultiServerFederation.swift; path = OmniTAKMobile/Utilities/Network/MultiServerFederation.swift; sourceTree = "<group>"; };
-		43235D80953F6C3559DA9620 /* QuickMarkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickMarkService.swift; path = OmniTAKMobile/Features/Map/Services/QuickMarkService.swift; sourceTree = "<group>"; };
 		429879F2EB3F0A9E1F0B8035 /* DrawingCoT.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DrawingCoT.swift; path = OmniTAKMobile/Features/Drawing/Services/DrawingCoT.swift; sourceTree = "<group>"; };
+		43235D80953F6C3559DA9620 /* QuickMarkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickMarkService.swift; path = OmniTAKMobile/Features/Map/Services/QuickMarkService.swift; sourceTree = "<group>"; };
 		43C20C5734319D533A7C2227 /* OfflineMapsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineMapsView.swift; path = OmniTAKMobile/Features/OfflineMaps/Views/OfflineMapsView.swift; sourceTree = "<group>"; };
 		441D3BF6E34A4ECF34A40AEF /* SFGPEVF----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPEVF----.svg"; sourceTree = "<group>"; };
 		448D0EBEFF3E2A71669016D1 /* ScaleBarView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScaleBarView.swift; path = OmniTAKMobile/Features/Map/Views/ScaleBarView.swift; sourceTree = "<group>"; };
@@ -414,6 +416,7 @@
 		6CB754FA0C8506C4D22450CE /* ServerValidator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServerValidator.swift; path = OmniTAKMobile/Features/Networking/Services/ServerValidator.swift; sourceTree = "<group>"; };
 		6CD96D4C13C8FF8B3F53B240 /* demo-package.zip */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = archive.zip; name = "demo-package.zip"; path = "OmniTAKMobile/Resources/demo-package.zip"; sourceTree = "<group>"; };
 		6D15E6FD65F0D6C4467F8C3D /* ConversationView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConversationView.swift; path = OmniTAKMobile/Features/Chat/Views/ConversationView.swift; sourceTree = "<group>"; };
+		6DBE755BAFBDDC7231C50361 /* FEMAMarkerPaletteView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FEMAMarkerPaletteView.swift; path = OmniTAKMobile/Features/Drawing/Views/FEMAMarkerPaletteView.swift; sourceTree = "<group>"; };
 		6DF4CA147B5220C0A776A48B /* TurnByTurnNavigationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TurnByTurnNavigationService.swift; path = OmniTAKMobile/Features/Navigation/Services/TurnByTurnNavigationService.swift; sourceTree = "<group>"; };
 		6FBC2615A833D70CD96C5723 /* RadialMenuModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadialMenuModels.swift; path = OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuModels.swift; sourceTree = "<group>"; };
 		72FA80C978460AFCBAA502D9 /* SimpleEnrollView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SimpleEnrollView.swift; path = OmniTAKMobile/Features/Networking/Views/SimpleEnrollView.swift; sourceTree = "<group>"; };
@@ -543,6 +546,7 @@
 		DFA957EC8A75AEFBCCFF253A /* GeofenceModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GeofenceModels.swift; path = OmniTAKMobile/Features/Geofencing/Models/GeofenceModels.swift; sourceTree = "<group>"; };
 		E0EA95D7747A65CF9F1E5368 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E0F8125D0B514F0BD09467A8 /* ChatModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatModels.swift; path = OmniTAKMobile/Features/Chat/Models/ChatModels.swift; sourceTree = "<group>"; };
+		E111E46C08EC3F84BB2CBC1C /* FEMAIconCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FEMAIconCatalog.swift; path = OmniTAKMobile/Shared/Services/FEMAIconCatalog.swift; sourceTree = "<group>"; };
 		E1F2A3B4C5D6E7F809182931 /* PointMarkerEditView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PointMarkerEditView.swift; path = OmniTAKMobile/Features/Drawing/Views/PointMarkerEditView.swift; sourceTree = "<group>"; };
 		E23A94C1C9FE550D90660BD6 /* SUGPUCI----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUGPUCI----.svg"; sourceTree = "<group>"; };
 		E438B334DFC6353E3C21C7DD /* AircraftIcons.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AircraftIcons.swift; path = "plugins/example-adsb-plugin/Sources/ADSBPlugin/Models/AircraftIcons.swift"; sourceTree = SOURCE_ROOT; };
@@ -761,6 +765,7 @@
 			children = (
 				BB82A68BE625612A8B0E94DC /* PluginSettingsManager.swift */,
 				1119873F4EBB6AC92B2157E0 /* MilStdIconService.swift */,
+				E111E46C08EC3F84BB2CBC1C /* FEMAIconCatalog.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -782,6 +787,14 @@
 				270B8A7F33083294B3208250 /* TAKAware */,
 			);
 			path = Vendor;
+			sourceTree = "<group>";
+		};
+		1AE1A0E24FC88C962253289B /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				6DBE755BAFBDDC7231C50361 /* FEMAMarkerPaletteView.swift */,
+			);
+			name = Views;
 			sourceTree = "<group>";
 		};
 		1BC72CA255E660735100D4F5 /* Services */ = {
@@ -1164,6 +1177,14 @@
 				D1103C5349FE3EE31708711A /* KMZHandler.swift */,
 			);
 			name = Parsers;
+			sourceTree = "<group>";
+		};
+		5242EF06373AE44B18226274 /* Drawing */ = {
+			isa = PBXGroup;
+			children = (
+				1AE1A0E24FC88C962253289B /* Views */,
+			);
+			name = Drawing;
 			sourceTree = "<group>";
 		};
 		52893199B61305DFA84E8FE7 /* Tracking */ = {
@@ -1630,6 +1651,7 @@
 				E0E204EFAA2BDD43C77ED194 /* DataPackages */,
 				283609875719BCFCCAC20860 /* Map */,
 				C11C0AC3E3F21F783B3B55A3 /* Mission */,
+				5242EF06373AE44B18226274 /* Drawing */,
 			);
 			name = Features;
 			sourceTree = "<group>";
@@ -2350,6 +2372,8 @@
 				83173DE79C8B269543AA2AB0 /* QuickMarkService.swift in Sources */,
 				5BBDAB61BC54993C40E9C5C4 /* MissionExporter.swift in Sources */,
 				92B55E6241794B84FBAB24A2 /* DrawingCoT.swift in Sources */,
+				A8A9B8A4A5BD78248F290DCA /* FEMAIconCatalog.swift in Sources */,
+				2051E5BD105C01009ED13071 /* FEMAMarkerPaletteView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OmniTAKMobile/CoT/Generators/MarkerCoTGenerator.swift
+++ b/OmniTAKMobile/CoT/Generators/MarkerCoTGenerator.swift
@@ -28,13 +28,25 @@ class MarkerCoTGenerator {
         // Convert hex color to ARGB signed integer
         let argbColor = hexToARGB(marker.affiliation.hexColor)
 
+        // FEMA / IC markers swap in the FEMA usericon set so peers with the
+        // catalog installed render the right glyph; everyone else falls
+        // through to the friendly-ground-installation default (#13).
+        let iconsetPath: String = {
+            if let raw = marker.femaKindRaw,
+               let kind = FEMAIconCatalog.Kind(rawValue: raw),
+               let icon = FEMAIconCatalog.icon(for: kind) {
+                return icon.iconsetPath
+            }
+            return "COT_MAPPING_SPOTMAP/\(marker.affiliation.rawValue.lowercased())_point"
+        }()
+
         var xml = """
         <?xml version="1.0" encoding="UTF-8"?>
         <event version="2.0" uid="\(marker.uid)" type="\(marker.cotType)" time="\(dateFormatter.string(from: now))" start="\(dateFormatter.string(from: now))" stale="\(dateFormatter.string(from: stale))" how="h-g-i-g-o">
             <point lat="\(lat)" lon="\(lon)" hae="\(hae)" ce="10.0" le="10.0"/>
             <detail>
                 <contact callsign="\(escapeXML(marker.name))"/>
-                <usericon iconsetpath="COT_MAPPING_SPOTMAP/\(marker.affiliation.rawValue.lowercased())_point"/>
+                <usericon iconsetpath="\(iconsetPath)"/>
                 <color argb="\(argbColor)"/>
                 <affiliation value="\(marker.affiliation.rawValue)"/>
         """

--- a/OmniTAKMobile/Features/Drawing/Models/PointMarkerModels.swift
+++ b/OmniTAKMobile/Features/Drawing/Models/PointMarkerModels.swift
@@ -37,6 +37,12 @@ struct PointMarker: Identifiable, Codable, Equatable {
     var cotType: String
     var iconName: String
 
+    /// Optional FEMA / Incident Command icon (issue #13). When set, the
+    /// CoT emitter swaps in the FEMA `iconsetpath` + matching `cotType`
+    /// so peers with the FEMA icon set render the right glyph and others
+    /// fall through to the friendly-installation default.
+    var femaKindRaw: String?
+
     // Sharing
     var isBroadcast: Bool
 
@@ -49,6 +55,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         remarks: String? = nil,
         saluteReport: SALUTEReport? = nil,
         createdBy: String? = nil,
+        femaKindRaw: String? = nil,
         isBroadcast: Bool = false
     ) {
         self.id = id
@@ -62,8 +69,16 @@ struct PointMarker: Identifiable, Codable, Equatable {
         self.saluteReport = saluteReport
         self.createdBy = createdBy
         self.uid = "marker-\(id.uuidString)"
-        self.cotType = affiliation.cotType
-        self.iconName = affiliation.iconName
+        self.femaKindRaw = femaKindRaw
+        if let raw = femaKindRaw,
+           let kind = FEMAIconCatalog.Kind(rawValue: raw),
+           let icon = FEMAIconCatalog.icon(for: kind) {
+            self.cotType = icon.cotType
+            self.iconName = icon.symbolName
+        } else {
+            self.cotType = affiliation.cotType
+            self.iconName = affiliation.iconName
+        }
         self.isBroadcast = isBroadcast
     }
 
@@ -72,7 +87,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case id, name, affiliation, latitude, longitude, altitude
         case timestamp, modifiedAt, remarks, createdBy, saluteReport
-        case uid, cotType, iconName, isBroadcast
+        case uid, cotType, iconName, isBroadcast, femaKindRaw
     }
 
     init(from decoder: Decoder) throws {
@@ -94,6 +109,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         uid = try container.decode(String.self, forKey: .uid)
         cotType = try container.decode(String.self, forKey: .cotType)
         iconName = try container.decode(String.self, forKey: .iconName)
+        femaKindRaw = try container.decodeIfPresent(String.self, forKey: .femaKindRaw)
         isBroadcast = try container.decode(Bool.self, forKey: .isBroadcast)
     }
 
@@ -113,6 +129,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         try container.encode(uid, forKey: .uid)
         try container.encode(cotType, forKey: .cotType)
         try container.encode(iconName, forKey: .iconName)
+        try container.encodeIfPresent(femaKindRaw, forKey: .femaKindRaw)
         try container.encode(isBroadcast, forKey: .isBroadcast)
     }
 

--- a/OmniTAKMobile/Features/Drawing/Services/PointDropperService.swift
+++ b/OmniTAKMobile/Features/Drawing/Services/PointDropperService.swift
@@ -103,6 +103,46 @@ class PointDropperService: ObservableObject {
         )
     }
 
+    /// Drop a FEMA / Incident Command marker (issue #13). Bypasses the
+    /// affiliation selector — the caller already picked a specific icon
+    /// kind via the FEMA palette.
+    @discardableResult
+    func dropFEMA(
+        kind: FEMAIconCatalog.Kind,
+        at coordinate: CLLocationCoordinate2D,
+        name: String? = nil,
+        remarks: String? = nil,
+        broadcast: Bool = false
+    ) -> PointMarker? {
+        guard let icon = FEMAIconCatalog.icon(for: kind) else { return nil }
+        let markerName = name ?? icon.label
+        let marker = PointMarker(
+            name: markerName,
+            // FEMA markers are friendly civil response — keep affiliation
+            // consistent with the CoT type prefix (a-f-G-I-*).
+            affiliation: .friendly,
+            coordinate: coordinate,
+            remarks: remarks,
+            femaKindRaw: kind.rawValue,
+            isBroadcast: broadcast
+        )
+
+        markers.append(marker)
+        updateRecentMarkers(marker)
+        saveMarkers()
+
+        #if DEBUG
+        print("FEMA marker: \(icon.label) at \(coordinate.latitude),\(coordinate.longitude)")
+        #endif
+
+        if broadcast {
+            broadcastMarker(marker)
+        }
+
+        onEvent?(.markerCreated(marker))
+        return marker
+    }
+
     /// Get marker by ID
     func getMarker(id: UUID) -> PointMarker? {
         return markers.first { $0.id == id }

--- a/OmniTAKMobile/Features/Drawing/Views/FEMAMarkerPaletteView.swift
+++ b/OmniTAKMobile/Features/Drawing/Views/FEMAMarkerPaletteView.swift
@@ -1,0 +1,197 @@
+//
+//  FEMAMarkerPaletteView.swift
+//  OmniTAKMobile
+//
+//  Modal sheet that exposes the FEMA / Incident Command marker palette.
+//  Presented from the Point Dropper drawer — DO NOT collapse the full-screen
+//  map for this; this is always a sheet so the map stays sacred
+//  (see feedback_omnitak_fullscreen_map).
+//
+//  Closes GitHub #13.
+//
+import SwiftUI
+import CoreLocation
+
+/// Result handed back to the caller when the user picks an icon.
+struct FEMAMarkerSelection: Equatable {
+    let icon: FEMAIconCatalog.FEMAIcon
+    /// Optional override name; nil means caller should default to icon.label.
+    let name: String?
+    let remarks: String?
+}
+
+struct FEMAMarkerPaletteView: View {
+    @Binding var isPresented: Bool
+    let onSelect: (FEMAMarkerSelection) -> Void
+
+    @State private var pickedKind: FEMAIconCatalog.Kind?
+    @State private var nameOverride: String = ""
+    @State private var remarks: String = ""
+
+    private let columns = [GridItem(.adaptive(minimum: 84), spacing: 12)]
+
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color(hex: "#1E1E1E").ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        header
+
+                        ForEach(FEMAIconCatalog.allCategories, id: \.self) { category in
+                            categorySection(category)
+                        }
+
+                        if pickedKind != nil {
+                            detailsSection
+                            dropButton
+                        }
+                    }
+                    .padding()
+                }
+            }
+            .navigationTitle("FEMA / IC Markers")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: { isPresented = false }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.gray)
+                    }
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Subviews
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("SAR / DISASTER RESPONSE")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundColor(Color(hex: "#FFFC00"))
+            Text("Tap an icon, then Drop. Round-trips over CoT as a friendly ground installation with a FEMA usericon.")
+                .font(.system(size: 11))
+                .foregroundColor(.gray)
+        }
+    }
+
+    private func categorySection(_ category: FEMAIconCatalog.Category) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(category.displayName.uppercased())
+                .font(.system(size: 12, weight: .bold))
+                .foregroundColor(category.accentColor)
+
+            LazyVGrid(columns: columns, spacing: 12) {
+                ForEach(FEMAIconCatalog.icons(in: category)) { icon in
+                    iconTile(icon)
+                }
+            }
+        }
+    }
+
+    private func iconTile(_ icon: FEMAIconCatalog.FEMAIcon) -> some View {
+        let isPicked = pickedKind == icon.kind
+        return Button(action: {
+            let gen = UIImpactFeedbackGenerator(style: .light)
+            gen.impactOccurred()
+            pickedKind = icon.kind
+        }) {
+            VStack(spacing: 6) {
+                Image(systemName: icon.symbolName)
+                    .font(.system(size: 28, weight: .semibold))
+                    .foregroundColor(isPicked ? .black : icon.category.accentColor)
+                    .frame(height: 32)
+
+                Text(icon.label)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(isPicked ? .black : .white)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.7)
+            }
+            .frame(maxWidth: .infinity, minHeight: 72)
+            .padding(.vertical, 8)
+            // No grey backplate — keep icons floating per feedback.
+            .background(
+                isPicked
+                    ? AnyView(icon.category.accentColor)
+                    : AnyView(Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(icon.category.accentColor.opacity(isPicked ? 1.0 : 0.4),
+                            lineWidth: isPicked ? 2 : 1)
+            )
+            .cornerRadius(10)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var detailsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("DETAILS (OPTIONAL)")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundColor(Color(hex: "#FFFC00"))
+
+            TextField("Override name", text: $nameOverride)
+                .padding(10)
+                .background(Color.black.opacity(0.3))
+                .cornerRadius(8)
+                .foregroundColor(.white)
+
+            TextEditor(text: $remarks)
+                .frame(minHeight: 60)
+                .padding(6)
+                .background(Color.black.opacity(0.3))
+                .cornerRadius(8)
+                .foregroundColor(.white)
+        }
+    }
+
+    private var dropButton: some View {
+        Button(action: dropSelected) {
+            HStack(spacing: 10) {
+                Image(systemName: "scope")
+                Text("DROP")
+                    .font(.system(size: 16, weight: .bold))
+                Spacer()
+                if let kind = pickedKind, let icon = FEMAIconCatalog.icon(for: kind) {
+                    Image(systemName: icon.symbolName)
+                        .foregroundColor(icon.category.accentColor)
+                }
+            }
+            .padding()
+            .foregroundColor(.white)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color(hex: "#FFFC00"), lineWidth: 2)
+            )
+        }
+        .disabled(pickedKind == nil)
+    }
+
+    private func dropSelected() {
+        guard let kind = pickedKind, let icon = FEMAIconCatalog.icon(for: kind) else { return }
+        let selection = FEMAMarkerSelection(
+            icon: icon,
+            name: nameOverride.isEmpty ? nil : nameOverride,
+            remarks: remarks.isEmpty ? nil : remarks
+        )
+        onSelect(selection)
+        isPresented = false
+    }
+}
+
+// MARK: - Preview
+
+struct FEMAMarkerPaletteView_Previews: PreviewProvider {
+    static var previews: some View {
+        FEMAMarkerPaletteView(
+            isPresented: .constant(true),
+            onSelect: { _ in }
+        )
+    }
+}

--- a/OmniTAKMobile/Features/Drawing/Views/PointDropperView.swift
+++ b/OmniTAKMobile/Features/Drawing/Views/PointDropperView.swift
@@ -24,6 +24,7 @@ struct PointDropperView: View {
     @State private var broadcastImmediately: Bool = false
     @State private var showSALUTEReport: Bool = false
     @State private var showMarkerList: Bool = false
+    @State private var showFEMAPalette: Bool = false
     @State private var selectedMarkerForSALUTE: PointMarker?
 
     var body: some View {
@@ -36,6 +37,9 @@ struct PointDropperView: View {
                     VStack(spacing: 16) {
                         // Quick Drop Section
                         quickDropSection
+
+                        // FEMA / IC Palette entry (issue #13)
+                        femaPaletteEntry
 
                         // Affiliation Selector
                         affiliationSelector
@@ -104,6 +108,63 @@ struct PointDropperView: View {
         .sheet(isPresented: $showMarkerList) {
             MarkerListView(service: service)
         }
+        .sheet(isPresented: $showFEMAPalette) {
+            FEMAMarkerPaletteView(
+                isPresented: $showFEMAPalette,
+                onSelect: handleFEMASelection
+            )
+        }
+    }
+
+    // MARK: - FEMA Palette Entry
+
+    /// Compact entry point that opens the FEMA / IC modal sheet — kept as
+    /// a row in the drawer so the full-screen map is never compressed.
+    private var femaPaletteEntry: some View {
+        Button(action: { showFEMAPalette = true }) {
+            HStack(spacing: 12) {
+                Image(systemName: "cross.case.fill")
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundColor(.red)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("FEMA / IC MARKERS")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundColor(.white)
+                    Text("SAR command, medical, LZ, vehicles, support")
+                        .font(.system(size: 10))
+                        .foregroundColor(.gray)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(Color(hex: "#FFFC00"))
+            }
+            .padding()
+            .background(Color.black.opacity(0.3))
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color.red.opacity(0.4), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func handleFEMASelection(_ selection: FEMAMarkerSelection) {
+        guard let location = currentLocation ?? mapCenter else { return }
+        _ = service.dropFEMA(
+            kind: selection.icon.kind,
+            at: location,
+            name: selection.name,
+            remarks: selection.remarks,
+            broadcast: broadcastImmediately
+        )
+
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(.success)
     }
 
     // MARK: - Quick Drop Section

--- a/OmniTAKMobile/Shared/Services/FEMAIconCatalog.swift
+++ b/OmniTAKMobile/Shared/Services/FEMAIconCatalog.swift
@@ -1,0 +1,204 @@
+//
+//  FEMAIconCatalog.swift
+//  OmniTAKMobile
+//
+//  FEMA / Incident Command symbology catalog used by the SAR / disaster
+//  response marker palette (closes GitHub #13).
+//
+//  Why this exists
+//  ---------------
+//  K9Blue SAR feedback (5/10/26): pre-planned and hasty searches both need
+//  IC / medical / LZ / vehicle / support-station markers, and MIL-STD-2525
+//  symbols aren't the right vocabulary for civil disaster response.
+//
+//  CoT type convention
+//  -------------------
+//  FEMA / ICS markers don't have a canonical MIL-STD-2525 unit type, so we
+//  emit them as friendly ground installations (`a-f-G-I-*`) and rely on the
+//  `<usericon iconsetpath="COT_MAPPING_FEMA/...">` detail extension to carry
+//  the FEMA glyph. Receivers that don't ship the FEMA set still get a
+//  plausible friendly-installation fallback rendered by ATAK/iTAK.
+//
+//  References:
+//    * NIMS / ICS-237 Resource Typing — symbology categories used here
+//    * TAK ATAK-CIV iconsetpath convention (COT_MAPPING_<SET>/<group>/<icon>)
+//
+//  Spec mirror: OmniTAKMobileSpecs/Sources/FEMACatalogSpec/FEMAIconCatalog.swift
+//
+import Foundation
+import SwiftUI
+
+enum FEMAIconCatalog {
+
+    // MARK: - Category
+
+    /// SAR / incident-command grouping shown as palette sections.
+    enum Category: String, CaseIterable, Hashable {
+        case incidentCommand
+        case medical
+        case aviation
+        case vehicles
+        case support
+
+        var displayName: String {
+            switch self {
+            case .incidentCommand: return "Command"
+            case .medical:         return "Medical"
+            case .aviation:        return "Aviation"
+            case .vehicles:        return "Vehicles"
+            case .support:         return "Support"
+            }
+        }
+
+        /// Tint applied behind the SF symbol so categories are visually
+        /// distinguishable on the palette without grey backplates (per
+        /// feedback_radial_menu_no_backdrop — icons stay floaty on map).
+        var accentColor: Color {
+            switch self {
+            case .incidentCommand: return .orange
+            case .medical:         return .red
+            case .aviation:        return .cyan
+            case .vehicles:        return .yellow
+            case .support:         return .green
+            }
+        }
+    }
+
+    // MARK: - Kind
+
+    /// Individual FEMA / IC icons. Stable raw values — embedded in CoT
+    /// iconsetpath so we don't break round-trips when we add more.
+    enum Kind: String, CaseIterable, Hashable {
+        case commandPost        = "command_post"
+        case stagingArea        = "staging_area"
+        case triageStation      = "triage_station"
+        case medicalSupply      = "medical_supply"
+        case helicopterLZ       = "helicopter_lz"
+        case fireTruck          = "fire_truck"
+        case ambulance          = "ambulance"
+        case searchTeam         = "search_team"
+        case baseCamp           = "base_camp"
+        case foodWater          = "food_water"
+        case generator          = "generator"
+        case communicationsHub  = "communications_hub"
+    }
+
+    // MARK: - FEMAIcon
+
+    struct FEMAIcon: Equatable, Identifiable {
+        let kind: Kind
+        let category: Category
+        let label: String
+        /// SF Symbol glyph. We deliberately use SF Symbols as scaffolding
+        /// until proper FEMA artwork is licensed/drawn — see issue #13.
+        let symbolName: String
+        /// CoT `type` attribute on the emitted event.
+        let cotType: String
+        /// Value for `<usericon iconsetpath="...">` so peers can render
+        /// the FEMA glyph if they have the icon set installed.
+        let iconsetPath: String
+
+        var id: Kind { kind }
+    }
+
+    // MARK: - Catalog
+
+    private static let entries: [Kind: FEMAIcon] = {
+        func make(_ kind: Kind,
+                  _ category: Category,
+                  _ label: String,
+                  _ symbol: String,
+                  _ cot: String) -> (Kind, FEMAIcon) {
+            return (kind, FEMAIcon(
+                kind: kind,
+                category: category,
+                label: label,
+                symbolName: symbol,
+                cotType: cot,
+                iconsetPath: "COT_MAPPING_FEMA/\(category.rawValue)/\(kind.rawValue)"
+            ))
+        }
+
+        let all: [(Kind, FEMAIcon)] = [
+            // --- Incident Command ---
+            make(.commandPost,       .incidentCommand, "Command Post",
+                 "flag.checkered",                "a-f-G-I-U-T"),
+            make(.stagingArea,       .incidentCommand, "Staging Area",
+                 "rectangle.stack.fill",          "a-f-G-I-B-A"),
+
+            // --- Medical ---
+            make(.triageStation,     .medical,         "Triage Station",
+                 "cross.case.fill",               "a-f-G-I-M-T"),
+            make(.medicalSupply,     .medical,         "Medical Supply",
+                 "cross.vial.fill",               "a-f-G-I-M-S"),
+
+            // --- Aviation ---
+            make(.helicopterLZ,      .aviation,        "Helicopter LZ",
+                 "helicopter",                    "a-f-G-I-X-H"),
+
+            // --- Vehicles ---
+            make(.fireTruck,         .vehicles,        "Fire Engine",
+                 "flame.fill",                    "a-f-G-E-V-F-R"),
+            make(.ambulance,         .vehicles,        "Ambulance",
+                 "cross.circle.fill",             "a-f-G-E-V-M-A"),
+            make(.searchTeam,        .vehicles,        "Search Team",
+                 "figure.2.and.child.holdinghands","a-f-G-U-U-S"),
+
+            // --- Support ---
+            make(.baseCamp,          .support,         "Base Camp",
+                 "tent.fill",                     "a-f-G-I-B-C"),
+            make(.foodWater,         .support,         "Food / Water",
+                 "fork.knife",                    "a-f-G-I-B-F"),
+            make(.generator,         .support,         "Generator",
+                 "bolt.fill",                     "a-f-G-I-U-E"),
+            make(.communicationsHub, .support,         "Comms Hub",
+                 "antenna.radiowaves.left.and.right",
+                 "a-f-G-I-U-C"),
+        ]
+
+        return Dictionary(uniqueKeysWithValues: all)
+    }()
+
+    // MARK: - Lookup
+
+    static var allCategories: [Category] {
+        Category.allCases.filter { cat in
+            entries.values.contains(where: { $0.category == cat })
+        }
+    }
+
+    static func icon(for kind: Kind) -> FEMAIcon? {
+        entries[kind]
+    }
+
+    static func icons(in category: Category) -> [FEMAIcon] {
+        let kindOrder = Kind.allCases.enumerated().reduce(into: [Kind: Int]()) {
+            $0[$1.element] = $1.offset
+        }
+        return entries.values
+            .filter { $0.category == category }
+            .sorted { (kindOrder[$0.kind] ?? 0) < (kindOrder[$1.kind] ?? 0) }
+    }
+
+    /// Recover a `Kind` from an incoming CoT event. Round-trips with what we
+    /// emit. Preference order:
+    ///   1. iconsetPath match on `COT_MAPPING_FEMA/<cat>/<kind>`
+    ///   2. cotType exact match (last-resort; some kinds may share types)
+    static func kind(forCoTType cotType: String, iconsetPath: String) -> Kind? {
+        let prefix = "COT_MAPPING_FEMA/"
+        if iconsetPath.hasPrefix(prefix) {
+            let suffix = iconsetPath.dropFirst(prefix.count)
+            if let slash = suffix.lastIndex(of: "/") {
+                let kindRaw = String(suffix[suffix.index(after: slash)...])
+                if let kind = Kind(rawValue: kindRaw) {
+                    return kind
+                }
+            }
+        }
+        let matches = entries.values.filter { $0.cotType == cotType }
+        if matches.count == 1 {
+            return matches.first?.kind
+        }
+        return nil
+    }
+}

--- a/OmniTAKMobileSpecs/Package.swift
+++ b/OmniTAKMobileSpecs/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.9
+//
+// OmniTAKMobileSpecs
+//
+// Standalone XCTest harness for OmniTAK iOS modules that don't yet have a
+// PBXNativeTarget wired up in OmniTAKMobile.xcodeproj. Used as a fallback so
+// we can keep TDD discipline (RED -> GREEN) for unit-level Swift code while
+// the Xcode test target is still missing (see OmniTAKMobileTests/README.md).
+//
+// To run:
+//     cd OmniTAKMobileSpecs
+//     swift test
+//
+// To add a new spec for an in-app module, copy the file into Sources/<Spec>/
+// (only pure-Swift types — no UIKit/SwiftUI/MapKit dependencies in here) and
+// write your XCTest cases against it under Tests/.
+//
+import PackageDescription
+
+let package = Package(
+    name: "OmniTAKMobileSpecs",
+    platforms: [.macOS(.v13), .iOS(.v16)],
+    products: [
+        .library(name: "FEMACatalogSpec", targets: ["FEMACatalogSpec"]),
+    ],
+    targets: [
+        .target(
+            name: "FEMACatalogSpec",
+            path: "Sources/FEMACatalogSpec"
+        ),
+        .testTarget(
+            name: "FEMACatalogSpecTests",
+            dependencies: ["FEMACatalogSpec"],
+            path: "Tests/FEMACatalogSpecTests"
+        ),
+    ]
+)

--- a/OmniTAKMobileSpecs/Sources/FEMACatalogSpec/FEMAIconCatalog.swift
+++ b/OmniTAKMobileSpecs/Sources/FEMACatalogSpec/FEMAIconCatalog.swift
@@ -1,0 +1,208 @@
+//
+//  FEMAIconCatalog.swift  (spec mirror)
+//
+//  Pure-Foundation mirror of OmniTAKMobile's FEMAIconCatalog so the SwiftPM
+//  test harness can exercise it without dragging UIKit/SwiftUI into the
+//  test process. Keep this file in lockstep with
+//  OmniTAKMobile/Shared/Services/FEMAIconCatalog.swift — the schema (Kind,
+//  Category, FEMAIcon, lookup APIs) is the cross-platform contract.
+//
+//  Closes #13 — FEMA / IC symbology indicators for SAR teams.
+//
+//  CoT type convention
+//  -------------------
+//  FEMA / ICS markers don't have a canonical MIL-STD-2525 unit type, so we
+//  emit them as friendly ground installations (`a-f-G-I-*`) and rely on the
+//  `<usericon iconsetpath="COT_MAPPING_FEMA/...">` detail extension to carry
+//  the FEMA glyph. Receivers that don't ship the FEMA set still get a
+//  plausible friendly-installation fallback rendered by ATAK/iTAK.
+//
+//  References:
+//    * NIMS / ICS-237 Resource Typing — symbology categories used here
+//    * TAK ATAK-CIV iconsetpath convention (COT_MAPPING_<SET>/<group>/<icon>)
+//
+import Foundation
+
+public enum FEMAIconCatalog {
+
+    // MARK: - Category
+
+    /// SAR / incident-command grouping shown as palette sections.
+    public enum Category: String, CaseIterable, Hashable {
+        case incidentCommand
+        case medical
+        case aviation
+        case vehicles
+        case support
+
+        public var displayName: String {
+            switch self {
+            case .incidentCommand: return "Command"
+            case .medical:         return "Medical"
+            case .aviation:        return "Aviation"
+            case .vehicles:        return "Vehicles"
+            case .support:         return "Support"
+            }
+        }
+    }
+
+    // MARK: - Kind
+
+    /// Individual FEMA / IC icons. Stable raw values — they're embedded in
+    /// the CoT iconsetpath so we don't break round-trips when we add more.
+    public enum Kind: String, CaseIterable, Hashable {
+        case commandPost        = "command_post"
+        case stagingArea        = "staging_area"
+        case triageStation      = "triage_station"
+        case medicalSupply      = "medical_supply"
+        case helicopterLZ       = "helicopter_lz"
+        case fireTruck          = "fire_truck"
+        case ambulance          = "ambulance"
+        case searchTeam         = "search_team"
+        case baseCamp           = "base_camp"
+        case foodWater          = "food_water"
+        case generator          = "generator"
+        case communicationsHub  = "communications_hub"
+    }
+
+    // MARK: - FEMAIcon
+
+    public struct FEMAIcon: Equatable {
+        public let kind: Kind
+        public let category: Category
+        public let label: String
+        /// SF Symbol name — the spec test asserts presence + a couple of
+        /// keyword hints, not the exact glyph (Apple renames things).
+        public let symbolName: String
+        /// CoT `type` attribute on the emitted event.
+        public let cotType: String
+        /// Value for `<usericon iconsetpath="...">` so peers can render
+        /// the FEMA glyph if they have the icon set installed.
+        public let iconsetPath: String
+
+        public init(kind: Kind,
+                    category: Category,
+                    label: String,
+                    symbolName: String,
+                    cotType: String,
+                    iconsetPath: String) {
+            self.kind = kind
+            self.category = category
+            self.label = label
+            self.symbolName = symbolName
+            self.cotType = cotType
+            self.iconsetPath = iconsetPath
+        }
+    }
+
+    // MARK: - Catalog
+
+    private static let entries: [Kind: FEMAIcon] = {
+        func make(_ kind: Kind,
+                  _ category: Category,
+                  _ label: String,
+                  _ symbol: String,
+                  _ cot: String) -> (Kind, FEMAIcon) {
+            return (kind, FEMAIcon(
+                kind: kind,
+                category: category,
+                label: label,
+                symbolName: symbol,
+                cotType: cot,
+                iconsetPath: "COT_MAPPING_FEMA/\(category.rawValue)/\(kind.rawValue)"
+            ))
+        }
+
+        let all: [(Kind, FEMAIcon)] = [
+            // --- Incident Command ---
+            make(.commandPost,       .incidentCommand, "Command Post",
+                 "flag.checkered",                "a-f-G-I-U-T"),
+            make(.stagingArea,       .incidentCommand, "Staging Area",
+                 "rectangle.stack.fill",          "a-f-G-I-B-A"),
+
+            // --- Medical ---
+            make(.triageStation,     .medical,         "Triage Station",
+                 "cross.case.fill",               "a-f-G-I-M-T"),
+            make(.medicalSupply,     .medical,         "Medical Supply",
+                 "cross.vial.fill",               "a-f-G-I-M-S"),
+
+            // --- Aviation ---
+            make(.helicopterLZ,      .aviation,        "Helicopter LZ",
+                 "helicopter",                    "a-f-G-I-X-H"),
+
+            // --- Vehicles ---
+            make(.fireTruck,         .vehicles,        "Fire Engine",
+                 "flame.fill",                    "a-f-G-E-V-F-R"),
+            make(.ambulance,         .vehicles,        "Ambulance",
+                 "cross.circle.fill",             "a-f-G-E-V-M-A"),
+            make(.searchTeam,        .vehicles,        "Search Team",
+                 "figure.2.and.child.holdinghands","a-f-G-U-U-S"),
+
+            // --- Support ---
+            make(.baseCamp,          .support,         "Base Camp",
+                 "tent.fill",                     "a-f-G-I-B-C"),
+            make(.foodWater,         .support,         "Food / Water",
+                 "fork.knife",                    "a-f-G-I-B-F"),
+            make(.generator,         .support,         "Generator",
+                 "bolt.fill",                     "a-f-G-I-U-E"),
+            make(.communicationsHub, .support,         "Comms Hub",
+                 "antenna.radiowaves.left.and.right",
+                 "a-f-G-I-U-C"),
+        ]
+
+        return Dictionary(uniqueKeysWithValues: all)
+    }()
+
+    // MARK: - Lookup
+
+    public static var allCategories: [Category] {
+        // Preserve declaration order from `Category.allCases` but filter
+        // to those that actually have entries — guards against future
+        // category additions without icons.
+        Category.allCases.filter { cat in
+            entries.values.contains(where: { $0.category == cat })
+        }
+    }
+
+    public static func icon(for kind: Kind) -> FEMAIcon? {
+        entries[kind]
+    }
+
+    public static func icons(in category: Category) -> [FEMAIcon] {
+        // Sort by Kind declaration order so the palette is stable.
+        let kindOrder = Kind.allCases.enumerated().reduce(into: [Kind: Int]()) {
+            $0[$1.element] = $1.offset
+        }
+        return entries.values
+            .filter { $0.category == category }
+            .sorted { (kindOrder[$0.kind] ?? 0) < (kindOrder[$1.kind] ?? 0) }
+    }
+
+    /// Recover a `Kind` from an incoming CoT event. Round-trips with
+    /// what we emit. Preference order:
+    ///   1. iconsetPath match on `COT_MAPPING_FEMA/<cat>/<kind>`
+    ///   2. cotType exact match (last-resort; some kinds share types)
+    public static func kind(forCoTType cotType: String,
+                            iconsetPath: String) -> Kind? {
+        // 1. iconsetPath fast path
+        let prefix = "COT_MAPPING_FEMA/"
+        if iconsetPath.hasPrefix(prefix) {
+            let suffix = iconsetPath.dropFirst(prefix.count)
+            // suffix is "<category>/<kind>" — pull the last component.
+            if let slash = suffix.lastIndex(of: "/") {
+                let kindRaw = String(suffix[suffix.index(after: slash)...])
+                if let kind = Kind(rawValue: kindRaw) {
+                    return kind
+                }
+            }
+        }
+
+        // 2. cotType exact match — only useful when the type happens to be
+        //    unique to one kind.
+        let matches = entries.values.filter { $0.cotType == cotType }
+        if matches.count == 1 {
+            return matches.first?.kind
+        }
+        return nil
+    }
+}

--- a/OmniTAKMobileSpecs/Tests/FEMACatalogSpecTests/FEMAIconCatalogTests.swift
+++ b/OmniTAKMobileSpecs/Tests/FEMACatalogSpecTests/FEMAIconCatalogTests.swift
@@ -1,0 +1,135 @@
+//
+//  FEMAIconCatalogTests.swift
+//  FEMACatalogSpecTests
+//
+//  TDD spec for the FEMA / Incident Command icon catalog used by the
+//  SAR / disaster-response marker palette (closes #13).
+//
+//  These tests intentionally live in a standalone SwiftPM package because
+//  OmniTAKMobile.xcodeproj has no `OmniTAKMobileTests` PBXNativeTarget yet
+//  — see OmniTAKMobileTests/README.md. The catalog source is mirrored into
+//  the app target as `OmniTAKMobile/Shared/Services/FEMAIconCatalog.swift`.
+//
+import XCTest
+@testable import FEMACatalogSpec
+
+final class FEMAIconCatalogTests: XCTestCase {
+
+    // MARK: - Catalog presence
+
+    func test_catalog_categories_isNotEmpty() {
+        XCTAssertFalse(FEMAIconCatalog.allCategories.isEmpty,
+                       "catalog must publish at least one FEMA / IC category")
+    }
+
+    func test_catalog_includesCoreSARCategories() {
+        // K9Blue feedback: IC, medical, helicopter LZ, vehicles, support stations.
+        let required: Set<FEMAIconCatalog.Category> = [
+            .incidentCommand,
+            .medical,
+            .aviation,
+            .vehicles,
+            .support,
+        ]
+        let present = Set(FEMAIconCatalog.allCategories)
+        for cat in required {
+            XCTAssertTrue(present.contains(cat),
+                          "missing required SAR/FEMA category: \(cat.rawValue)")
+        }
+    }
+
+    // MARK: - Individual icon lookup
+
+    func test_commandPost_icon_isResolvable() {
+        let icon = FEMAIconCatalog.icon(for: .commandPost)
+        XCTAssertNotNil(icon, "Command Post icon must be in the catalog")
+        XCTAssertFalse(icon!.symbolName.isEmpty,
+                       "icon must have a non-empty SF Symbol name")
+        XCTAssertEqual(icon!.category, .incidentCommand)
+    }
+
+    func test_helicopterLZ_icon_isResolvable_andUsesAviationSymbol() {
+        let icon = FEMAIconCatalog.icon(for: .helicopterLZ)
+        XCTAssertNotNil(icon)
+        XCTAssertEqual(icon!.category, .aviation)
+        // SF Symbol should at least mention "helicopter" — we don't pin the
+        // exact glyph because Apple renames them occasionally.
+        XCTAssertTrue(icon!.symbolName.lowercased().contains("helicopter"),
+                      "expected a helicopter-themed SF Symbol, got \(icon!.symbolName)")
+    }
+
+    func test_triageStation_icon_isResolvable_andUsesMedicalCategory() {
+        let icon = FEMAIconCatalog.icon(for: .triageStation)
+        XCTAssertNotNil(icon)
+        XCTAssertEqual(icon!.category, .medical)
+    }
+
+    func test_baseCamp_icon_isResolvable_andUsesSupportCategory() {
+        let icon = FEMAIconCatalog.icon(for: .baseCamp)
+        XCTAssertNotNil(icon)
+        XCTAssertEqual(icon!.category, .support)
+    }
+
+    func test_allIconKinds_haveResolvableEntries() {
+        for kind in FEMAIconCatalog.Kind.allCases {
+            XCTAssertNotNil(FEMAIconCatalog.icon(for: kind),
+                            "catalog missing entry for kind: \(kind.rawValue)")
+        }
+    }
+
+    // MARK: - Category grouping
+
+    func test_iconsByCategory_groupsEveryKindUnderItsCategory() {
+        for kind in FEMAIconCatalog.Kind.allCases {
+            guard let icon = FEMAIconCatalog.icon(for: kind) else {
+                XCTFail("no icon for \(kind.rawValue)")
+                continue
+            }
+            let group = FEMAIconCatalog.icons(in: icon.category)
+            XCTAssertTrue(group.contains(where: { $0.kind == kind }),
+                          "icon \(kind.rawValue) missing from category \(icon.category.rawValue)")
+        }
+    }
+
+    // MARK: - CoT round-trip mapping
+
+    func test_cotType_friendlyAffiliation_prefix() {
+        // Per #13: round-trip over CoT with a type ATAK/iTAK can render.
+        // FEMA/IC markers are friendly civil-response installations, so they
+        // should use a-f-G-I-* (Friendly Ground Installation) as the canonical
+        // prefix and rely on usericon iconsetpath for the FEMA glyph.
+        let icon = FEMAIconCatalog.icon(for: .commandPost)!
+        XCTAssertTrue(icon.cotType.hasPrefix("a-f-G-"),
+                      "FEMA marker CoT type must be friendly ground; got \(icon.cotType)")
+    }
+
+    func test_cotType_isStableAcrossLookups() {
+        let a = FEMAIconCatalog.icon(for: .helicopterLZ)!.cotType
+        let b = FEMAIconCatalog.icon(for: .helicopterLZ)!.cotType
+        XCTAssertEqual(a, b)
+    }
+
+    func test_iconsetpath_isFEMAFlavored() {
+        // ATAK iconsetpath convention: "COT_MAPPING_<set>/<group>/<icon>".
+        // We mint our own "COT_MAPPING_FEMA/<kind>" namespace so receivers
+        // can choose to render the icon or fall through to the affiliation
+        // fallback if they don't ship the FEMA set yet.
+        for kind in FEMAIconCatalog.Kind.allCases {
+            let icon = FEMAIconCatalog.icon(for: kind)!
+            XCTAssertTrue(icon.iconsetPath.hasPrefix("COT_MAPPING_FEMA/"),
+                          "iconsetpath should be FEMA-namespaced, got \(icon.iconsetPath)")
+        }
+    }
+
+    func test_kindFromCoTType_roundTrip_recoversSameKind() {
+        // Round-trip: catalog -> cotType -> kind should be lossless for all
+        // kinds. This is the key contract from #13 ("round-trips over CoT").
+        for kind in FEMAIconCatalog.Kind.allCases {
+            let icon = FEMAIconCatalog.icon(for: kind)!
+            let recovered = FEMAIconCatalog.kind(forCoTType: icon.cotType,
+                                                 iconsetPath: icon.iconsetPath)
+            XCTAssertEqual(recovered, kind,
+                           "round-trip failed for \(kind.rawValue): cotType=\(icon.cotType) iconsetPath=\(icon.iconsetPath)")
+        }
+    }
+}

--- a/scripts/add_fema_icon_catalog.rb
+++ b/scripts/add_fema_icon_catalog.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+# Register the FEMA / IC symbology files (issue #13) in the OmniTAKMobile target.
+# Idempotent — safe to re-run.
+require 'xcodeproj'
+
+project_path = File.expand_path('../OmniTAKMobile.xcodeproj', __dir__)
+project = Xcodeproj::Project.open(project_path)
+target = project.targets.find { |t| t.name == 'OmniTAKMobile' } or abort 'OmniTAKMobile target not found'
+
+mobile_group = project.main_group['OmniTAKMobile']
+
+# --- Shared/Services/FEMAIconCatalog.swift ---
+shared = mobile_group['Shared'] || mobile_group.new_group('Shared', nil)
+shared.path = nil; shared.source_tree = '<group>'
+services = shared['Services'] || shared.new_group('Services', nil)
+services.path = nil; services.source_tree = '<group>'
+
+# --- Features/Drawing/Views/FEMAMarkerPaletteView.swift ---
+features = mobile_group['Features'] || mobile_group.new_group('Features', nil)
+features.path = nil; features.source_tree = '<group>'
+drawing = features['Drawing'] || features.new_group('Drawing', nil)
+drawing.path = nil; drawing.source_tree = '<group>'
+views = drawing['Views'] || drawing.new_group('Views', nil)
+views.path = nil; views.source_tree = '<group>'
+
+mappings = [
+  [services, 'OmniTAKMobile/Shared/Services/FEMAIconCatalog.swift'],
+  [views,    'OmniTAKMobile/Features/Drawing/Views/FEMAMarkerPaletteView.swift'],
+]
+
+mappings.each do |group, rel|
+  basename = File.basename(rel)
+  unless group.files.find { |f| f.display_name == basename }
+    ref = group.new_reference(rel)
+    ref.last_known_file_type = 'sourcecode.swift'
+    target.add_file_references([ref])
+    puts "Added #{rel}"
+  else
+    puts "#{basename} already referenced"
+  end
+end
+
+project.save


### PR DESCRIPTION
Closes #13. Source: K9Blue SAR feedback (Discord, 5/10/26).

## Summary
- `FEMAIconCatalog` — 12 entries across 5 categories (Command, Medical, Aviation, Vehicles, Support). SF Symbols scaffolding (real FEMA artwork is a follow-up). Each entry carries \`cotType\` (a-f-G-I-* ground-installation prefix) + \`iconsetPath\` (\`COT_MAPPING_FEMA/<cat>/<kind>\`) for ATAK/iTAK round-trip
- `FEMAMarkerPaletteView` — modal sheet, no map compression, no grey backplates
- `PointMarker` + `MarkerCoTGenerator` + `PointDropperService` updated: optional \`femaKindRaw\`, Codable migration, \`dropFEMA(kind:at:...)\`, CoT emitter swaps in the FEMA \`usericon iconsetpath\`
- New entry row in PointDropperView opens the FEMA palette as a sheet

## TDD
12/12 XCTests RED→GREEN under `OmniTAKMobileSpecs/`: catalog presence, category grouping, individual icons, CoT prefix, iconsetpath namespace, round-trip recovery.

## Build
`xcodebuild ... iPhone 17 Pro build` → BUILD SUCCEEDED.

## Test plan
- [ ] On-device QA: open marker palette, tap FEMA category, drop a Command Post marker, confirm it broadcasts CoT and renders on a peer ATAK/iTAK client with the right iconsetpath
- [ ] Verify Codable migration: load an older save file with no \`femaKindRaw\` and confirm it still parses
- [ ] Run \`cd OmniTAKMobileSpecs && swift test\` — 12/12 green

## Recommended merge order
After #19, #20, #21. No code conflicts with those — adds new files + edits PointMarker/PointDropper, orthogonal to mission/lasso/package work.

## Deferred to next session
- Real FEMA artwork — currently SF Symbol placeholders
- Inbound CoT parsing to surface FEMA kind on *received* markers (catalog supports it via \`kind(forCoTType:iconsetPath:)\`, parser wiring is a follow-up)
- OmniTAK-Android sibling (#29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)