### PR TITLE
feat(i18n): true multi-language support — live runtime switching

### DIFF
--- a/OmniTAKMobile.xcodeproj/project.pbxproj
+++ b/OmniTAKMobile.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		1A2B3C4D5E6F70801A2B3C4D /* SelfPositionMarkerImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F70801A2B3C4E /* SelfPositionMarkerImage.swift */; };
 		1A5776DB1338FD3EC8D25046 /* SNGP-------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 103C33E3B66400D772DDE95F /* SNGP-------.svg */; };
 		1BE25DA5B44BA5AD28D90C82 /* RadialMenuMapCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628B317671CF6452847569CB /* RadialMenuMapCoordinator.swift */; };
+		1C9137217214B1713429C1F8 /* LocalizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7545CAC8E7D57583BCDAB1CE /* LocalizationManager.swift */; };
 		20CAAB4409715F7431C1DEAB /* AppPreviewRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786486F562966ED005A6E978 /* AppPreviewRecordingTests.swift */; };
 		21F8CB94928A130D0CC47B88 /* CompassOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7C9A85F883C8B6FBEDC4EA /* CompassOverlay.swift */; };
 		221CFB201E760AE1F327AE9F /* SHAPMFQ----.svg in Resources */ = {isa = PBXBuildFile; fileRef = E763527D180A2BFA06815720 /* SHAPMFQ----.svg */; };
@@ -212,6 +213,7 @@
 		9D41D2F2BD209FCD028D5785 /* ImprovedErrorDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBD37DB92FC41317D68DAAF0 /* ImprovedErrorDialog.swift */; };
 		9D4DD979FA07D0D920CA576A /* MEDEVACRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C046FF14CC38A998A3C9C57A /* MEDEVACRequestView.swift */; };
 		9F360AA41C05B15FC6B71F75 /* EchelonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D5A42ABFBE8EF268B187D8 /* EchelonModels.swift */; };
+		9F975E18CC49BBAC535F8A0B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D9B49FD9370499A376CCF227 /* Localizable.strings */; };
 		A1645CC72ECC172B00B71E89 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		A1645CC82ECC172B00B71E89 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		A1645CC92ECC172B00B71E89 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
@@ -383,12 +385,14 @@
 		0F89B3D56C89FA4871A2956F /* SFGP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGP-------.svg"; sourceTree = "<group>"; };
 		101D7C9B957410F4D6827B09 /* SFGPUST----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPUST----.svg"; sourceTree = "<group>"; };
 		103C33E3B66400D772DDE95F /* SNGP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNGP-------.svg"; sourceTree = "<group>"; };
+		1085EAF3533D48F16848B402 /* pl */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = pl; path = OmniTAKMobile/Resources/pl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1119873F4EBB6AC92B2157E0 /* MilStdIconService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MilStdIconService.swift; path = OmniTAKMobile/Shared/Services/MilStdIconService.swift; sourceTree = "<group>"; };
 		113A471CCFDBCA8105C05942 /* MapStateManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MapStateManager.swift; path = OmniTAKMobile/Features/Map/Controllers/MapStateManager.swift; sourceTree = "<group>"; };
 		1146597916B3AEC4BAE8C687 /* SFSPX------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFSPX------.svg"; sourceTree = "<group>"; };
 		11874432DFCDF2E0677A18A4 /* ChatCoTGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatCoTGenerator.swift; path = OmniTAKMobile/CoT/Generators/ChatCoTGenerator.swift; sourceTree = "<group>"; };
 		12421DDA65FBEF785C811D32 /* SUGPUC-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUGPUC-----.svg"; sourceTree = "<group>"; };
 		1287DC93EA62300164EA7189 /* SUGPUCA----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUGPUCA----.svg"; sourceTree = "<group>"; };
+		12E56E27EB21947AA8755F77 /* en */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = en; path = OmniTAKMobile/Resources/en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1370BC2ECA72FEDBDD92B226 /* PositionBroadcastView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PositionBroadcastView.swift; path = OmniTAKMobile/Features/Networking/Views/PositionBroadcastView.swift; sourceTree = "<group>"; };
 		1419954D52EBD5859EFA2213 /* MeshtasticCoTConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshtasticCoTConverter.swift; path = OmniTAKMobile/Features/Meshtastic/Services/MeshtasticCoTConverter.swift; sourceTree = "<group>"; };
 		14751E8F7455DF58CA15A0A1 /* ChatXMLParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatXMLParser.swift; path = OmniTAKMobile/CoT/Parsers/ChatXMLParser.swift; sourceTree = "<group>"; };
@@ -496,6 +500,7 @@
 		628B317671CF6452847569CB /* RadialMenuMapCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadialMenuMapCoordinator.swift; path = OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuMapCoordinator.swift; sourceTree = "<group>"; };
 		63C4E34598B862901EB54825 /* EchelonService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EchelonService.swift; path = OmniTAKMobile/Features/Teams/Services/EchelonService.swift; sourceTree = "<group>"; };
 		64977A5E2ADECCCF61D023F2 /* OmniTAKMobile-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OmniTAKMobile-Bridging-Header.h"; path = "OmniTAKMobile/Core/OmniTAKMobile-Bridging-Header.h"; sourceTree = "<group>"; };
+		6573C607EB2B7E7F82B0B79D /* de */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = de; path = OmniTAKMobile/Resources/de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		674ABDF90EAA0EFA702FBFF1 /* MeasurementOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeasurementOverlay.swift; path = OmniTAKMobile/Features/Map/Overlays/MeasurementOverlay.swift; sourceTree = "<group>"; };
 		676590F7AFD402DEBBC6868D /* VideoPlayerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VideoPlayerView.swift; path = OmniTAKMobile/Features/Video/Views/VideoPlayerView.swift; sourceTree = "<group>"; };
 		697D89D57F2BFE738817AF87 /* Map3DSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Map3DSettingsView.swift; path = OmniTAKMobile/Features/Map/Views/Map3DSettingsView.swift; sourceTree = "<group>"; };
@@ -513,6 +518,7 @@
 		6F1BF5D92F7208BB2FC250FF /* SFGPUCF----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPUCF----.svg"; sourceTree = "<group>"; };
 		6FBC2615A833D70CD96C5723 /* RadialMenuModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadialMenuModels.swift; path = OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuModels.swift; sourceTree = "<group>"; };
 		6FCAC552E3C92673698AE656 /* SHAPMF-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHAPMF-----.svg"; sourceTree = "<group>"; };
+		6FCE1B4E75FDD28A57526314 /* uk */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = uk; path = OmniTAKMobile/Resources/uk.lproj/Localizable.strings; sourceTree = "<group>"; };
 		701980E052FA63176EC5337E /* SNGPUULC---.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNGPUULC---.svg"; sourceTree = "<group>"; };
 		70EA451E061A876807E914DA /* SFAPMFA----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFAPMFA----.svg"; sourceTree = "<group>"; };
 		72FA80C978460AFCBAA502D9 /* SimpleEnrollView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SimpleEnrollView.swift; path = OmniTAKMobile/Features/Networking/Views/SimpleEnrollView.swift; sourceTree = "<group>"; };
@@ -520,6 +526,7 @@
 		73475124B5F208920CB87732 /* SHAPMH-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHAPMH-----.svg"; sourceTree = "<group>"; };
 		743A8E555F95C2902C263102 /* SHGPU------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGPU------.svg"; sourceTree = "<group>"; };
 		751D3A5EF96A28BFB73F0122 /* PhotoPickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PhotoPickerView.swift; path = OmniTAKMobile/Shared/UI/Components/PhotoPickerView.swift; sourceTree = "<group>"; };
+		7545CAC8E7D57583BCDAB1CE /* LocalizationManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalizationManager.swift; path = OmniTAKMobile/Core/Localization/LocalizationManager.swift; sourceTree = "<group>"; };
 		76EE71ECBA829946C5219664 /* ChatXMLGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatXMLGenerator.swift; path = OmniTAKMobile/CoT/Parsers/ChatXMLGenerator.swift; sourceTree = "<group>"; };
 		7740DF1463CF041207C4772B /* RegionSelectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RegionSelectionView.swift; path = OmniTAKMobile/Features/OfflineMaps/Views/RegionSelectionView.swift; sourceTree = "<group>"; };
 		7773A5DF20505E3BE995732E /* ChatManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatManager.swift; path = OmniTAKMobile/Features/Chat/Managers/ChatManager.swift; sourceTree = "<group>"; };
@@ -603,6 +610,7 @@
 		B10EBDD09B119246F57296CE /* SFGPUCI----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPUCI----.svg"; sourceTree = "<group>"; };
 		B1A726FDC5E3383C783799A5 /* SHSPN------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHSPN------.svg"; sourceTree = "<group>"; };
 		B1B2C3D4E5F607080910B1B3 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = OmniTAKMobile/Resources/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		B1F80E89642B38A496E02F12 /* fr */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = fr; path = OmniTAKMobile/Resources/fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B4A0DCCEFB04D08FB298E2FD /* MeshNodeMapView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshNodeMapView.swift; path = OmniTAKMobile/Features/Meshtastic/Views/MeshNodeMapView.swift; sourceTree = SOURCE_ROOT; };
 		B4E49EC79566C4E1FA39BB03 /* SNAPMF-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNAPMF-----.svg"; sourceTree = "<group>"; };
 		B568C4A280F1992132EFA970 /* SNGPU------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNGPU------.svg"; sourceTree = "<group>"; };
@@ -672,6 +680,7 @@
 		E5160EE3247DE0377F3E6CE8 /* BNGConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BNGConverter.swift; path = OmniTAKMobile/Utilities/Converters/BNGConverter.swift; sourceTree = "<group>"; };
 		E6426A4780DEDD91B5DA2B46 /* SFAPMFT----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFAPMFT----.svg"; sourceTree = "<group>"; };
 		E763527D180A2BFA06815720 /* SHAPMFQ----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHAPMFQ----.svg"; sourceTree = "<group>"; };
+		E7CD94F2AA3C9E1621AE6021 /* es */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = es; path = OmniTAKMobile/Resources/es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E7CED1E79EF4463A98DDA34A /* MapLibre3DSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MapLibre3DSettingsView.swift; path = OmniTAKMobile/Features/Map/MapLibre/MapLibre3DSettingsView.swift; sourceTree = "<group>"; };
 		EA171D08B8BECD16ACA18D51 /* SHGP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGP-------.svg"; sourceTree = "<group>"; };
 		EA4A86523E550E87AC1EE8A4 /* SALUTEReportView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SALUTEReportView.swift; path = OmniTAKMobile/Features/Military/Views/SALUTEReportView.swift; sourceTree = "<group>"; };
@@ -948,6 +957,7 @@
 				E9657E193700B70B4814B0F9 /* App */,
 				F36F0DFF03DEAEA2AB6C408C /* Configuration */,
 				64977A5E2ADECCCF61D023F2 /* OmniTAKMobile-Bridging-Header.h */,
+				CDBCCD9EDC4CC8ADA0D3976D /* Localization */,
 			);
 			name = Core;
 			sourceTree = "<group>";
@@ -1437,6 +1447,7 @@
 			isa = PBXGroup;
 			children = (
 				5F2CB5969F88417DADA93B74 /* Documentation */,
+				D9B49FD9370499A376CCF227 /* Localizable.strings */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -2049,6 +2060,14 @@
 			name = Models;
 			sourceTree = "<group>";
 		};
+		CDBCCD9EDC4CC8ADA0D3976D /* Localization */ = {
+			isa = PBXGroup;
+			children = (
+				7545CAC8E7D57583BCDAB1CE /* LocalizationManager.swift */,
+			);
+			name = Localization;
+			sourceTree = "<group>";
+		};
 		D02CFA540A06057C35EB9EAE /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -2236,6 +2255,11 @@
 			knownRegions = (
 				en,
 				Base,
+				uk,
+				pl,
+				de,
+				fr,
+				es,
 			);
 			mainGroup = A1111111111111111111111100000071;
 			packageReferences = (
@@ -2367,6 +2391,7 @@
 				B7EF06AABA74804FDBA3131B /* SUSPCL-----.svg in Resources */,
 				94D9B6A4217A70F4DB366B6D /* SUSPN------.svg in Resources */,
 				2363511BE3602F0BBEE29361 /* SUSPX------.svg in Resources */,
+				9F975E18CC49BBAC535F8A0B /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2607,6 +2632,7 @@
 				B31DE0874D24FB971A6F8ACC /* RemoteIdToPointMarkerConverter.swift in Sources */,
 				0123DD83F4B3A860CC2EF51E /* RemoteIdScanner.swift in Sources */,
 				3026CC323DB5601B76A69A3C /* RemoteIdAppBridge.swift in Sources */,
+				1C9137217214B1713429C1F8 /* LocalizationManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2630,6 +2656,22 @@
 			targetProxy = 9E29FAD18980F93F9B796A93 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		D9B49FD9370499A376CCF227 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				12E56E27EB21947AA8755F77 /* en */,
+				6FCE1B4E75FDD28A57526314 /* uk */,
+				1085EAF3533D48F16848B402 /* pl */,
+				6573C607EB2B7E7F82B0B79D /* de */,
+				B1F80E89642B38A496E02F12 /* fr */,
+				E7CD94F2AA3C9E1621AE6021 /* es */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		60DBBBD45F08535BFDB332A2 /* Debug */ = {

--- a/OmniTAKMobile/Core/App/OmniTAKMobileApp.swift
+++ b/OmniTAKMobile/Core/App/OmniTAKMobileApp.swift
@@ -80,7 +80,11 @@ struct OmniTAKMobileApp: App {
                 FirstTimeOnboarding(onComplete: {
                     hasCompletedOnboarding = true
                 })
+                .environmentObject(LocalizationManager.shared)
             }
+            // Inject the localization manager app-wide so any view can
+            // observe it and re-render the instant the language changes.
+            .environmentObject(LocalizationManager.shared)
         }
     }
 }

--- a/OmniTAKMobile/Core/Localization/LocalizationManager.swift
+++ b/OmniTAKMobile/Core/Localization/LocalizationManager.swift
@@ -1,0 +1,173 @@
+//
+//  LocalizationManager.swift
+//  OmniTAKMobile
+//
+//  Runtime language switching without an app restart.
+//
+//  iOS normally only picks up a language change on relaunch. This
+//  manager swaps in a per-language `.lproj` bundle at runtime and,
+//  being an ObservableObject, drives a SwiftUI re-render the instant
+//  the language changes — so the picker in Settings takes effect
+//  immediately.
+//
+//  ## Usage
+//  Views that show localized text observe the manager and resolve
+//  keys through it:
+//
+//      @EnvironmentObject private var loc: LocalizationManager
+//      ...
+//      Text(loc.t("onboarding.welcome.title"))
+//
+//  The `@EnvironmentObject` dependency is what makes the view
+//  re-render when `setLanguage` fires. Inject it once at the app
+//  root: `.environmentObject(LocalizationManager.shared)`.
+//
+//  Non-view code (formatters, services) can use the free function
+//  `L("key")` — but those call sites won't auto-refresh on a live
+//  switch; that's fine for one-shot strings.
+//
+
+import Foundation
+import SwiftUI
+import Combine
+
+final class LocalizationManager: ObservableObject {
+
+    static let shared = LocalizationManager()
+
+    /// Languages OmniTAK ships UI translations for. English is the
+    /// base catalogue every other language falls back to.
+    enum Language: String, CaseIterable, Identifiable {
+        case english   = "en"
+        case ukrainian = "uk"
+        case polish    = "pl"
+        case german    = "de"
+        case french    = "fr"
+        case spanish   = "es"
+
+        var id: String { rawValue }
+
+        /// Endonym — the language's name in its own language, which
+        /// is what users scanning a language list expect to see.
+        var displayName: String {
+            switch self {
+            case .english:   return "English"
+            case .ukrainian: return "Українська"
+            case .polish:    return "Polski"
+            case .german:    return "Deutsch"
+            case .french:    return "Français"
+            case .spanish:   return "Español"
+            }
+        }
+
+        /// Flag emoji for the picker. Ukrainian uses the UA flag;
+        /// the rest map to the obvious nation.
+        var flag: String {
+            switch self {
+            case .english:   return "🇬🇧"
+            case .ukrainian: return "🇺🇦"
+            case .polish:    return "🇵🇱"
+            case .german:    return "🇩🇪"
+            case .french:    return "🇫🇷"
+            case .spanish:   return "🇪🇸"
+            }
+        }
+    }
+
+    /// The active language. SwiftUI views observing the manager
+    /// re-render whenever this changes.
+    @Published private(set) var current: Language
+
+    /// Bundle for the active language's `.lproj`. Falls back to
+    /// `.main` if the resource is missing (shouldn't happen once the
+    /// catalogues are registered, but keeps the app rendering).
+    private var activeBundle: Bundle
+
+    /// English base bundle — the fallback for any key a translation
+    /// catalogue hasn't filled in yet.
+    private let baseBundle: Bundle
+
+    private static let storageKey = "appLanguage"
+    private static let keyMissingSentinel = "\u{0}__OMNITAK_KEY_MISSING__\u{0}"
+
+    private init() {
+        let stored = UserDefaults.standard.string(forKey: Self.storageKey)
+        let initial = stored.flatMap(Language.init(rawValue:)) ?? Self.systemDefault()
+        self.current = initial
+        self.activeBundle = Self.bundle(for: initial)
+        self.baseBundle = Self.bundle(for: .english)
+    }
+
+    /// Switch the app's language. Persists the choice, updates the
+    /// active bundle, and updates `AppleLanguages` so anything that
+    /// reads the system locale directly (date formatters,
+    /// UIKit-hosted views) picks it up on next launch. The
+    /// `@Published` change re-renders every observing SwiftUI view
+    /// immediately — no restart for the SwiftUI surface.
+    func setLanguage(_ language: Language) {
+        guard language != current else { return }
+        current = language
+        activeBundle = Self.bundle(for: language)
+        UserDefaults.standard.set(language.rawValue, forKey: Self.storageKey)
+        UserDefaults.standard.set([language.rawValue], forKey: "AppleLanguages")
+    }
+
+    /// Resolve a localization key against the active language,
+    /// falling back to the English base catalogue, then to the key
+    /// itself (so a missing string is visible in testing rather
+    /// than rendering blank).
+    func t(_ key: String) -> String {
+        let value = activeBundle.localizedString(
+            forKey: key, value: Self.keyMissingSentinel, table: nil
+        )
+        if value != Self.keyMissingSentinel {
+            return value
+        }
+        // Active catalogue doesn't have this key — fall back to English.
+        if current != .english {
+            let baseValue = baseBundle.localizedString(
+                forKey: key, value: Self.keyMissingSentinel, table: nil
+            )
+            if baseValue != Self.keyMissingSentinel {
+                return baseValue
+            }
+        }
+        return key
+    }
+
+    /// Resolve a key with `String(format:)` arguments — for strings
+    /// carrying `%@` / `%d` placeholders.
+    func t(_ key: String, _ args: CVarArg...) -> String {
+        String(format: t(key), arguments: args)
+    }
+
+    // MARK: - Private
+
+    private static func bundle(for language: Language) -> Bundle {
+        guard let path = Bundle.main.path(forResource: language.rawValue, ofType: "lproj"),
+              let langBundle = Bundle(path: path) else {
+            return .main
+        }
+        return langBundle
+    }
+
+    /// Best-effort match of the device's preferred language to one
+    /// OmniTAK ships. Falls back to English.
+    private static func systemDefault() -> Language {
+        for preferred in Locale.preferredLanguages {
+            let code = String(preferred.prefix(2)).lowercased()
+            if let match = Language(rawValue: code) {
+                return match
+            }
+        }
+        return .english
+    }
+}
+
+/// Free-function shortcut for non-view code (formatters, services,
+/// log strings). Call sites using this do NOT auto-refresh on a
+/// live language switch — use `loc.t(...)` with `@EnvironmentObject`
+/// inside SwiftUI views that need to react.
+func L(_ key: String) -> String {
+    LocalizationManager.shared.t(key)
+}

--- a/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
@@ -730,6 +730,7 @@ struct ATAKMapView: View {
             }
             .sheet(isPresented: $showSettings) {
                 SettingsView()
+                    .environmentObject(LocalizationManager.shared)
             }
             .sheet(isPresented: $showPlugins) {
                 PluginsListView()

--- a/OmniTAKMobile/Features/Settings/Views/FirstTimeOnboarding.swift
+++ b/OmniTAKMobile/Features/Settings/Views/FirstTimeOnboarding.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct FirstTimeOnboarding: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var loc: LocalizationManager
     @State private var currentPage = 0
     @State private var showEnrollment = false
 
@@ -30,7 +31,7 @@ struct FirstTimeOnboarding: View {
                         onComplete()
                         dismiss()
                     }) {
-                        Text("Skip")
+                        Text(loc.t("onboarding.skip"))
                             .font(.system(size: 15, weight: .medium))
                             .foregroundColor(Color(hex: "#CCCCCC"))
                     }
@@ -56,6 +57,7 @@ struct FirstTimeOnboarding: View {
         }
         .fullScreenCover(isPresented: $showEnrollment) {
             SimpleEnrollView()
+                .environmentObject(loc)
         }
     }
 
@@ -84,7 +86,9 @@ struct FirstTimeOnboarding: View {
                 }
             }) {
                 HStack {
-                    Text(currentPage == pages.count - 1 ? "Get Started" : "Continue")
+                    Text(currentPage == pages.count - 1
+                         ? loc.t("onboarding.getStarted")
+                         : loc.t("onboarding.continue"))
                         .font(.system(size: 18, weight: .semibold))
                     if currentPage == pages.count - 1 {
                         Image(systemName: "arrow.right")
@@ -104,7 +108,7 @@ struct FirstTimeOnboarding: View {
                         currentPage -= 1
                     }
                 }) {
-                    Text("Back")
+                    Text(loc.t("onboarding.back"))
                         .font(.system(size: 16, weight: .medium))
                         .foregroundColor(Color(hex: "#CCCCCC"))
                         .frame(maxWidth: .infinity)
@@ -121,58 +125,61 @@ struct FirstTimeOnboarding: View {
 
 struct OnboardingPage {
     let icon: String
-    let title: String
-    let description: String
+    /// Localization keys — resolved through LocalizationManager in
+    /// OnboardingPageView so the page re-renders on a live language
+    /// switch. See Resources/*.lproj/Localizable.strings.
+    let titleKey: String
+    let descKey: String
     let color: Color
-    let features: [String]
+    let featureKeys: [String]
 
     static let all: [OnboardingPage] = [
         OnboardingPage(
             icon: "antenna.radiowaves.left.and.right",
-            title: "Welcome to OmniTAK",
-            description: "Your powerful iOS client for Team Awareness Kit (TAK) servers. Connect, share, and collaborate in real-time.",
+            titleKey: "onboarding.page1.title",
+            descKey: "onboarding.page1.desc",
             color: Color(hex: "#FFFC00"),
-            features: [
-                "Real-time position sharing",
-                "Secure communications",
-                "Map-based awareness",
-                "Multi-platform support"
+            featureKeys: [
+                "onboarding.page1.feature1",
+                "onboarding.page1.feature2",
+                "onboarding.page1.feature3",
+                "onboarding.page1.feature4"
             ]
         ),
         OnboardingPage(
             icon: "lock.shield.fill",
-            title: "Secure & Certified",
-            description: "OmniTAK supports certificate-based authentication for secure connections to TAK servers.",
+            titleKey: "onboarding.page2.title",
+            descKey: "onboarding.page2.desc",
             color: Color(hex: "#00FF00"),
-            features: [
-                "Client certificate support",
-                "TLS/SSL encryption",
-                "Keychain integration",
-                "Automatic enrollment"
+            featureKeys: [
+                "onboarding.page2.feature1",
+                "onboarding.page2.feature2",
+                "onboarding.page2.feature3",
+                "onboarding.page2.feature4"
             ]
         ),
         OnboardingPage(
             icon: "bolt.circle.fill",
-            title: "Quick & Easy Setup",
-            description: "Get connected in seconds with our smart setup wizard. Multiple connection methods for every scenario.",
+            titleKey: "onboarding.page3.title",
+            descKey: "onboarding.page3.desc",
             color: Color(hex: "#00BFFF"),
-            features: [
-                "QR code scanning",
-                "Auto-discovery",
-                "Common presets",
-                "Manual configuration"
+            featureKeys: [
+                "onboarding.page3.feature1",
+                "onboarding.page3.feature2",
+                "onboarding.page3.feature3",
+                "onboarding.page3.feature4"
             ]
         ),
         OnboardingPage(
             icon: "map.fill",
-            title: "Ready to Connect?",
-            description: "Let's get you connected to a TAK server. Choose the method that works best for you.",
+            titleKey: "onboarding.page4.title",
+            descKey: "onboarding.page4.desc",
             color: Color(hex: "#FF6B35"),
-            features: [
-                "Connect in < 30 seconds",
-                "No technical knowledge needed",
-                "Full ATAK compatibility",
-                "Works with any TAK server"
+            featureKeys: [
+                "onboarding.page4.feature1",
+                "onboarding.page4.feature2",
+                "onboarding.page4.feature3",
+                "onboarding.page4.feature4"
             ]
         )
     ]
@@ -182,6 +189,7 @@ struct OnboardingPage {
 
 struct OnboardingPageView: View {
     let page: OnboardingPage
+    @EnvironmentObject private var loc: LocalizationManager
 
     var body: some View {
         VStack(spacing: 32) {
@@ -203,14 +211,14 @@ struct OnboardingPageView: View {
             }
 
             // Title
-            Text(page.title)
+            Text(loc.t(page.titleKey))
                 .font(.system(size: 32, weight: .bold))
                 .foregroundColor(.white)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
 
             // Description
-            Text(page.description)
+            Text(loc.t(page.descKey))
                 .font(.system(size: 17))
                 .foregroundColor(Color(hex: "#CCCCCC"))
                 .multilineTextAlignment(.center)
@@ -219,8 +227,8 @@ struct OnboardingPageView: View {
 
             // Features
             VStack(spacing: 14) {
-                ForEach(page.features, id: \.self) { feature in
-                    FeatureRow(text: feature, color: page.color)
+                ForEach(page.featureKeys, id: \.self) { featureKey in
+                    FeatureRow(text: loc.t(featureKey), color: page.color)
                 }
             }
             .padding(.horizontal, 40)
@@ -277,37 +285,38 @@ class OnboardingManager: ObservableObject {
 
 struct QuickStartGuide: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var loc: LocalizationManager
 
     let guides = [
         QuickStartItem(
             icon: "qrcode.viewfinder",
-            title: "Scan QR Code",
-            description: "Fastest method - scan the enrollment QR from your TAK server admin",
-            difficulty: "Easiest",
+            titleKey: "quickstart.item.qr.title",
+            descKey: "quickstart.item.qr.desc",
+            difficultyKey: "quickstart.difficulty.easiest",
             time: "< 30 sec",
             color: Color(hex: "#00FF00")
         ),
         QuickStartItem(
             icon: "wifi.circle.fill",
-            title: "Auto-Discover",
-            description: "Find TAK servers on your local network automatically",
-            difficulty: "Easy",
+            titleKey: "quickstart.item.discover.title",
+            descKey: "quickstart.item.discover.desc",
+            difficultyKey: "quickstart.difficulty.easy",
             time: "< 1 min",
             color: Color(hex: "#00BFFF")
         ),
         QuickStartItem(
             icon: "bolt.circle.fill",
-            title: "Quick Setup",
-            description: "Use presets for common TAK server configurations",
-            difficulty: "Easy",
+            titleKey: "quickstart.item.quick.title",
+            descKey: "quickstart.item.quick.desc",
+            difficultyKey: "quickstart.difficulty.easy",
             time: "< 2 min",
             color: Color(hex: "#FF6B35")
         ),
         QuickStartItem(
             icon: "keyboard",
-            title: "Manual Setup",
-            description: "Full control - configure all connection parameters yourself",
-            difficulty: "Advanced",
+            titleKey: "quickstart.item.manual.title",
+            descKey: "quickstart.item.manual.desc",
+            difficultyKey: "quickstart.difficulty.advanced",
             time: "~3 min",
             color: Color(hex: "#9B59B6")
         )
@@ -326,11 +335,11 @@ struct QuickStartGuide: View {
                                 .font(.system(size: 48))
                                 .foregroundColor(Color(hex: "#FFFC00"))
 
-                            Text("Quick Start Guide")
+                            Text(loc.t("quickstart.title"))
                                 .font(.system(size: 26, weight: .bold))
                                 .foregroundColor(.white)
 
-                            Text("Choose the connection method that works best for your situation")
+                            Text(loc.t("quickstart.subtitle"))
                                 .font(.system(size: 15))
                                 .foregroundColor(Color(hex: "#CCCCCC"))
                                 .multilineTextAlignment(.center)
@@ -340,7 +349,7 @@ struct QuickStartGuide: View {
 
                         // Guide items
                         VStack(spacing: 16) {
-                            ForEach(guides, id: \.title) { guide in
+                            ForEach(guides, id: \.titleKey) { guide in
                                 QuickStartItemView(item: guide)
                             }
                         }
@@ -355,7 +364,7 @@ struct QuickStartGuide: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Done") {
+                    Button(loc.t("quickstart.done")) {
                         dismiss()
                     }
                     .foregroundColor(Color(hex: "#FFFC00"))
@@ -369,15 +378,15 @@ struct QuickStartGuide: View {
             HStack {
                 Image(systemName: "questionmark.circle.fill")
                     .foregroundColor(Color(hex: "#FFFC00"))
-                Text("Need Help?")
+                Text(loc.t("quickstart.needHelp"))
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 12) {
-                HelpLink(icon: "doc.text.fill", text: "Read the Documentation", url: "https://docs.omnitak.com")
-                HelpLink(icon: "person.2.fill", text: "Contact Support", url: "mailto:support@omnitak.com")
-                HelpLink(icon: "video.fill", text: "Watch Tutorial Videos", url: "https://youtube.com/@omnitak")
+                HelpLink(icon: "doc.text.fill", text: loc.t("quickstart.help.docs"), url: "https://docs.omnitak.com")
+                HelpLink(icon: "person.2.fill", text: loc.t("quickstart.help.support"), url: "mailto:support@omnitak.com")
+                HelpLink(icon: "video.fill", text: loc.t("quickstart.help.videos"), url: "https://youtube.com/@omnitak")
             }
         }
         .padding(20)
@@ -390,15 +399,19 @@ struct QuickStartGuide: View {
 
 struct QuickStartItem {
     let icon: String
-    let title: String
-    let description: String
-    let difficulty: String
+    /// Localization keys — resolved through LocalizationManager in
+    /// QuickStartItemView. `time` stays a literal (numeric-ish, no
+    /// catalogue key in the v1 scope).
+    let titleKey: String
+    let descKey: String
+    let difficultyKey: String
     let time: String
     let color: Color
 }
 
 struct QuickStartItemView: View {
     let item: QuickStartItem
+    @EnvironmentObject private var loc: LocalizationManager
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -411,12 +424,12 @@ struct QuickStartItemView: View {
                     .clipShape(Circle())
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(item.title)
+                    Text(loc.t(item.titleKey))
                         .font(.system(size: 17, weight: .semibold))
                         .foregroundColor(.white)
 
                     HStack(spacing: 12) {
-                        Label(item.difficulty, systemImage: "star.fill")
+                        Label(loc.t(item.difficultyKey), systemImage: "star.fill")
                             .font(.system(size: 12))
                             .foregroundColor(item.color)
 
@@ -429,7 +442,7 @@ struct QuickStartItemView: View {
                 Spacer()
             }
 
-            Text(item.description)
+            Text(loc.t(item.descKey))
                 .font(.system(size: 14))
                 .foregroundColor(Color(hex: "#CCCCCC"))
                 .lineSpacing(2)
@@ -484,6 +497,7 @@ struct FirstTimeOnboarding_Previews: PreviewProvider {
             FirstTimeOnboarding()
             QuickStartGuide()
         }
+        .environmentObject(LocalizationManager.shared)
         .preferredColorScheme(.dark)
     }
 }

--- a/OmniTAKMobile/Features/Settings/Views/SettingsView.swift
+++ b/OmniTAKMobile/Features/Settings/Views/SettingsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(\.dismiss) var dismiss
+    @EnvironmentObject private var loc: LocalizationManager
     @AppStorage("userCallsign") private var userCallsign = "ALPHA-1"
     @AppStorage("userName") private var userName = "Operator"
     @AppStorage("unitSystem") private var unitSystemString = "Metric"
@@ -37,11 +38,11 @@ struct SettingsView: View {
         NavigationView {
             List {
                 // User Profile
-                Section("USER PROFILE") {
+                Section(loc.t("settings.section.userProfile")) {
                     HStack {
-                        Text("Callsign")
+                        Text(loc.t("settings.callsign"))
                         Spacer()
-                        TextField("Callsign", text: $userCallsign)
+                        TextField(loc.t("settings.callsign"), text: $userCallsign)
                             .multilineTextAlignment(.trailing)
                             .foregroundColor(.blue)
                             .onChange(of: userCallsign) { newValue in
@@ -52,16 +53,16 @@ struct SettingsView: View {
                     }
 
                     HStack {
-                        Text("Name")
+                        Text(loc.t("settings.name"))
                         Spacer()
-                        TextField("Name", text: $userName)
+                        TextField(loc.t("settings.name"), text: $userName)
                             .multilineTextAlignment(.trailing)
                             .foregroundColor(.blue)
                     }
                 }
 
                 // Servers (Streamlined)
-                Section("SERVERS") {
+                Section(loc.t("settings.section.servers")) {
                     Button(action: { showServersSheet = true }) {
                         HStack {
                             // Status indicator
@@ -69,7 +70,7 @@ struct SettingsView: View {
                                 .fill(TAKService.shared.isConnected ? Color(hex: "#00FF00") : Color(hex: "#FF4444"))
                                 .frame(width: 10, height: 10)
 
-                            Text("Manage Servers")
+                            Text(loc.t("settings.manageServers"))
                                 .foregroundColor(.primary)
 
                             Spacer()
@@ -87,13 +88,13 @@ struct SettingsView: View {
                 }
 
                 // Navigation Settings
-                Section("NAVIGATION") {
+                Section(loc.t("settings.section.navigation")) {
                     NavigationLink(destination: NavigationSettingsView()) {
                         HStack {
                             Image(systemName: "location.north.line.fill")
                                 .foregroundColor(Color(hex: "#FFFC00"))
                                 .frame(width: 24)
-                            Text("Route Navigation")
+                            Text(loc.t("settings.routeNavigation"))
                             Spacer()
                             Text("ATAK-Style")
                                 .font(.system(size: 12))
@@ -104,22 +105,22 @@ struct SettingsView: View {
 
 
                 // Map Overlay Settings
-                Section("MAP OVERLAYS") {
+                Section(loc.t("settings.section.mapOverlays")) {
                     // MGRS Grid Settings
-                    Toggle("MGRS Grid Overlay", isOn: $mgrsGridEnabled)
+                    Toggle(loc.t("settings.mgrsGridOverlay"), isOn: $mgrsGridEnabled)
 
                     if mgrsGridEnabled {
-                        Picker("Grid Density", selection: $mgrsGridDensityString) {
+                        Picker(loc.t("settings.gridDensity"), selection: $mgrsGridDensityString) {
                             Text("100km").tag("100km")
                             Text("10km").tag("10km")
                             Text("1km").tag("1km")
                         }
 
-                        Toggle("Show Grid Labels", isOn: $showMGRSLabels)
+                        Toggle(loc.t("settings.showGridLabels"), isOn: $showMGRSLabels)
                     }
 
                     // Coordinate Display Format
-                    Picker("Coordinate Format", selection: $coordinateFormatString) {
+                    Picker(loc.t("settings.coordinateFormat"), selection: $coordinateFormatString) {
                         Text("Decimal Degrees (DD)").tag("DD")
                         Text("Degrees Minutes (DM)").tag("DM")
                         Text("Degrees Minutes Seconds (DMS)").tag("DMS")
@@ -141,14 +142,14 @@ struct SettingsView: View {
                     // own pip shares iconography with friendly contact
                     // markers. Picking "Bullseye" reverts to the legacy
                     // tactical green disc.
-                    Picker("Self-Position Marker", selection: $selfMarkerStyle) {
+                    Picker(loc.t("settings.selfPositionMarker"), selection: $selfMarkerStyle) {
                         Text("MIL-STD Symbol").tag("milstd")
                         Text("Bullseye (Legacy)").tag("bullseye")
                     }
                 }
 
-                Section("DRONE DETECTION") {
-                    Toggle("FAA Remote ID Scanner", isOn: $remoteIdScanEnabled)
+                Section(loc.t("settings.section.droneDetection")) {
+                    Toggle(loc.t("settings.faaRemoteIdScanner"), isOn: $remoteIdScanEnabled)
 
                     Text("Listen for nearby drones (DJI Mavic, Skydio, Autel) broadcasting FAA Remote ID over Bluetooth. Detected drones appear on the map as unknown-air UAS contacts. Catches the Bluetooth-broadcast subset of Remote ID; WiFi-beacon broadcasts require a gy6 sensor. BLE scanning has a battery cost.")
                         .font(.caption2)
@@ -162,14 +163,32 @@ struct SettingsView: View {
                     }
                 }
 
+                // Language — switches the app UI language live, no
+                // restart. Bound straight to LocalizationManager so
+                // every observing view re-renders the instant the
+                // picker changes.
+                Section(loc.t("settings.section.language")) {
+                    Picker(
+                        loc.t("settings.appLanguage"),
+                        selection: Binding(
+                            get: { loc.current },
+                            set: { loc.setLanguage($0) }
+                        )
+                    ) {
+                        ForEach(LocalizationManager.Language.allCases) { lang in
+                            Text("\(lang.flag)  \(lang.displayName)").tag(lang)
+                        }
+                    }
+                }
+
                 // Trail Settings
-                Section("BREADCRUMB TRAILS") {
-                    Toggle("Enable Trails", isOn: $breadcrumbTrailsEnabled)
+                Section(loc.t("settings.section.breadcrumbTrails")) {
+                    Toggle(loc.t("settings.enableTrails"), isOn: $breadcrumbTrailsEnabled)
 
                     if breadcrumbTrailsEnabled {
                         VStack(alignment: .leading, spacing: 4) {
                             HStack {
-                                Text("Max Trail Length")
+                                Text(loc.t("settings.maxTrailLength"))
                                 Spacer()
                                 Text("\(trailMaxLength) points")
                                     .foregroundColor(.gray)
@@ -180,7 +199,7 @@ struct SettingsView: View {
                             ), in: 10...500, step: 10)
                         }
 
-                        Picker("Trail Color", selection: $trailColorName) {
+                        Picker(loc.t("settings.trailColor"), selection: $trailColorName) {
                             Text("Cyan").tag("cyan")
                             Text("Green").tag("green")
                             Text("Orange").tag("orange")
@@ -191,36 +210,36 @@ struct SettingsView: View {
                 }
 
                 // Display Settings
-                Section("DISPLAY") {
+                Section(loc.t("settings.section.display")) {
                     // Unit System Picker
-                    Picker("Unit System", selection: $unitSystemString) {
+                    Picker(loc.t("settings.unitSystem"), selection: $unitSystemString) {
                         Text("Metric (km, m, km/h)").tag("Metric")
                         Text("Imperial (mi, ft, mph)").tag("Imperial")
                     }
                 }
 
                 // Performance
-                Section("PERFORMANCE") {
+                Section(loc.t("settings.section.performance")) {
                     HStack {
-                        Text("Cache Size")
+                        Text(loc.t("settings.cacheSize"))
                         Spacer()
                         Text(cacheSizeText)
                             .foregroundColor(.gray)
                     }
 
-                    Button("Clear Cache") {
+                    Button(loc.t("settings.clearCache")) {
                         clearCache()
                     }
                     .foregroundColor(.red)
                 }
 
                 // Data Management
-                Section("DATA MANAGEMENT") {
+                Section(loc.t("settings.section.dataManagement")) {
                     NavigationLink(destination: DataPackageImportView()) {
-                        Text("Import Data Package")
+                        Text(loc.t("settings.importDataPackage"))
                     }
 
-                    Button("Reset to Defaults") {
+                    Button(loc.t("settings.resetToDefaults")) {
                         userCallsign = "ALPHA-1"
                         userName = "Operator"
                         unitSystemString = "Metric"
@@ -237,18 +256,18 @@ struct SettingsView: View {
                 }
 
                 // Danger Zone
-                Section("DANGER ZONE") {
-                    Button("Clear All Team Data") {
+                Section(loc.t("settings.section.dangerZone")) {
+                    Button(loc.t("settings.clearAllTeamData")) {
                         TeamService.shared.clearAllTeamData()
                     }
                     .foregroundColor(.red)
                 }
             }
-            .navigationTitle("Settings")
+            .navigationTitle(loc.t("settings.title"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Done") {
+                    Button(loc.t("settings.done")) {
                         dismiss()
                     }
                 }

--- a/OmniTAKMobile/Resources/de.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/de.lproj/Localizable.strings
@@ -1,0 +1,96 @@
+/* OmniTAK Mobile — German / Deutsch
+   Technical standards (TAK, MGRS, UTM, TLS/SSL, QR, FAA Remote ID,
+   MIL-STD, Bluetooth) kept as-is — they are proper nouns. */
+
+/* --- Onboarding navigation --- */
+"onboarding.skip" = "Überspringen";
+"onboarding.continue" = "Weiter";
+"onboarding.getStarted" = "Loslegen";
+"onboarding.back" = "Zurück";
+
+/* --- Onboarding page 1: Welcome --- */
+"onboarding.page1.title" = "Willkommen bei OmniTAK";
+"onboarding.page1.desc" = "Dein leistungsstarker iOS-Client für Team-Awareness-Kit-(TAK)-Server. Verbinden, teilen und in Echtzeit zusammenarbeiten.";
+"onboarding.page1.feature1" = "Positionsfreigabe in Echtzeit";
+"onboarding.page1.feature2" = "Sichere Kommunikation";
+"onboarding.page1.feature3" = "Kartenbasierte Lageübersicht";
+"onboarding.page1.feature4" = "Plattformübergreifende Unterstützung";
+
+/* --- Onboarding page 2: Secure & Certified --- */
+"onboarding.page2.title" = "Sicher & zertifiziert";
+"onboarding.page2.desc" = "OmniTAK unterstützt zertifikatsbasierte Authentifizierung für sichere Verbindungen zu TAK-Servern.";
+"onboarding.page2.feature1" = "Unterstützung für Client-Zertifikate";
+"onboarding.page2.feature2" = "TLS/SSL-Verschlüsselung";
+"onboarding.page2.feature3" = "Schlüsselbund-Integration";
+"onboarding.page2.feature4" = "Automatische Registrierung";
+
+/* --- Onboarding page 3: Quick & Easy Setup --- */
+"onboarding.page3.title" = "Schnelle & einfache Einrichtung";
+"onboarding.page3.desc" = "In Sekunden verbunden dank des intelligenten Einrichtungsassistenten. Mehrere Verbindungsmethoden für jedes Szenario.";
+"onboarding.page3.feature1" = "QR-Code-Scan";
+"onboarding.page3.feature2" = "Automatische Erkennung";
+"onboarding.page3.feature3" = "Gängige Voreinstellungen";
+"onboarding.page3.feature4" = "Manuelle Konfiguration";
+
+/* --- Onboarding page 4: Ready to Connect --- */
+"onboarding.page4.title" = "Bereit zum Verbinden?";
+"onboarding.page4.desc" = "Verbinden wir dich mit einem TAK-Server. Wähle die Methode, die für dich am besten funktioniert.";
+"onboarding.page4.feature1" = "Verbindung in unter 30 Sekunden";
+"onboarding.page4.feature2" = "Keine technischen Kenntnisse nötig";
+"onboarding.page4.feature3" = "Volle ATAK-Kompatibilität";
+"onboarding.page4.feature4" = "Funktioniert mit jedem TAK-Server";
+
+/* --- Quick Start Guide --- */
+"quickstart.title" = "Schnellstart-Anleitung";
+"quickstart.subtitle" = "Wähle die Verbindungsmethode, die am besten zu deiner Situation passt";
+"quickstart.done" = "Fertig";
+"quickstart.needHelp" = "Brauchst du Hilfe?";
+"quickstart.help.docs" = "Dokumentation lesen";
+"quickstart.help.support" = "Support kontaktieren";
+"quickstart.help.videos" = "Tutorial-Videos ansehen";
+"quickstart.item.qr.title" = "QR-Code scannen";
+"quickstart.item.qr.desc" = "Schnellste Methode — scanne den Registrierungs-QR-Code von deinem TAK-Server-Administrator";
+"quickstart.item.discover.title" = "Automatische Erkennung";
+"quickstart.item.discover.desc" = "TAK-Server in deinem lokalen Netzwerk automatisch finden";
+"quickstart.item.quick.title" = "Schnelleinrichtung";
+"quickstart.item.quick.desc" = "Voreinstellungen für gängige TAK-Server-Konfigurationen verwenden";
+"quickstart.item.manual.title" = "Manuelle Einrichtung";
+"quickstart.item.manual.desc" = "Volle Kontrolle — konfiguriere alle Verbindungsparameter selbst";
+"quickstart.difficulty.easiest" = "Am einfachsten";
+"quickstart.difficulty.easy" = "Einfach";
+"quickstart.difficulty.advanced" = "Fortgeschritten";
+
+/* --- Settings --- */
+"settings.title" = "Einstellungen";
+"settings.done" = "Fertig";
+"settings.section.userProfile" = "BENUTZERPROFIL";
+"settings.callsign" = "Rufzeichen";
+"settings.name" = "Name";
+"settings.section.servers" = "SERVER";
+"settings.manageServers" = "Server verwalten";
+"settings.section.navigation" = "NAVIGATION";
+"settings.routeNavigation" = "Routennavigation";
+"settings.section.mapOverlays" = "KARTEN-OVERLAYS";
+"settings.mgrsGridOverlay" = "MGRS-Gitter";
+"settings.gridDensity" = "Gitterdichte";
+"settings.showGridLabels" = "Gitterbeschriftungen anzeigen";
+"settings.coordinateFormat" = "Koordinatenformat";
+"settings.selfPositionMarker" = "Eigener Positionsmarker";
+"settings.section.droneDetection" = "DROHNENERKENNUNG";
+"settings.faaRemoteIdScanner" = "FAA-Remote-ID-Scanner";
+"settings.section.language" = "SPRACHE";
+"settings.appLanguage" = "App-Sprache";
+"settings.section.breadcrumbTrails" = "WEGSPUREN";
+"settings.enableTrails" = "Spuren aktivieren";
+"settings.maxTrailLength" = "Max. Spurlänge";
+"settings.trailColor" = "Spurfarbe";
+"settings.section.display" = "ANZEIGE";
+"settings.unitSystem" = "Einheitensystem";
+"settings.section.performance" = "LEISTUNG";
+"settings.cacheSize" = "Cache-Größe";
+"settings.clearCache" = "Cache leeren";
+"settings.section.dataManagement" = "DATENVERWALTUNG";
+"settings.importDataPackage" = "Datenpaket importieren";
+"settings.resetToDefaults" = "Auf Standard zurücksetzen";
+"settings.section.dangerZone" = "GEFAHRENZONE";
+"settings.clearAllTeamData" = "Alle Teamdaten löschen";

--- a/OmniTAKMobile/Resources/en.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,97 @@
+/* OmniTAK Mobile — English (base catalogue)
+   v1 scope: onboarding flow + Settings screen.
+   Other screens fall back to these English strings until later
+   localization passes extend coverage. */
+
+/* --- Onboarding navigation --- */
+"onboarding.skip" = "Skip";
+"onboarding.continue" = "Continue";
+"onboarding.getStarted" = "Get Started";
+"onboarding.back" = "Back";
+
+/* --- Onboarding page 1: Welcome --- */
+"onboarding.page1.title" = "Welcome to OmniTAK";
+"onboarding.page1.desc" = "Your powerful iOS client for Team Awareness Kit (TAK) servers. Connect, share, and collaborate in real-time.";
+"onboarding.page1.feature1" = "Real-time position sharing";
+"onboarding.page1.feature2" = "Secure communications";
+"onboarding.page1.feature3" = "Map-based awareness";
+"onboarding.page1.feature4" = "Multi-platform support";
+
+/* --- Onboarding page 2: Secure & Certified --- */
+"onboarding.page2.title" = "Secure & Certified";
+"onboarding.page2.desc" = "OmniTAK supports certificate-based authentication for secure connections to TAK servers.";
+"onboarding.page2.feature1" = "Client certificate support";
+"onboarding.page2.feature2" = "TLS/SSL encryption";
+"onboarding.page2.feature3" = "Keychain integration";
+"onboarding.page2.feature4" = "Automatic enrollment";
+
+/* --- Onboarding page 3: Quick & Easy Setup --- */
+"onboarding.page3.title" = "Quick & Easy Setup";
+"onboarding.page3.desc" = "Get connected in seconds with our smart setup wizard. Multiple connection methods for every scenario.";
+"onboarding.page3.feature1" = "QR code scanning";
+"onboarding.page3.feature2" = "Auto-discovery";
+"onboarding.page3.feature3" = "Common presets";
+"onboarding.page3.feature4" = "Manual configuration";
+
+/* --- Onboarding page 4: Ready to Connect --- */
+"onboarding.page4.title" = "Ready to Connect?";
+"onboarding.page4.desc" = "Let's get you connected to a TAK server. Choose the method that works best for you.";
+"onboarding.page4.feature1" = "Connect in < 30 seconds";
+"onboarding.page4.feature2" = "No technical knowledge needed";
+"onboarding.page4.feature3" = "Full ATAK compatibility";
+"onboarding.page4.feature4" = "Works with any TAK server";
+
+/* --- Quick Start Guide --- */
+"quickstart.title" = "Quick Start Guide";
+"quickstart.subtitle" = "Choose the connection method that works best for your situation";
+"quickstart.done" = "Done";
+"quickstart.needHelp" = "Need Help?";
+"quickstart.help.docs" = "Read the Documentation";
+"quickstart.help.support" = "Contact Support";
+"quickstart.help.videos" = "Watch Tutorial Videos";
+"quickstart.item.qr.title" = "Scan QR Code";
+"quickstart.item.qr.desc" = "Fastest method — scan the enrollment QR from your TAK server admin";
+"quickstart.item.discover.title" = "Auto-Discover";
+"quickstart.item.discover.desc" = "Find TAK servers on your local network automatically";
+"quickstart.item.quick.title" = "Quick Setup";
+"quickstart.item.quick.desc" = "Use presets for common TAK server configurations";
+"quickstart.item.manual.title" = "Manual Setup";
+"quickstart.item.manual.desc" = "Full control — configure all connection parameters yourself";
+"quickstart.difficulty.easiest" = "Easiest";
+"quickstart.difficulty.easy" = "Easy";
+"quickstart.difficulty.advanced" = "Advanced";
+
+/* --- Settings --- */
+"settings.title" = "Settings";
+"settings.done" = "Done";
+"settings.section.userProfile" = "USER PROFILE";
+"settings.callsign" = "Callsign";
+"settings.name" = "Name";
+"settings.section.servers" = "SERVERS";
+"settings.manageServers" = "Manage Servers";
+"settings.section.navigation" = "NAVIGATION";
+"settings.routeNavigation" = "Route Navigation";
+"settings.section.mapOverlays" = "MAP OVERLAYS";
+"settings.mgrsGridOverlay" = "MGRS Grid Overlay";
+"settings.gridDensity" = "Grid Density";
+"settings.showGridLabels" = "Show Grid Labels";
+"settings.coordinateFormat" = "Coordinate Format";
+"settings.selfPositionMarker" = "Self-Position Marker";
+"settings.section.droneDetection" = "DRONE DETECTION";
+"settings.faaRemoteIdScanner" = "FAA Remote ID Scanner";
+"settings.section.language" = "LANGUAGE";
+"settings.appLanguage" = "App Language";
+"settings.section.breadcrumbTrails" = "BREADCRUMB TRAILS";
+"settings.enableTrails" = "Enable Trails";
+"settings.maxTrailLength" = "Max Trail Length";
+"settings.trailColor" = "Trail Color";
+"settings.section.display" = "DISPLAY";
+"settings.unitSystem" = "Unit System";
+"settings.section.performance" = "PERFORMANCE";
+"settings.cacheSize" = "Cache Size";
+"settings.clearCache" = "Clear Cache";
+"settings.section.dataManagement" = "DATA MANAGEMENT";
+"settings.importDataPackage" = "Import Data Package";
+"settings.resetToDefaults" = "Reset to Defaults";
+"settings.section.dangerZone" = "DANGER ZONE";
+"settings.clearAllTeamData" = "Clear All Team Data";

--- a/OmniTAKMobile/Resources/es.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/es.lproj/Localizable.strings
@@ -1,0 +1,96 @@
+/* OmniTAK Mobile — Spanish / Español
+   Technical standards (TAK, MGRS, UTM, TLS/SSL, QR, FAA Remote ID,
+   MIL-STD, Bluetooth) kept as-is — they are proper nouns. */
+
+/* --- Onboarding navigation --- */
+"onboarding.skip" = "Omitir";
+"onboarding.continue" = "Continuar";
+"onboarding.getStarted" = "Comenzar";
+"onboarding.back" = "Atrás";
+
+/* --- Onboarding page 1: Welcome --- */
+"onboarding.page1.title" = "Bienvenido a OmniTAK";
+"onboarding.page1.desc" = "Tu potente cliente iOS para servidores Team Awareness Kit (TAK). Conéctate, comparte y colabora en tiempo real.";
+"onboarding.page1.feature1" = "Compartir posición en tiempo real";
+"onboarding.page1.feature2" = "Comunicaciones seguras";
+"onboarding.page1.feature3" = "Conciencia situacional en el mapa";
+"onboarding.page1.feature4" = "Compatibilidad multiplataforma";
+
+/* --- Onboarding page 2: Secure & Certified --- */
+"onboarding.page2.title" = "Seguro y certificado";
+"onboarding.page2.desc" = "OmniTAK admite autenticación basada en certificados para conexiones seguras con servidores TAK.";
+"onboarding.page2.feature1" = "Compatibilidad con certificados de cliente";
+"onboarding.page2.feature2" = "Cifrado TLS/SSL";
+"onboarding.page2.feature3" = "Integración con el llavero";
+"onboarding.page2.feature4" = "Inscripción automática";
+
+/* --- Onboarding page 3: Quick & Easy Setup --- */
+"onboarding.page3.title" = "Configuración rápida y sencilla";
+"onboarding.page3.desc" = "Conéctate en segundos con nuestro asistente de configuración inteligente. Varios métodos de conexión para cada escenario.";
+"onboarding.page3.feature1" = "Escaneo de código QR";
+"onboarding.page3.feature2" = "Detección automática";
+"onboarding.page3.feature3" = "Ajustes preestablecidos comunes";
+"onboarding.page3.feature4" = "Configuración manual";
+
+/* --- Onboarding page 4: Ready to Connect --- */
+"onboarding.page4.title" = "¿Listo para conectar?";
+"onboarding.page4.desc" = "Vamos a conectarte a un servidor TAK. Elige el método que mejor te funcione.";
+"onboarding.page4.feature1" = "Conexión en menos de 30 segundos";
+"onboarding.page4.feature2" = "Sin conocimientos técnicos";
+"onboarding.page4.feature3" = "Compatibilidad total con ATAK";
+"onboarding.page4.feature4" = "Funciona con cualquier servidor TAK";
+
+/* --- Quick Start Guide --- */
+"quickstart.title" = "Guía de inicio rápido";
+"quickstart.subtitle" = "Elige el método de conexión que mejor se adapte a tu situación";
+"quickstart.done" = "Listo";
+"quickstart.needHelp" = "¿Necesitas ayuda?";
+"quickstart.help.docs" = "Leer la documentación";
+"quickstart.help.support" = "Contactar con soporte";
+"quickstart.help.videos" = "Ver vídeos tutoriales";
+"quickstart.item.qr.title" = "Escanear código QR";
+"quickstart.item.qr.desc" = "El método más rápido: escanea el código QR de inscripción del administrador de tu servidor TAK";
+"quickstart.item.discover.title" = "Detección automática";
+"quickstart.item.discover.desc" = "Encuentra servidores TAK en tu red local automáticamente";
+"quickstart.item.quick.title" = "Configuración rápida";
+"quickstart.item.quick.desc" = "Usa ajustes preestablecidos para configuraciones comunes de servidores TAK";
+"quickstart.item.manual.title" = "Configuración manual";
+"quickstart.item.manual.desc" = "Control total: configura todos los parámetros de conexión tú mismo";
+"quickstart.difficulty.easiest" = "Más fácil";
+"quickstart.difficulty.easy" = "Fácil";
+"quickstart.difficulty.advanced" = "Avanzado";
+
+/* --- Settings --- */
+"settings.title" = "Ajustes";
+"settings.done" = "Listo";
+"settings.section.userProfile" = "PERFIL DE USUARIO";
+"settings.callsign" = "Indicativo";
+"settings.name" = "Nombre";
+"settings.section.servers" = "SERVIDORES";
+"settings.manageServers" = "Gestionar servidores";
+"settings.section.navigation" = "NAVEGACIÓN";
+"settings.routeNavigation" = "Navegación de ruta";
+"settings.section.mapOverlays" = "CAPAS DEL MAPA";
+"settings.mgrsGridOverlay" = "Cuadrícula MGRS";
+"settings.gridDensity" = "Densidad de cuadrícula";
+"settings.showGridLabels" = "Mostrar etiquetas de cuadrícula";
+"settings.coordinateFormat" = "Formato de coordenadas";
+"settings.selfPositionMarker" = "Marcador de posición propia";
+"settings.section.droneDetection" = "DETECCIÓN DE DRONES";
+"settings.faaRemoteIdScanner" = "Escáner FAA Remote ID";
+"settings.section.language" = "IDIOMA";
+"settings.appLanguage" = "Idioma de la aplicación";
+"settings.section.breadcrumbTrails" = "RASTROS DE RECORRIDO";
+"settings.enableTrails" = "Activar rastros";
+"settings.maxTrailLength" = "Longitud máx. del rastro";
+"settings.trailColor" = "Color del rastro";
+"settings.section.display" = "PANTALLA";
+"settings.unitSystem" = "Sistema de unidades";
+"settings.section.performance" = "RENDIMIENTO";
+"settings.cacheSize" = "Tamaño de caché";
+"settings.clearCache" = "Borrar caché";
+"settings.section.dataManagement" = "GESTIÓN DE DATOS";
+"settings.importDataPackage" = "Importar paquete de datos";
+"settings.resetToDefaults" = "Restablecer valores predeterminados";
+"settings.section.dangerZone" = "ZONA DE PELIGRO";
+"settings.clearAllTeamData" = "Borrar todos los datos del equipo";

--- a/OmniTAKMobile/Resources/fr.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/fr.lproj/Localizable.strings
@@ -1,0 +1,96 @@
+/* OmniTAK Mobile — French / Français
+   Technical standards (TAK, MGRS, UTM, TLS/SSL, QR, FAA Remote ID,
+   MIL-STD, Bluetooth) kept as-is — they are proper nouns. */
+
+/* --- Onboarding navigation --- */
+"onboarding.skip" = "Passer";
+"onboarding.continue" = "Continuer";
+"onboarding.getStarted" = "Commencer";
+"onboarding.back" = "Retour";
+
+/* --- Onboarding page 1: Welcome --- */
+"onboarding.page1.title" = "Bienvenue sur OmniTAK";
+"onboarding.page1.desc" = "Votre client iOS performant pour les serveurs Team Awareness Kit (TAK). Connectez-vous, partagez et collaborez en temps réel.";
+"onboarding.page1.feature1" = "Partage de position en temps réel";
+"onboarding.page1.feature2" = "Communications sécurisées";
+"onboarding.page1.feature3" = "Connaissance de la situation sur carte";
+"onboarding.page1.feature4" = "Prise en charge multiplateforme";
+
+/* --- Onboarding page 2: Secure & Certified --- */
+"onboarding.page2.title" = "Sécurisé et certifié";
+"onboarding.page2.desc" = "OmniTAK prend en charge l'authentification par certificat pour des connexions sécurisées aux serveurs TAK.";
+"onboarding.page2.feature1" = "Prise en charge des certificats client";
+"onboarding.page2.feature2" = "Chiffrement TLS/SSL";
+"onboarding.page2.feature3" = "Intégration au trousseau";
+"onboarding.page2.feature4" = "Enrôlement automatique";
+
+/* --- Onboarding page 3: Quick & Easy Setup --- */
+"onboarding.page3.title" = "Configuration rapide et simple";
+"onboarding.page3.desc" = "Connectez-vous en quelques secondes grâce à notre assistant de configuration intelligent. Plusieurs méthodes de connexion pour chaque scénario.";
+"onboarding.page3.feature1" = "Lecture de code QR";
+"onboarding.page3.feature2" = "Découverte automatique";
+"onboarding.page3.feature3" = "Préréglages courants";
+"onboarding.page3.feature4" = "Configuration manuelle";
+
+/* --- Onboarding page 4: Ready to Connect --- */
+"onboarding.page4.title" = "Prêt à vous connecter ?";
+"onboarding.page4.desc" = "Connectons-vous à un serveur TAK. Choisissez la méthode qui vous convient le mieux.";
+"onboarding.page4.feature1" = "Connexion en moins de 30 secondes";
+"onboarding.page4.feature2" = "Aucune connaissance technique requise";
+"onboarding.page4.feature3" = "Compatibilité ATAK complète";
+"onboarding.page4.feature4" = "Fonctionne avec tout serveur TAK";
+
+/* --- Quick Start Guide --- */
+"quickstart.title" = "Guide de démarrage rapide";
+"quickstart.subtitle" = "Choisissez la méthode de connexion la mieux adaptée à votre situation";
+"quickstart.done" = "Terminé";
+"quickstart.needHelp" = "Besoin d'aide ?";
+"quickstart.help.docs" = "Lire la documentation";
+"quickstart.help.support" = "Contacter l'assistance";
+"quickstart.help.videos" = "Regarder les tutoriels vidéo";
+"quickstart.item.qr.title" = "Scanner un code QR";
+"quickstart.item.qr.desc" = "Méthode la plus rapide — scannez le code QR d'enrôlement fourni par l'administrateur de votre serveur TAK";
+"quickstart.item.discover.title" = "Découverte automatique";
+"quickstart.item.discover.desc" = "Trouvez automatiquement les serveurs TAK sur votre réseau local";
+"quickstart.item.quick.title" = "Configuration rapide";
+"quickstart.item.quick.desc" = "Utilisez des préréglages pour les configurations de serveur TAK courantes";
+"quickstart.item.manual.title" = "Configuration manuelle";
+"quickstart.item.manual.desc" = "Contrôle total — configurez vous-même tous les paramètres de connexion";
+"quickstart.difficulty.easiest" = "Le plus simple";
+"quickstart.difficulty.easy" = "Facile";
+"quickstart.difficulty.advanced" = "Avancé";
+
+/* --- Settings --- */
+"settings.title" = "Réglages";
+"settings.done" = "Terminé";
+"settings.section.userProfile" = "PROFIL UTILISATEUR";
+"settings.callsign" = "Indicatif";
+"settings.name" = "Nom";
+"settings.section.servers" = "SERVEURS";
+"settings.manageServers" = "Gérer les serveurs";
+"settings.section.navigation" = "NAVIGATION";
+"settings.routeNavigation" = "Navigation d'itinéraire";
+"settings.section.mapOverlays" = "CALQUES DE CARTE";
+"settings.mgrsGridOverlay" = "Grille MGRS";
+"settings.gridDensity" = "Densité de la grille";
+"settings.showGridLabels" = "Afficher les étiquettes de grille";
+"settings.coordinateFormat" = "Format de coordonnées";
+"settings.selfPositionMarker" = "Marqueur de position personnelle";
+"settings.section.droneDetection" = "DÉTECTION DE DRONES";
+"settings.faaRemoteIdScanner" = "Scanner FAA Remote ID";
+"settings.section.language" = "LANGUE";
+"settings.appLanguage" = "Langue de l'application";
+"settings.section.breadcrumbTrails" = "TRACÉS DE PARCOURS";
+"settings.enableTrails" = "Activer les tracés";
+"settings.maxTrailLength" = "Longueur max. du tracé";
+"settings.trailColor" = "Couleur du tracé";
+"settings.section.display" = "AFFICHAGE";
+"settings.unitSystem" = "Système d'unités";
+"settings.section.performance" = "PERFORMANCES";
+"settings.cacheSize" = "Taille du cache";
+"settings.clearCache" = "Vider le cache";
+"settings.section.dataManagement" = "GESTION DES DONNÉES";
+"settings.importDataPackage" = "Importer un paquet de données";
+"settings.resetToDefaults" = "Réinitialiser par défaut";
+"settings.section.dangerZone" = "ZONE SENSIBLE";
+"settings.clearAllTeamData" = "Effacer toutes les données d'équipe";

--- a/OmniTAKMobile/Resources/pl.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/pl.lproj/Localizable.strings
@@ -1,0 +1,96 @@
+/* OmniTAK Mobile — Polish / Polski
+   Technical standards (TAK, MGRS, UTM, TLS/SSL, QR, FAA Remote ID,
+   MIL-STD, Bluetooth) kept as-is — they are proper nouns. */
+
+/* --- Onboarding navigation --- */
+"onboarding.skip" = "Pomiń";
+"onboarding.continue" = "Dalej";
+"onboarding.getStarted" = "Rozpocznij";
+"onboarding.back" = "Wstecz";
+
+/* --- Onboarding page 1: Welcome --- */
+"onboarding.page1.title" = "Witamy w OmniTAK";
+"onboarding.page1.desc" = "Zaawansowany klient iOS dla serwerów Team Awareness Kit (TAK). Łącz się, udostępniaj i współpracuj w czasie rzeczywistym.";
+"onboarding.page1.feature1" = "Udostępnianie pozycji w czasie rzeczywistym";
+"onboarding.page1.feature2" = "Bezpieczna łączność";
+"onboarding.page1.feature3" = "Świadomość sytuacyjna na mapie";
+"onboarding.page1.feature4" = "Obsługa wielu platform";
+
+/* --- Onboarding page 2: Secure & Certified --- */
+"onboarding.page2.title" = "Bezpieczny i certyfikowany";
+"onboarding.page2.desc" = "OmniTAK obsługuje uwierzytelnianie oparte na certyfikatach dla bezpiecznych połączeń z serwerami TAK.";
+"onboarding.page2.feature1" = "Obsługa certyfikatów klienta";
+"onboarding.page2.feature2" = "Szyfrowanie TLS/SSL";
+"onboarding.page2.feature3" = "Integracja z pęku kluczy";
+"onboarding.page2.feature4" = "Automatyczna rejestracja";
+
+/* --- Onboarding page 3: Quick & Easy Setup --- */
+"onboarding.page3.title" = "Szybka i łatwa konfiguracja";
+"onboarding.page3.desc" = "Połącz się w kilka sekund dzięki inteligentnemu kreatorowi konfiguracji. Wiele metod połączenia dla każdego scenariusza.";
+"onboarding.page3.feature1" = "Skanowanie kodu QR";
+"onboarding.page3.feature2" = "Automatyczne wykrywanie";
+"onboarding.page3.feature3" = "Popularne ustawienia";
+"onboarding.page3.feature4" = "Konfiguracja ręczna";
+
+/* --- Onboarding page 4: Ready to Connect --- */
+"onboarding.page4.title" = "Gotów do połączenia?";
+"onboarding.page4.desc" = "Połączmy Cię z serwerem TAK. Wybierz metodę, która sprawdzi się najlepiej.";
+"onboarding.page4.feature1" = "Połączenie w mniej niż 30 sekund";
+"onboarding.page4.feature2" = "Bez wiedzy technicznej";
+"onboarding.page4.feature3" = "Pełna zgodność z ATAK";
+"onboarding.page4.feature4" = "Działa z dowolnym serwerem TAK";
+
+/* --- Quick Start Guide --- */
+"quickstart.title" = "Szybki start";
+"quickstart.subtitle" = "Wybierz metodę połączenia najlepszą dla Twojej sytuacji";
+"quickstart.done" = "Gotowe";
+"quickstart.needHelp" = "Potrzebujesz pomocy?";
+"quickstart.help.docs" = "Przeczytaj dokumentację";
+"quickstart.help.support" = "Skontaktuj się z pomocą techniczną";
+"quickstart.help.videos" = "Obejrzyj samouczki wideo";
+"quickstart.item.qr.title" = "Skanuj kod QR";
+"quickstart.item.qr.desc" = "Najszybsza metoda — zeskanuj kod QR rejestracji od administratora serwera TAK";
+"quickstart.item.discover.title" = "Automatyczne wykrywanie";
+"quickstart.item.discover.desc" = "Automatycznie znajdź serwery TAK w sieci lokalnej";
+"quickstart.item.quick.title" = "Szybka konfiguracja";
+"quickstart.item.quick.desc" = "Użyj gotowych ustawień dla typowych konfiguracji serwerów TAK";
+"quickstart.item.manual.title" = "Konfiguracja ręczna";
+"quickstart.item.manual.desc" = "Pełna kontrola — skonfiguruj wszystkie parametry połączenia samodzielnie";
+"quickstart.difficulty.easiest" = "Najłatwiejsze";
+"quickstart.difficulty.easy" = "Łatwe";
+"quickstart.difficulty.advanced" = "Zaawansowane";
+
+/* --- Settings --- */
+"settings.title" = "Ustawienia";
+"settings.done" = "Gotowe";
+"settings.section.userProfile" = "PROFIL UŻYTKOWNIKA";
+"settings.callsign" = "Znak wywoławczy";
+"settings.name" = "Imię";
+"settings.section.servers" = "SERWERY";
+"settings.manageServers" = "Zarządzaj serwerami";
+"settings.section.navigation" = "NAWIGACJA";
+"settings.routeNavigation" = "Nawigacja po trasie";
+"settings.section.mapOverlays" = "WARSTWY MAPY";
+"settings.mgrsGridOverlay" = "Siatka MGRS";
+"settings.gridDensity" = "Gęstość siatki";
+"settings.showGridLabels" = "Pokaż etykiety siatki";
+"settings.coordinateFormat" = "Format współrzędnych";
+"settings.selfPositionMarker" = "Znacznik własnej pozycji";
+"settings.section.droneDetection" = "WYKRYWANIE DRONÓW";
+"settings.faaRemoteIdScanner" = "Skaner FAA Remote ID";
+"settings.section.language" = "JĘZYK";
+"settings.appLanguage" = "Język aplikacji";
+"settings.section.breadcrumbTrails" = "ŚLADY TRASY";
+"settings.enableTrails" = "Włącz ślady";
+"settings.maxTrailLength" = "Maks. długość śladu";
+"settings.trailColor" = "Kolor śladu";
+"settings.section.display" = "WYŚWIETLANIE";
+"settings.unitSystem" = "Układ jednostek";
+"settings.section.performance" = "WYDAJNOŚĆ";
+"settings.cacheSize" = "Rozmiar pamięci podręcznej";
+"settings.clearCache" = "Wyczyść pamięć podręczną";
+"settings.section.dataManagement" = "ZARZĄDZANIE DANYMI";
+"settings.importDataPackage" = "Importuj pakiet danych";
+"settings.resetToDefaults" = "Przywróć domyślne";
+"settings.section.dangerZone" = "STREFA NIEBEZPIECZNA";
+"settings.clearAllTeamData" = "Wyczyść wszystkie dane zespołu";

--- a/OmniTAKMobile/Resources/uk.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/uk.lproj/Localizable.strings
@@ -1,0 +1,96 @@
+/* OmniTAK Mobile — Ukrainian / Українська
+   Technical standards (TAK, MGRS, UTM, TLS/SSL, QR, FAA Remote ID,
+   MIL-STD, Bluetooth) kept as-is — they are proper nouns. */
+
+/* --- Onboarding navigation --- */
+"onboarding.skip" = "Пропустити";
+"onboarding.continue" = "Далі";
+"onboarding.getStarted" = "Почати";
+"onboarding.back" = "Назад";
+
+/* --- Onboarding page 1: Welcome --- */
+"onboarding.page1.title" = "Ласкаво просимо до OmniTAK";
+"onboarding.page1.desc" = "Потужний iOS-клієнт для серверів Team Awareness Kit (TAK). Підключайтеся, діліться даними та співпрацюйте в реальному часі.";
+"onboarding.page1.feature1" = "Передавання позиції в реальному часі";
+"onboarding.page1.feature2" = "Захищений зв'язок";
+"onboarding.page1.feature3" = "Ситуаційна обізнаність на карті";
+"onboarding.page1.feature4" = "Підтримка кількох платформ";
+
+/* --- Onboarding page 2: Secure & Certified --- */
+"onboarding.page2.title" = "Безпечно та сертифіковано";
+"onboarding.page2.desc" = "OmniTAK підтримує автентифікацію на основі сертифікатів для безпечного з'єднання з серверами TAK.";
+"onboarding.page2.feature1" = "Підтримка клієнтських сертифікатів";
+"onboarding.page2.feature2" = "Шифрування TLS/SSL";
+"onboarding.page2.feature3" = "Інтеграція з Keychain";
+"onboarding.page2.feature4" = "Автоматична реєстрація";
+
+/* --- Onboarding page 3: Quick & Easy Setup --- */
+"onboarding.page3.title" = "Швидке й просте налаштування";
+"onboarding.page3.desc" = "Підключайтеся за секунди завдяки розумному майстру налаштування. Кілька способів підключення для будь-якої ситуації.";
+"onboarding.page3.feature1" = "Сканування QR-коду";
+"onboarding.page3.feature2" = "Автоматичне виявлення";
+"onboarding.page3.feature3" = "Поширені пресети";
+"onboarding.page3.feature4" = "Ручне налаштування";
+
+/* --- Onboarding page 4: Ready to Connect --- */
+"onboarding.page4.title" = "Готові підключитися?";
+"onboarding.page4.desc" = "Підключімо вас до сервера TAK. Оберіть спосіб, який підходить вам найкраще.";
+"onboarding.page4.feature1" = "Підключення менш ніж за 30 секунд";
+"onboarding.page4.feature2" = "Технічні знання не потрібні";
+"onboarding.page4.feature3" = "Повна сумісність з ATAK";
+"onboarding.page4.feature4" = "Працює з будь-яким сервером TAK";
+
+/* --- Quick Start Guide --- */
+"quickstart.title" = "Короткий посібник";
+"quickstart.subtitle" = "Оберіть спосіб підключення, що найкраще підходить для вашої ситуації";
+"quickstart.done" = "Готово";
+"quickstart.needHelp" = "Потрібна допомога?";
+"quickstart.help.docs" = "Прочитати документацію";
+"quickstart.help.support" = "Звернутися до підтримки";
+"quickstart.help.videos" = "Переглянути відеоуроки";
+"quickstart.item.qr.title" = "Сканувати QR-код";
+"quickstart.item.qr.desc" = "Найшвидший спосіб — відскануйте QR-код реєстрації від адміністратора вашого сервера TAK";
+"quickstart.item.discover.title" = "Автовиявлення";
+"quickstart.item.discover.desc" = "Автоматичний пошук серверів TAK у вашій локальній мережі";
+"quickstart.item.quick.title" = "Швидке налаштування";
+"quickstart.item.quick.desc" = "Використовуйте пресети для типових конфігурацій серверів TAK";
+"quickstart.item.manual.title" = "Ручне налаштування";
+"quickstart.item.manual.desc" = "Повний контроль — налаштуйте всі параметри підключення самостійно";
+"quickstart.difficulty.easiest" = "Найпростіше";
+"quickstart.difficulty.easy" = "Просто";
+"quickstart.difficulty.advanced" = "Для досвідчених";
+
+/* --- Settings --- */
+"settings.title" = "Налаштування";
+"settings.done" = "Готово";
+"settings.section.userProfile" = "ПРОФІЛЬ КОРИСТУВАЧА";
+"settings.callsign" = "Позивний";
+"settings.name" = "Ім'я";
+"settings.section.servers" = "СЕРВЕРИ";
+"settings.manageServers" = "Керування серверами";
+"settings.section.navigation" = "НАВІГАЦІЯ";
+"settings.routeNavigation" = "Навігація маршрутом";
+"settings.section.mapOverlays" = "ШАРИ КАРТИ";
+"settings.mgrsGridOverlay" = "Сітка MGRS";
+"settings.gridDensity" = "Щільність сітки";
+"settings.showGridLabels" = "Показувати підписи сітки";
+"settings.coordinateFormat" = "Формат координат";
+"settings.selfPositionMarker" = "Маркер власної позиції";
+"settings.section.droneDetection" = "ВИЯВЛЕННЯ ДРОНІВ";
+"settings.faaRemoteIdScanner" = "Сканер FAA Remote ID";
+"settings.section.language" = "МОВА";
+"settings.appLanguage" = "Мова застосунку";
+"settings.section.breadcrumbTrails" = "СЛІДИ МАРШРУТУ";
+"settings.enableTrails" = "Увімкнути сліди";
+"settings.maxTrailLength" = "Макс. довжина сліду";
+"settings.trailColor" = "Колір сліду";
+"settings.section.display" = "ВІДОБРАЖЕННЯ";
+"settings.unitSystem" = "Система одиниць";
+"settings.section.performance" = "ПРОДУКТИВНІСТЬ";
+"settings.cacheSize" = "Розмір кешу";
+"settings.clearCache" = "Очистити кеш";
+"settings.section.dataManagement" = "КЕРУВАННЯ ДАНИМИ";
+"settings.importDataPackage" = "Імпортувати пакет даних";
+"settings.resetToDefaults" = "Скинути до типових";
+"settings.section.dangerZone" = "НЕБЕЗПЕЧНА ЗОНА";
+"settings.clearAllTeamData" = "Стерти всі дані команди";

--- a/OmniTAKMobile/Shared/UI/Components/ATAKToolsView.swift
+++ b/OmniTAKMobile/Shared/UI/Components/ATAKToolsView.swift
@@ -120,6 +120,7 @@ struct ATAKToolsView: View {
         }
         .sheet(isPresented: $showSettings) {
             SettingsView()
+                .environmentObject(LocalizationManager.shared)
         }
         .sheet(isPresented: $showPlugins) {
             PluginsListView()

--- a/scripts/sync-localization-pbxproj.rb
+++ b/scripts/sync-localization-pbxproj.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+#
+# Register the Localizable.strings variant group in
+# OmniTAKMobile.xcodeproj — one PBXVariantGroup with a child file
+# reference per language .lproj, added to the app target's
+# resources build phase, plus the language codes in knownRegions.
+#
+# Idempotent: re-run after adding a new language .lproj and it adds
+# only the missing pieces.
+#
+#     ruby scripts/sync-localization-pbxproj.rb
+
+require 'xcodeproj'
+require 'pathname'
+
+ROOT = Pathname.new(__dir__).parent.realpath
+PROJ_PATH = ROOT.join('OmniTAKMobile.xcodeproj')
+LANGS = %w[en uk pl de fr es]
+
+project = Xcodeproj::Project.open(PROJ_PATH)
+app = project.targets.find { |t| t.name == 'OmniTAKMobile' } || project.targets.first
+abort 'app target not found' unless app
+
+# --- knownRegions -------------------------------------------------------
+LANGS.each do |lang|
+  project.root_object.known_regions << lang unless project.root_object.known_regions.include?(lang)
+end
+
+# --- Localizable.strings variant group ----------------------------------
+resources_group = project.main_group.children.find { |c| c.display_name == 'Resources' } ||
+                  project.main_group.new_group('Resources')
+
+# Drop any pre-existing variant group so a re-run is clean.
+existing = resources_group.children.find { |c|
+  c.is_a?(Xcodeproj::Project::Object::PBXVariantGroup) && c.display_name == 'Localizable.strings'
+}
+if existing
+  app.resources_build_phase.files.dup.each do |bf|
+    app.resources_build_phase.remove_build_file(bf) if bf.file_ref == existing
+  end
+  existing.recursive_children.dup.each { |c| c.remove_from_project rescue nil }
+  existing.remove_from_project
+end
+
+variant = project.new(Xcodeproj::Project::Object::PBXVariantGroup)
+variant.name = 'Localizable.strings'
+variant.source_tree = '<group>'
+resources_group << variant
+
+LANGS.each do |lang|
+  rel = "OmniTAKMobile/Resources/#{lang}.lproj/Localizable.strings"
+  abort "missing file: #{rel}" unless ROOT.join(rel).exist?
+  ref = project.new(Xcodeproj::Project::Object::PBXFileReference)
+  ref.path = rel
+  ref.name = lang
+  ref.source_tree = '<group>'
+  ref.last_known_file_type = 'text.plist.strings'
+  variant << ref
+end
+
+app.resources_build_phase.add_file_reference(variant)
+
+project.save
+
+puts "registered Localizable.strings variant group:"
+LANGS.each { |l| puts "    + #{l}.lproj/Localizable.strings" }
+puts "knownRegions: #{project.root_object.known_regions.join(', ')}"


### PR DESCRIPTION
## User report

> The onboarding language settings doesn't seem to actually change the language, please enable true multi language support.

Root cause: the app had **no** language support — no `.lproj` folders, no `Localizable.strings`, no picker anywhere. There was nothing to fix; it had to be built.

## What this delivers

### Infrastructure — live runtime switching, no restart
`LocalizationManager` (ObservableObject) loads a per-language `.lproj` bundle at runtime and swaps it live. Picking a language re-renders the SwiftUI UI immediately — `@Published current` drives the re-render, views observe via `@EnvironmentObject` (injected once at the app root). `setLanguage` also writes `AppleLanguages` so date formatters / UIKit-hosted views pick it up on next launch. `t(key)` resolves against the active bundle → English base fallback → the key itself (so a missing string is visible in testing, never blank).

### Languages — 6
`en` (base) · `uk` Українська · `pl` Polski · `de` Deutsch · `fr` Français · `es` Español. Endonym + flag in the picker. Registered as a `Localizable.strings` variant group via `scripts/sync-localization-pbxproj.rb`; `knownRegions` updated.

### v1 coverage
Onboarding flow (4 pages + Quick Start Guide) and the Settings screen — **79 keys per language**. Settings gains a "LANGUAGE" section with a live picker. Other screens fall back to English until later passes; the framework extends without rework.

## Verification

- `xcodebuild` for the simulator: **BUILD SUCCEEDED**
- All 6 `.lproj` catalogs land in the built app bundle, 79 keys each, `plutil`-clean
- Ran the `LocalizationManager` bundle-load + key-resolution path against the built bundle — every sampled key resolves to the correct translation across all 6 languages (e.g. `onboarding.skip` → `Пропустити` / `Pomiń` / `Überspringen` / `Passer` / `Omitir`)

## Notes

- Translations are first-pass and usable; native-speaker review recommended before a marketing push.
- v1 scope is onboarding + Settings per the agreed plan. Map UI, enrollment, chat, mission, military screens are follow-up localization passes against the same framework.

## Test plan

- [ ] Settings → LANGUAGE → pick Ukrainian; Settings + onboarding flip immediately, no restart
- [ ] Relaunch — chosen language persists
- [ ] Fresh install with device language set to de/fr/es/pl/uk — app auto-selects the match
- [ ] A key with no translation falls back to English, not blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)