### PR TITLE
fix(onboarding): explicit confirmation before public demo server connect

### DIFF
--- a/OmniTAKMobile/Features/Settings/Views/FirstTimeOnboarding.swift
+++ b/OmniTAKMobile/Features/Settings/Views/FirstTimeOnboarding.swift
@@ -35,6 +35,10 @@ struct FirstTimeOnboarding: View {
     @State private var showQRScanner = false
     @State private var showImporter = false
     @State private var showReady = false
+    // Public demo server requires an explicit confirmation step — the
+    // tile only opens this sheet; the actual connect happens after the
+    // user confirms they understand it's a public server.
+    @State private var showDemoServerConfirmation = false
     @StateObject private var permissions = PermissionsCoordinator()
 
     // Persistent user choices.
@@ -65,6 +69,29 @@ struct FirstTimeOnboarding: View {
         }
         .fullScreenCover(isPresented: $showReady) {
             ReadyToFlyView { finish() }
+        }
+        .alert(
+            String(localized: "onboarding.connect.demo.confirm.title",
+                   comment: "Demo server confirmation title"),
+            isPresented: $showDemoServerConfirmation
+        ) {
+            Button(
+                String(localized: "onboarding.connect.demo.confirm.cta",
+                       comment: "Demo server confirm CTA"),
+                role: .destructive
+            ) {
+                DemoServerConnector.connect()
+                showReady = true
+            }
+            .accessibilityIdentifier("onboarding.connect.demo.confirm.cta")
+            Button(
+                String(localized: "onboarding.connect.demo.confirm.cancel",
+                       comment: "Demo server confirm cancel"),
+                role: .cancel
+            ) {}
+        } message: {
+            Text(String(localized: "onboarding.connect.demo.confirm.body",
+                        comment: "Demo server confirmation body"))
         }
         .onAppear {
             if userCallsign.isEmpty {
@@ -523,8 +550,10 @@ struct FirstTimeOnboarding: View {
                     time: String(localized: "onboarding.connect.demo.time", comment: "Demo server time"),
                     accessibilityID: "onboarding.connect.demo"
                 ) {
-                    DemoServerConnector.connect()
-                    showReady = true
+                    // Tile tap only opens the disclosure sheet — the
+                    // actual connect requires explicit confirmation
+                    // because tak.engindearing.soy is a PUBLIC server.
+                    showDemoServerConfirmation = true
                 }
 
                 ConnectTile(

--- a/OmniTAKMobile/Resources/en.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/en.lproj/Localizable.strings
@@ -117,9 +117,13 @@
 
 "onboarding.connect.title" = "Connect to a TAK server";
 "onboarding.connect.subtitle" = "Pick whatever's easiest — you can change it later.";
-"onboarding.connect.demo.title" = "Use Demo Server";
-"onboarding.connect.demo.body" = "1-tap. Public OpenTAK server.";
-"onboarding.connect.demo.time" = "< 30 sec";
+"onboarding.connect.demo.title" = "Try a Public Demo Server";
+"onboarding.connect.demo.body" = "Public server hosted by Engindearing. Anyone connected can see your location and callsign. Opt-in only — remove anytime from Settings → Servers.";
+"onboarding.connect.demo.time" = "Public · removable";
+"onboarding.connect.demo.confirm.title" = "Connect to a PUBLIC server?";
+"onboarding.connect.demo.confirm.body" = "You're about to connect to tak.engindearing.soy — a public OpenTAK server Engindearing hosts for community testing. Your live location, callsign, and any markers or chat you send will be visible to everyone else connected.\n\nYou can disconnect or delete this server at any time from Settings → Servers.";
+"onboarding.connect.demo.confirm.cta" = "Connect to public server";
+"onboarding.connect.demo.confirm.cancel" = "Not now";
 "onboarding.connect.qr.title" = "Scan QR code";
 "onboarding.connect.qr.body" = "From your TAK admin or onboarding email.";
 "onboarding.connect.qr.time" = "< 30 sec";


### PR DESCRIPTION
**Source:** K9Blue Discord exchange with H!r0 (2026-05-12). Privacy concern surfaced that connecting to the engindearing public TAK server during onboarding leaks the user's location.

## Problem

Today the "Use Demo Server" tile on the onboarding Connect page **auto-connects** to `tak.engindearing.soy` the moment a user taps it. Tile copy is "1-tap. Public OpenTAK server." The "Public" qualifier is there, but neither the tile nor any confirmation explains the implication — that the user's live location + callsign become visible to everyone else connected to that public server.

## Change

- Tile tap now opens a system alert. Connection does not happen until the user explicitly confirms.
- Alert names the host (`tak.engindearing.soy`), names the operator (Engindearing), names the data that goes out (location, callsign, markers, chat), and points the user at Settings → Servers for opt-out.
- Confirm button is `.destructive` role — "Connect to public server". Cancel is "Not now".
- Tile copy strengthened: title is "Try a Public Demo Server", body states the visibility implication on the tile itself.

## Opt-out path (already works, just verified)

`ServersView` already exposes a per-server delete (`onDelete` → `takService.disconnectFromServer` + `serverManager.deleteServer`). The new alert text directs users there. No additional UX needed for removal.

## Visual verification

Local `xcodebuild` is currently broken on this machine due to a CoreSimulator version-drift (unrelated to this change — iOS 26.5 platform not installed). The diff is small and structurally sound. Recommend a quick on-device pass before merging:

- [ ] Fresh-install OmniTAK iOS, go through onboarding to the Connect page
- [ ] Tap "Try a Public Demo Server" → confirm the alert appears
- [ ] Tap "Not now" → no connection happens, return to Connect page
- [ ] Tap the tile again → tap "Connect to public server" → connection proceeds, Ready screen appears
- [ ] After install: Settings → Servers → swipe the `TAK_5.7_Engindearing` row → Delete → confirm server is removed

## Localizations

Only English strings updated. `pl.lproj` and `fr.lproj` still say "Public OpenTAK server" — iOS will fall back to English for the new confirmation keys. Translator pass for the new keys is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)