### PR TITLE
fix(chat/ios): port GAP-115 — broadcast row + contact stubs

### DIFF
--- a/OmniTAKMobile/Features/Chat/Views/ChatView.swift
+++ b/OmniTAKMobile/Features/Chat/Views/ChatView.swift
@@ -2,41 +2,86 @@
 //  ChatView.swift
 //  OmniTAKTest
 //
-//  Conversation list UI with unread counts
+//  Conversation list UI with unread counts.
+//
+//  GAP-115-ios: Chat screen now merges ChatManager.conversations with
+//  ChatManager.participants so every EUD seen on the map (via PPLI/CoT) appears
+//  as a contact, even if they have never sent a GeoChat message.
+//  The broadcast "All Chat Users" row is always pinned at the top regardless
+//  of whether any messages have been exchanged.
+//
+//  Port of Android PR #48 (GAP-115, v0.33.0).
 //
 
 import SwiftUI
+
+// MARK: - ChatView
 
 struct ChatView: View {
     @ObservedObject var chatManager: ChatManager
     @State private var showNewChat = false
     @Environment(\.dismiss) var dismiss
 
+    // The broadcast / all-users conversation — always present after init.
+    var allUsersConversation: Conversation? {
+        chatManager.conversations.first { $0.id == ChatRoom.allUsersId }
+    }
+
+    // Real DM/group threads (excludes the broadcast row which is pinned separately).
     var sortedConversations: [Conversation] {
-        chatManager.conversations.sorted { $0.lastActivity > $1.lastActivity }
+        chatManager.conversations
+            .filter { $0.id != ChatRoom.allUsersId }
+            .sorted { $0.lastActivity > $1.lastActivity }
+    }
+
+    // Participants that do NOT yet have a DM thread.  De-duped by UID; own
+    // device excluded.  Mirrors Android's ContactStore → conversation stub
+    // approach from GAP-115 / PR #48.
+    var contactStubs: [ChatParticipant] {
+        let existingUids = Set(
+            chatManager.conversations
+                .filter { !$0.isGroupChat }
+                .compactMap { $0.participants.first?.id }
+        )
+        return chatManager.participants
+            .filter { $0.id != chatManager.currentUserId && !existingUids.contains($0.id) }
+            .sorted { $0.callsign < $1.callsign }
     }
 
     var body: some View {
         NavigationView {
-            ZStack {
-                if chatManager.conversations.isEmpty {
-                    // Empty state
-                    VStack(spacing: 16) {
-                        Image(systemName: "bubble.left.and.bubble.right")
-                            .font(.system(size: 64))
-                            .foregroundColor(.gray)
-                        Text("No Conversations")
-                            .font(.title2)
-                            .foregroundColor(.gray)
-                        Text("Start a new chat to begin messaging")
-                            .font(.subheadline)
-                            .foregroundColor(.gray)
-                            .multilineTextAlignment(.center)
+            List {
+                // ── Broadcast row — always visible ──────────────────────────
+                Section {
+                    if let broadcast = allUsersConversation {
+                        NavigationLink(destination: ConversationView(
+                            chatManager: chatManager,
+                            conversation: broadcast
+                        )) {
+                            ConversationRow(conversation: broadcast)
+                        }
+                    } else {
+                        // setupDefaultConversations() is async; show a placeholder
+                        // so the row is never invisible while it loads.
+                        HStack(spacing: 12) {
+                            ZStack {
+                                Circle().fill(Color.blue).frame(width: 50, height: 50)
+                                Image(systemName: "person.3.fill").foregroundColor(.white).font(.system(size: 20))
+                            }
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(ChatRoom.allUsersTitle)
+                                    .font(.system(size: 16, weight: .semibold))
+                                Text("No messages yet")
+                                    .font(.system(size: 14)).foregroundColor(.gray).italic()
+                            }
+                        }
+                        .padding(.vertical, 4)
                     }
-                    .padding()
-                } else {
-                    // Conversation list
-                    List {
+                }
+
+                // ── Active DM / group threads ───────────────────────────────
+                if !sortedConversations.isEmpty {
+                    Section("DIRECT MESSAGES") {
                         ForEach(sortedConversations) { conversation in
                             NavigationLink(destination: ConversationView(
                                 chatManager: chatManager,
@@ -47,16 +92,45 @@ struct ChatView: View {
                         }
                         .onDelete(perform: deleteConversations)
                     }
-                    .listStyle(.insetGrouped)
+                }
+
+                // ── Contact stubs (EUDs seen on map, no chat yet) ───────────
+                if !contactStubs.isEmpty {
+                    Section("KNOWN CONTACTS") {
+                        ForEach(contactStubs) { participant in
+                            Button(action: {
+                                openOrCreateConversation(with: participant)
+                            }) {
+                                ContactStubRow(participant: participant)
+                            }
+                        }
+                    }
+                }
+
+                // ── Empty hint if nothing at all is visible ─────────────────
+                if sortedConversations.isEmpty && contactStubs.isEmpty {
+                    Section {
+                        VStack(spacing: 12) {
+                            Image(systemName: "antenna.radiowaves.left.and.right")
+                                .font(.system(size: 40))
+                                .foregroundColor(.gray)
+                            Text("No contacts yet")
+                                .font(.subheadline).foregroundColor(.gray)
+                            Text("Contacts appear as units come online. Use \"All Chat Users\" to broadcast.")
+                                .font(.caption).foregroundColor(.gray)
+                                .multilineTextAlignment(.center)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                    }
                 }
             }
-            .navigationTitle("Team Chat")
+            .listStyle(.insetGrouped)
+            .navigationTitle("All Chat Users")
             .navigationBarTitleDisplayMode(.large)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Close") {
-                        dismiss()
-                    }
+                    Button("Close") { dismiss() }
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: { showNewChat = true }) {
@@ -70,14 +144,60 @@ struct ChatView: View {
         }
     }
 
+    // Tap on a contact stub → get-or-create conversation, then navigate
+    // by injecting it into conversations so ConversationView can find it.
+    private func openOrCreateConversation(with participant: ChatParticipant) {
+        _ = chatManager.getOrCreateDirectConversation(with: participant)
+        // The new conversation will appear in sortedConversations on next
+        // render; dismiss the sheet so the user sees it in the list.
+        showNewChat = false
+    }
+
     private func deleteConversations(at offsets: IndexSet) {
         for index in offsets {
             let conversation = sortedConversations[index]
-            // Don't allow deleting "All Chat Users"
             if conversation.id != ChatRoom.allUsersId {
                 chatManager.deleteConversation(conversation)
             }
         }
+    }
+}
+
+// MARK: - ContactStubRow
+
+/// Renders a known EUD (from PPLI) that has no conversation thread yet.
+/// Visual design matches ConversationRow so the list looks uniform.
+struct ContactStubRow: View {
+    let participant: ChatParticipant
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(participant.isOnline ? Color.green : Color.gray)
+                    .frame(width: 50, height: 50)
+                Image(systemName: "person.fill")
+                    .foregroundColor(.white)
+                    .font(.system(size: 20))
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(participant.callsign)
+                        .font(.system(size: 16, weight: .semibold))
+                        .lineLimit(1)
+                    ChatServerBadge(serverId: participant.serverId)
+                    Spacer()
+                }
+
+                Text("No messages yet")
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+                    .italic()
+            }
+        }
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
     }
 }
 


### PR DESCRIPTION
## Summary

Ports Android PR engindearing-projects/OmniTAK-Android#48 (GAP-115) to iOS. The chat list now always shows the \"All Chat Users\" broadcast row and surfaces every known participant as a \"no messages yet\" stub.

## Before / After

| Before | After |
|---|---|
| Chat → All Chat Users showed empty body | Chat tab shows \"All Chat Users\" broadcast row always; KNOWN CONTACTS section appears as participants populate; helpful empty state when neither has any entries |

(Verified on iPhone 17 Pro sim — see screenshots in PR thread.)

## What changed

- \`ChatView.swift\`: ConversationListView merges \`ChatManager.conversations\` + \`ChatManager.participants\` (de-duped by UID, own UID excluded). Broadcast row pinned at the top with a placeholder while \`setupDefaultConversations()\` resolves. Tapping a stub calls \`getOrCreateDirectConversation(with:)\` which seeds participant metadata for the send path.

## Known follow-ups (separate PRs)

1. **\`ChatManager.participants\` registry never gets fed from incoming PPLI/CoT.** Stubs UI is ready; data plumbing is broken. Even with EUDs visible on the map (Silver Spring server, ALPHA-1 callsign), the New Chat sheet shows \"No participants available.\"
2. **\`ConversationView\` body is empty for zero-message conversations.** Tapping a broadcast/DM with no history shows just the title + back chevron, no compose box. Compose box should always render so user can send the first message.

## Reporter
Reported by J on iOS sim 2026-05-27 after shipping Android fix in v0.33.0.