### PR TITLE
feat(chat/ios): multi-server attribution + per-server DMs

### DIFF
--- a/OmniTAKMobile/CoT/CoTEventHandler.swift
+++ b/OmniTAKMobile/CoT/CoTEventHandler.swift
@@ -98,7 +98,7 @@ class CoTEventHandler: ObservableObject {
     // MARK: - Event Routing
 
     /// Handle a parsed CoT event and route to appropriate handlers
-    func handle(event: CoTEventType) {
+    func handle(event: CoTEventType, serverId: UUID? = nil) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
 
@@ -110,7 +110,7 @@ class CoTEventHandler: ObservableObject {
                 self.handlePositionUpdate(cotEvent)
 
             case .chatMessage(let message):
-                self.handleChatMessage(message)
+                self.handleChatMessage(message, serverId: serverId)
 
             case .emergencyAlert(let alert):
                 self.handleEmergencyAlert(alert)
@@ -197,13 +197,13 @@ class CoTEventHandler: ObservableObject {
 
     // MARK: - Chat Message Handler
 
-    private func handleChatMessage(_ message: ChatMessage) {
+    private func handleChatMessage(_ message: ChatMessage, serverId: UUID? = nil) {
         print("CoTEventHandler: Chat message from \(message.senderCallsign): \(message.messageText)")
 
         latestChatMessage = message
 
-        // Forward to ChatManager
-        chatManager?.receiveMessage(message)
+        // Forward to ChatManager with the source server for multi-server attribution
+        chatManager?.receiveMessage(message, serverId: serverId)
 
         // Update sender's last seen
         chatManager?.updateParticipantLastSeen(id: message.senderId)

--- a/OmniTAKMobile/CoT/CoTEventHandler.swift
+++ b/OmniTAKMobile/CoT/CoTEventHandler.swift
@@ -107,7 +107,7 @@ class CoTEventHandler: ObservableObject {
 
             switch event {
             case .positionUpdate(let cotEvent):
-                self.handlePositionUpdate(cotEvent)
+                self.handlePositionUpdate(cotEvent, serverId: serverId)
 
             case .chatMessage(let message):
                 self.handleChatMessage(message, serverId: serverId)
@@ -126,7 +126,7 @@ class CoTEventHandler: ObservableObject {
 
     // MARK: - Position Update Handler
 
-    private func handlePositionUpdate(_ event: CoTEvent) {
+    private func handlePositionUpdate(_ event: CoTEvent, serverId: UUID? = nil) {
         print("CoTEventHandler: Position update from \(event.detail.callsign) at (\(event.point.lat), \(event.point.lon))")
 
         latestPositionUpdate = event
@@ -166,8 +166,10 @@ class CoTEventHandler: ObservableObject {
             #endif
         }
 
-        // Update participant info for chat
-        if let participant = ChatXMLParser.parseParticipantFromPresence(xml: createPresenceXML(from: event)) {
+        // Update participant info for chat, tagged with the source server so
+        // the contact list + DM routing are server-aware (multi-server).
+        if var participant = ChatXMLParser.parseParticipantFromPresence(xml: createPresenceXML(from: event)) {
+            participant.serverId = serverId
             chatManager?.updateParticipant(participant)
             chatManager?.updateParticipantLastSeen(id: participant.id)
         } else {
@@ -176,7 +178,8 @@ class CoTEventHandler: ObservableObject {
                 id: event.uid,
                 callsign: event.detail.callsign,
                 lastSeen: event.time,
-                isOnline: true
+                isOnline: true,
+                serverId: serverId
             )
             chatManager?.updateParticipant(participant)
         }

--- a/OmniTAKMobile/Features/Chat/Managers/ChatManager.swift
+++ b/OmniTAKMobile/Features/Chat/Managers/ChatManager.swift
@@ -83,7 +83,8 @@ class ChatManager: ObservableObject {
             timestamp: Date(),
             status: .sending,
             type: .geochat,
-            isFromSelf: true
+            isFromSelf: true,
+            serverId: conversation.serverId
         )
 
         // Add to messages array
@@ -114,7 +115,7 @@ class ChatManager: ObservableObject {
             #if DEBUG
             print("📤 [CHAT DEBUG] TAKService available, attempting to send...")
             #endif
-            let success = takService.sendCoT(xml: xml)
+            let success = takService.sendCoT(xml: xml, toServerId: conversation.serverId)
             if success {
                 // Update message status to sent
                 if let index = messages.firstIndex(where: { $0.id == message.id }) {
@@ -157,7 +158,8 @@ class ChatManager: ObservableObject {
             type: .geochat,
             isFromSelf: true,
             attachmentType: .image,
-            imageAttachment: imageAttachment
+            imageAttachment: imageAttachment,
+            serverId: conversation.serverId
         )
 
         // Add to messages array
@@ -179,7 +181,7 @@ class ChatManager: ObservableObject {
 
         // Send via TAK service
         if let takService = takService {
-            let success = takService.sendCoT(xml: xml)
+            let success = takService.sendCoT(xml: xml, toServerId: conversation.serverId)
             if success {
                 // Update message status to sent
                 if let index = messages.firstIndex(where: { $0.id == message.id }) {
@@ -203,34 +205,48 @@ class ChatManager: ObservableObject {
 
     // MARK: - Receive Message
 
-    func receiveMessage(_ message: ChatMessage) {
+    func receiveMessage(_ message: ChatMessage, serverId: UUID? = nil) {
         // Check if message already exists
         guard !messages.contains(where: { $0.id == message.id }) else {
             print("Duplicate message ignored: \(message.id)")
             return
         }
 
+        // Attribute to the source server, and re-scope DMs per server so the
+        // same contact on two servers stays in separate threads. The merged
+        // All Chat room keeps its id (messages carry a per-message server badge).
+        var msg = message
+        msg.serverId = serverId
+        let isGroup = message.recipientId == nil
+            || message.conversationId == ChatRoom.allUsersId
+            || message.conversationId == ChatRoom.broadcastId
+        if !isGroup, let sid = serverId {
+            msg.conversationId = createDirectConversationId(uid1: currentUserId, uid2: message.senderId, serverId: sid)
+        }
+
         // Add message
-        messages.append(message)
+        messages.append(msg)
         saveMessages()
 
         // Update or create conversation
-        if conversations.first(where: { $0.id == message.conversationId }) != nil {
-            updateConversation(conversationId: message.conversationId, with: message)
+        if conversations.first(where: { $0.id == msg.conversationId }) != nil {
+            updateConversation(conversationId: msg.conversationId, with: msg)
         } else {
-            createConversation(from: message)
+            createConversation(from: msg)
         }
 
-        print("Received chat message from \(message.senderCallsign): \(message.messageText)")
+        print("Received chat message from \(msg.senderCallsign) on server \(serverId?.uuidString ?? "—"): \(msg.messageText)")
     }
 
     // MARK: - Conversation Management
 
-    func getOrCreateDirectConversation(with participant: ChatParticipant) -> Conversation {
-        // Create conversation ID
+    func getOrCreateDirectConversation(with participant: ChatParticipant, serverId: UUID? = nil) -> Conversation {
+        // Scope the DM to the server the contact is on (multi-server).
+        let sid = serverId ?? participant.serverId
         let conversationId = createDirectConversationId(
             uid1: currentUserId,
-            uid2: participant.id
+            uid2: participant.id,
+            serverId: sid
         )
 
         // Check if conversation exists
@@ -239,11 +255,14 @@ class ChatManager: ObservableObject {
         }
 
         // Create new conversation
+        var scopedParticipant = participant
+        scopedParticipant.serverId = sid
         let conversation = Conversation(
             id: conversationId,
             title: participant.callsign,
-            participants: [participant],
-            isGroupChat: false
+            participants: [scopedParticipant],
+            isGroupChat: false,
+            serverId: sid
         )
 
         conversations.append(conversation)
@@ -254,10 +273,11 @@ class ChatManager: ObservableObject {
     }
 
     private func createConversation(from message: ChatMessage) {
-        // Create participant for sender
+        // Create participant for sender, scoped to the source server.
         let sender = ChatParticipant(
             id: message.senderId,
-            callsign: message.senderCallsign
+            callsign: message.senderCallsign,
+            serverId: message.serverId
         )
 
         // Add to participants if not already present
@@ -274,7 +294,8 @@ class ChatManager: ObservableObject {
             lastMessage: message,
             unreadCount: 1,
             isGroupChat: message.recipientId == nil,
-            lastActivity: message.timestamp
+            lastActivity: message.timestamp,
+            serverId: message.serverId
         )
 
         conversations.append(conversation)
@@ -468,8 +489,13 @@ class ChatManager: ObservableObject {
 
     // MARK: - Helpers
 
-    private func createDirectConversationId(uid1: String, uid2: String) -> String {
+    private func createDirectConversationId(uid1: String, uid2: String, serverId: UUID? = nil) -> String {
         let sorted = [uid1, uid2].sorted()
+        // Scope DM threads per server so the same callsign/UID on two servers
+        // are distinct conversations (multi-server). Legacy (nil) keeps old id.
+        if let sid = serverId {
+            return "DM-\(sid.uuidString)-\(sorted[0])-\(sorted[1])"
+        }
         return "DM-\(sorted[0])-\(sorted[1])"
     }
 

--- a/OmniTAKMobile/Features/Chat/Models/ChatModels.swift
+++ b/OmniTAKMobile/Features/Chat/Models/ChatModels.swift
@@ -75,13 +75,16 @@ struct ChatParticipant: Identifiable, Codable, Equatable, Hashable {
     var endpoint: String? // IP:port:protocol for direct messages
     var lastSeen: Date
     var isOnline: Bool
+    /// The TAK server this contact was most recently seen on (multi-server).
+    var serverId: UUID?
 
-    init(id: String, callsign: String, endpoint: String? = nil, lastSeen: Date = Date(), isOnline: Bool = true) {
+    init(id: String, callsign: String, endpoint: String? = nil, lastSeen: Date = Date(), isOnline: Bool = true, serverId: UUID? = nil) {
         self.id = id
         self.callsign = callsign
         self.endpoint = endpoint
         self.lastSeen = lastSeen
         self.isOnline = isOnline
+        self.serverId = serverId
     }
 
     static func == (lhs: ChatParticipant, rhs: ChatParticipant) -> Bool {
@@ -97,7 +100,7 @@ struct ChatParticipant: Identifiable, Codable, Equatable, Hashable {
 
 struct ChatMessage: Identifiable, Codable, Equatable {
     let id: String // Message UID
-    let conversationId: String
+    var conversationId: String   // var: receive path re-scopes DMs per server
     let senderId: String // Sender UID
     let senderCallsign: String
     var recipientId: String? // nil for group messages
@@ -109,6 +112,8 @@ struct ChatMessage: Identifiable, Codable, Equatable {
     var isFromSelf: Bool
     var attachmentType: AttachmentType
     var imageAttachment: ImageAttachment?
+    /// Source server (received) or target server (sent). nil = broadcast/all-chat.
+    var serverId: UUID?
 
     init(
         id: String = UUID().uuidString,
@@ -123,10 +128,12 @@ struct ChatMessage: Identifiable, Codable, Equatable {
         type: ChatMessageType = .geochat,
         isFromSelf: Bool = false,
         attachmentType: AttachmentType = .none,
-        imageAttachment: ImageAttachment? = nil
+        imageAttachment: ImageAttachment? = nil,
+        serverId: UUID? = nil
     ) {
         self.id = id
         self.conversationId = conversationId
+        self.serverId = serverId
         self.senderId = senderId
         self.senderCallsign = senderCallsign
         self.recipientId = recipientId
@@ -164,6 +171,9 @@ struct Conversation: Identifiable, Codable, Equatable {
     var unreadCount: Int
     var isGroupChat: Bool
     var lastActivity: Date
+    /// The TAK server this conversation is scoped to. DMs are per-server;
+    /// nil = spans all servers (e.g. the merged All Chat Users room).
+    var serverId: UUID?
 
     init(
         id: String = UUID().uuidString,
@@ -172,7 +182,8 @@ struct Conversation: Identifiable, Codable, Equatable {
         lastMessage: ChatMessage? = nil,
         unreadCount: Int = 0,
         isGroupChat: Bool = false,
-        lastActivity: Date = Date()
+        lastActivity: Date = Date(),
+        serverId: UUID? = nil
     ) {
         self.id = id
         self.title = title
@@ -181,6 +192,7 @@ struct Conversation: Identifiable, Codable, Equatable {
         self.unreadCount = unreadCount
         self.isGroupChat = isGroupChat
         self.lastActivity = lastActivity
+        self.serverId = serverId
     }
 
     // Get the display title for the conversation

--- a/OmniTAKMobile/Features/Chat/Views/ChatView.swift
+++ b/OmniTAKMobile/Features/Chat/Views/ChatView.swift
@@ -226,8 +226,11 @@ struct NewChatView: View {
                                     }
 
                                     VStack(alignment: .leading, spacing: 2) {
-                                        Text(participant.callsign)
-                                            .foregroundColor(.primary)
+                                        HStack(spacing: 6) {
+                                            Text(participant.callsign)
+                                                .foregroundColor(.primary)
+                                            ChatServerBadge(serverId: participant.serverId)
+                                        }
                                         if participant.isOnline {
                                             Text("Online")
                                                 .font(.caption)

--- a/OmniTAKMobile/Features/Chat/Views/ChatView.swift
+++ b/OmniTAKMobile/Features/Chat/Views/ChatView.swift
@@ -106,6 +106,9 @@ struct ConversationRow: View {
                         .font(.system(size: 16, weight: .semibold))
                         .lineLimit(1)
 
+                    // Which server this (per-server) DM thread belongs to.
+                    ChatServerBadge(serverId: conversation.serverId)
+
                     Spacer()
 
                     if let lastMessage = conversation.lastMessage {

--- a/OmniTAKMobile/Features/Chat/Views/ConversationView.swift
+++ b/OmniTAKMobile/Features/Chat/Views/ConversationView.swift
@@ -211,12 +211,16 @@ struct MessageBubble: View {
             }
 
             VStack(alignment: isFromSelf ? .trailing : .leading, spacing: 4) {
-                // Sender name (only for received messages)
+                // Sender name + source-server badge (only for received messages).
+                // The badge lets you tell servers apart in the merged All Chat room.
                 if !isFromSelf {
-                    Text(message.senderCallsign)
-                        .font(.caption)
-                        .foregroundColor(.gray)
-                        .padding(.leading, 12)
+                    HStack(spacing: 6) {
+                        Text(message.senderCallsign)
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                        ChatServerBadge(serverId: message.serverId)
+                    }
+                    .padding(.leading, 12)
                 }
 
                 // Message bubble with optional image
@@ -402,6 +406,40 @@ struct ConversationView_Previews: PreviewProvider {
 
         NavigationView {
             ConversationView(chatManager: chatManager, conversation: conversation)
+        }
+    }
+}
+
+// MARK: - Multi-server chat badge
+
+/// Small colored chip showing which TAK server a message / conversation /
+/// contact belongs to. Renders nothing when serverId is nil (single-server
+/// or broadcast). Defined here so both ConversationView and ChatView use it.
+enum ChatServerStyle {
+    static func name(for serverId: UUID?) -> String? {
+        guard let id = serverId else { return nil }
+        return ServerManager.shared.servers.first(where: { $0.id == id })?.name
+    }
+
+    static func color(for serverId: UUID?) -> Color {
+        guard let id = serverId else { return .gray }
+        let palette: [Color] = [.cyan, .green, .orange, .purple, .pink, .blue, .mint, .indigo]
+        return palette[abs(id.uuidString.hashValue) % palette.count]
+    }
+}
+
+struct ChatServerBadge: View {
+    let serverId: UUID?
+    var body: some View {
+        if let name = ChatServerStyle.name(for: serverId) {
+            Text(name)
+                .font(.system(size: 9, weight: .semibold))
+                .lineLimit(1)
+                .foregroundColor(.white)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(ChatServerStyle.color(for: serverId))
+                .clipShape(Capsule())
         }
     }
 }

--- a/OmniTAKMobile/Features/Networking/Services/TAKService.swift
+++ b/OmniTAKMobile/Features/Networking/Services/TAKService.swift
@@ -1139,9 +1139,10 @@ class TAKService: ObservableObject {
         serverConnections[server.id] = connectionState
         connectionsLock.unlock()
 
-        // Setup handlers for this server's connection
+        // Setup handlers for this server's connection. Capture the server id so
+        // received messages can be attributed to their source server (multi-server).
         sender.onMessageReceived = { [weak self] xml in
-            self?.handleReceivedMessage(xml)
+            self?.handleReceivedMessage(xml, fromServerId: server.id)
         }
 
         sender.onConnectionStateChanged = { [weak self] connected in
@@ -1296,7 +1297,7 @@ class TAKService: ObservableObject {
         bytesReceived = totalBytes
     }
 
-    private func handleReceivedMessage(_ xml: String) {
+    private func handleReceivedMessage(_ xml: String, fromServerId serverId: UUID? = nil) {
         messagesReceived += 1
         lastMessage = xml
 
@@ -1330,7 +1331,7 @@ class TAKService: ObservableObject {
             #endif
 
             // Route to event handler
-            eventHandler.handle(event: eventType)
+            eventHandler.handle(event: eventType, serverId: serverId)
 
             #if DEBUG
             // Verify cotEvents was updated
@@ -1504,14 +1505,19 @@ class TAKService: ObservableObject {
         }
     }
 
-    func sendCoT(xml: String) -> Bool {
+    /// Send a CoT. When `toServerId` is non-nil, sends ONLY to that server
+    /// (used for per-server direct-message routing); nil broadcasts to every
+    /// connected server (group / all-chat / position).
+    func sendCoT(xml: String, toServerId: UUID? = nil) -> Bool {
         // Send to all connected servers
         // IMPORTANT: Check actual sender.isConnected (NWConnection state) not cached state
         // The cached ServerConnectionState.isConnected can get out of sync
         connectionsLock.lock()
         let allConnections = Array(serverConnections.values)
-        // Filter by actual connection state, not cached state
-        let connectedSenders = allConnections.filter { $0.sender.isConnected }.map { $0.sender }
+        // Filter by actual connection state, and by target server when routing a DM.
+        let connectedSenders = allConnections
+            .filter { $0.sender.isConnected && (toServerId == nil || $0.serverId == toServerId) }
+            .map { $0.sender }
         let totalConnections = allConnections.count
         let connectedCount = connectedSenders.count
 
@@ -1535,6 +1541,12 @@ class TAKService: ObservableObject {
         #endif
 
         guard !connectedSenders.isEmpty else {
+            // A DM targeted a specific server that isn't connected — don't
+            // silently fall back to the legacy connection (wrong server).
+            if toServerId != nil {
+                Logger.takNetwork.error("sendCoT: target server not connected; DM not sent")
+                return false
+            }
             // Fallback to legacy connection
             #if DEBUG
             print("📤 [SEND] No multi-server connections, trying legacy connection...")


### PR DESCRIPTION
Brings chat in line with multi-server connections.

## Problem
Chat was single-server: received messages weren't attributed to any server, a DM with the same callsign on two servers collapsed into one thread, and every send blasted to all connected servers.

## Changes
- `ChatMessage` / `ChatParticipant` / `Conversation` gain `serverId`.
- **Receive attribution**: source server id is threaded `TAKService.handleReceivedMessage` → `CoTEventHandler.handle(event:serverId:)` → `ChatManager.receiveMessage`.
- **Per-server DMs**: DM conversation ids include the server id, so the same contact on two servers is two separate threads. The merged **All Chat Users** room stays single, with a per-message server badge.
- **Send routing**: DMs go only to their conversation's server (`TAKService.sendCoT(xml:toServerId:)`); group/all-chat still broadcasts to all.
- **UI**: a colored `ChatServerBadge` on received message bubbles and on per-server DM rows.

Builds clean (SourceKit noise aside). 

## Follow-ups
- Attribute position-update-derived contacts to their server (so the New Chat contact list + DMs route for position-only contacts).
- Optional: per-server "All Chat" rooms instead of one merged room.

Pairs with the cert-resolver fix (#36, merged).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>