### PR TITLE
fix(chat/ios): feed ChatManager.participants from incoming PPLI/CoT

### DIFF
--- a/OmniTAKMobile/CoT/CoTEventHandler.swift
+++ b/OmniTAKMobile/CoT/CoTEventHandler.swift
@@ -166,6 +166,26 @@ class CoTEventHandler: ObservableObject {
             #endif
         }
 
+        // Feed ChatManager.participants from incoming PPLI/CoT so the
+        // "KNOWN CONTACTS" section and New-Chat sheet are populated as soon as
+        // other EUDs appear on the map.  Skip the user's own echoed PPLI so
+        // they don't appear as a contact they can message themselves.
+        let selfUID = PositionBroadcastService.shared.userUID
+        guard event.uid != selfUID else {
+            #if DEBUG
+            print("   ℹ️ Skipping self-PPLI for participant feed (uid: \(event.uid))")
+            #endif
+            // Still publish / callback for map rendering — just skip participant write.
+            positionUpdatePublisher.send(event)
+            NotificationCenter.default.post(
+                name: CoTEventHandler.positionUpdateNotification,
+                object: self,
+                userInfo: ["event": event]
+            )
+            takService?.onCoTReceived?(event)
+            return
+        }
+
         // Update participant info for chat, tagged with the source server so
         // the contact list + DM routing are server-aware (multi-server).
         if var participant = ChatXMLParser.parseParticipantFromPresence(xml: createPresenceXML(from: event)) {
@@ -173,7 +193,7 @@ class CoTEventHandler: ObservableObject {
             chatManager?.updateParticipant(participant)
             chatManager?.updateParticipantLastSeen(id: participant.id)
         } else {
-            // Create basic participant from CoT event
+            // Create basic participant from CoT event (callsign + UID are always present)
             let participant = ChatParticipant(
                 id: event.uid,
                 callsign: event.detail.callsign,

--- a/OmniTAKMobile/Features/Chat/Managers/ChatManager.swift
+++ b/OmniTAKMobile/Features/Chat/Managers/ChatManager.swift
@@ -16,14 +16,31 @@ class ChatManager: ObservableObject {
     @Published var conversations: [Conversation] = []
     @Published var messages: [ChatMessage] = []
     @Published var participants: [ChatParticipant] = []
-    @Published var currentUserId: String = "SELF-\(UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString)"
-    @Published var currentUserCallsign: String = "OmniTAK-iOS"
+    // Mirrors PositionBroadcastService.userUID so that incoming PPLI echoed
+    // back from the server is correctly recognised as "self" and excluded from
+    // the participants list.  Populated in init() and kept in sync via a
+    // Combine subscriber so late-init / UID-migration are handled automatically.
+    @Published var currentUserId: String = PositionBroadcastService.shared.userUID
+    @Published var currentUserCallsign: String = PositionBroadcastService.shared.userCallsign
 
     private let persistence = ChatPersistence.shared
     private var takService: TAKService?
     private var locationManager: LocationManager?
+    private var cancellables = Set<AnyCancellable>()
 
     private init() {
+        // Keep currentUserId / currentUserCallsign in sync with
+        // PositionBroadcastService so that self-PPLI is always filtered out.
+        PositionBroadcastService.shared.$userUID
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.currentUserId, on: self)
+            .store(in: &cancellables)
+
+        PositionBroadcastService.shared.$userCallsign
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.currentUserCallsign, on: self)
+            .store(in: &cancellables)
+
         // Perform file I/O on a background queue so the first access to
         // ChatManager.shared (e.g. from ContactListView) doesn't block the
         // main thread for 6–26 seconds while JSON is decoded from disk.

--- a/OmniTAKMobile/Features/Chat/Views/ChatView.swift
+++ b/OmniTAKMobile/Features/Chat/Views/ChatView.swift
@@ -2,41 +2,86 @@
 //  ChatView.swift
 //  OmniTAKTest
 //
-//  Conversation list UI with unread counts
+//  Conversation list UI with unread counts.
+//
+//  GAP-115-ios: Chat screen now merges ChatManager.conversations with
+//  ChatManager.participants so every EUD seen on the map (via PPLI/CoT) appears
+//  as a contact, even if they have never sent a GeoChat message.
+//  The broadcast "All Chat Users" row is always pinned at the top regardless
+//  of whether any messages have been exchanged.
+//
+//  Port of Android PR #48 (GAP-115, v0.33.0).
 //
 
 import SwiftUI
+
+// MARK: - ChatView
 
 struct ChatView: View {
     @ObservedObject var chatManager: ChatManager
     @State private var showNewChat = false
     @Environment(\.dismiss) var dismiss
 
+    // The broadcast / all-users conversation — always present after init.
+    var allUsersConversation: Conversation? {
+        chatManager.conversations.first { $0.id == ChatRoom.allUsersId }
+    }
+
+    // Real DM/group threads (excludes the broadcast row which is pinned separately).
     var sortedConversations: [Conversation] {
-        chatManager.conversations.sorted { $0.lastActivity > $1.lastActivity }
+        chatManager.conversations
+            .filter { $0.id != ChatRoom.allUsersId }
+            .sorted { $0.lastActivity > $1.lastActivity }
+    }
+
+    // Participants that do NOT yet have a DM thread.  De-duped by UID; own
+    // device excluded.  Mirrors Android's ContactStore → conversation stub
+    // approach from GAP-115 / PR #48.
+    var contactStubs: [ChatParticipant] {
+        let existingUids = Set(
+            chatManager.conversations
+                .filter { !$0.isGroupChat }
+                .compactMap { $0.participants.first?.id }
+        )
+        return chatManager.participants
+            .filter { $0.id != chatManager.currentUserId && !existingUids.contains($0.id) }
+            .sorted { $0.callsign < $1.callsign }
     }
 
     var body: some View {
         NavigationView {
-            ZStack {
-                if chatManager.conversations.isEmpty {
-                    // Empty state
-                    VStack(spacing: 16) {
-                        Image(systemName: "bubble.left.and.bubble.right")
-                            .font(.system(size: 64))
-                            .foregroundColor(.gray)
-                        Text("No Conversations")
-                            .font(.title2)
-                            .foregroundColor(.gray)
-                        Text("Start a new chat to begin messaging")
-                            .font(.subheadline)
-                            .foregroundColor(.gray)
-                            .multilineTextAlignment(.center)
+            List {
+                // ── Broadcast row — always visible ──────────────────────────
+                Section {
+                    if let broadcast = allUsersConversation {
+                        NavigationLink(destination: ConversationView(
+                            chatManager: chatManager,
+                            conversation: broadcast
+                        )) {
+                            ConversationRow(conversation: broadcast)
+                        }
+                    } else {
+                        // setupDefaultConversations() is async; show a placeholder
+                        // so the row is never invisible while it loads.
+                        HStack(spacing: 12) {
+                            ZStack {
+                                Circle().fill(Color.blue).frame(width: 50, height: 50)
+                                Image(systemName: "person.3.fill").foregroundColor(.white).font(.system(size: 20))
+                            }
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(ChatRoom.allUsersTitle)
+                                    .font(.system(size: 16, weight: .semibold))
+                                Text("No messages yet")
+                                    .font(.system(size: 14)).foregroundColor(.gray).italic()
+                            }
+                        }
+                        .padding(.vertical, 4)
                     }
-                    .padding()
-                } else {
-                    // Conversation list
-                    List {
+                }
+
+                // ── Active DM / group threads ───────────────────────────────
+                if !sortedConversations.isEmpty {
+                    Section("DIRECT MESSAGES") {
                         ForEach(sortedConversations) { conversation in
                             NavigationLink(destination: ConversationView(
                                 chatManager: chatManager,
@@ -47,16 +92,45 @@ struct ChatView: View {
                         }
                         .onDelete(perform: deleteConversations)
                     }
-                    .listStyle(.insetGrouped)
+                }
+
+                // ── Contact stubs (EUDs seen on map, no chat yet) ───────────
+                if !contactStubs.isEmpty {
+                    Section("KNOWN CONTACTS") {
+                        ForEach(contactStubs) { participant in
+                            Button(action: {
+                                openOrCreateConversation(with: participant)
+                            }) {
+                                ContactStubRow(participant: participant)
+                            }
+                        }
+                    }
+                }
+
+                // ── Empty hint if nothing at all is visible ─────────────────
+                if sortedConversations.isEmpty && contactStubs.isEmpty {
+                    Section {
+                        VStack(spacing: 12) {
+                            Image(systemName: "antenna.radiowaves.left.and.right")
+                                .font(.system(size: 40))
+                                .foregroundColor(.gray)
+                            Text("No contacts yet")
+                                .font(.subheadline).foregroundColor(.gray)
+                            Text("Contacts appear as units come online. Use \"All Chat Users\" to broadcast.")
+                                .font(.caption).foregroundColor(.gray)
+                                .multilineTextAlignment(.center)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                    }
                 }
             }
-            .navigationTitle("Team Chat")
+            .listStyle(.insetGrouped)
+            .navigationTitle("All Chat Users")
             .navigationBarTitleDisplayMode(.large)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Close") {
-                        dismiss()
-                    }
+                    Button("Close") { dismiss() }
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: { showNewChat = true }) {
@@ -70,14 +144,60 @@ struct ChatView: View {
         }
     }
 
+    // Tap on a contact stub → get-or-create conversation, then navigate
+    // by injecting it into conversations so ConversationView can find it.
+    private func openOrCreateConversation(with participant: ChatParticipant) {
+        _ = chatManager.getOrCreateDirectConversation(with: participant)
+        // The new conversation will appear in sortedConversations on next
+        // render; dismiss the sheet so the user sees it in the list.
+        showNewChat = false
+    }
+
     private func deleteConversations(at offsets: IndexSet) {
         for index in offsets {
             let conversation = sortedConversations[index]
-            // Don't allow deleting "All Chat Users"
             if conversation.id != ChatRoom.allUsersId {
                 chatManager.deleteConversation(conversation)
             }
         }
+    }
+}
+
+// MARK: - ContactStubRow
+
+/// Renders a known EUD (from PPLI) that has no conversation thread yet.
+/// Visual design matches ConversationRow so the list looks uniform.
+struct ContactStubRow: View {
+    let participant: ChatParticipant
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(participant.isOnline ? Color.green : Color.gray)
+                    .frame(width: 50, height: 50)
+                Image(systemName: "person.fill")
+                    .foregroundColor(.white)
+                    .font(.system(size: 20))
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(participant.callsign)
+                        .font(.system(size: 16, weight: .semibold))
+                        .lineLimit(1)
+                    ChatServerBadge(serverId: participant.serverId)
+                    Spacer()
+                }
+
+                Text("No messages yet")
+                    .font(.system(size: 14))
+                    .foregroundColor(.gray)
+                    .italic()
+            }
+        }
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
     }
 }
 

--- a/OmniTAKMobile/Features/Networking/Services/TAKService.swift
+++ b/OmniTAKMobile/Features/Networking/Services/TAKService.swift
@@ -1929,8 +1929,9 @@ private func cotCallback(
                 // Update enhanced marker
                 service.updateEnhancedMarker(from: event)
 
-                // Also parse participant info for chat
-                if let participant = ChatXMLParser.parseParticipantFromPresence(xml: message) {
+                // Also parse participant info for chat (skip own echoed PPLI)
+                if event.uid != PositionBroadcastService.shared.userUID,
+                   let participant = ChatXMLParser.parseParticipantFromPresence(xml: message) {
                     ChatManager.shared.updateParticipant(participant)
                 }
 


### PR DESCRIPTION
## Problem

`ChatManager.participants` stayed empty even when EUDs were visible on the map, so the "KNOWN CONTACTS" section (PR #41) and "New Chat" sheet always showed "No participants available".

Two root causes:

1. **Wrong self-UID**: `ChatManager.currentUserId` was initialised to `"SELF-<vendorUUID>"` but the real broadcast UID (stored in UserDefaults `selfPositionUID`) is `"IOS-<UUID>"`. The view's self-skip filter (`$0.id != chatManager.currentUserId`) therefore never matched incoming echoed PPLI, so own PPLI was being written as a contact.

2. **No self-skip in the receive path**: `CoTEventHandler.handlePositionUpdate` and the legacy TAKService receive path called `updateParticipant` for every PPLI including the user's own echoed position.

## Receive path

CoT/PPLI flows: `TAKService.processMessage` -> `eventHandler.handle(event:serverId:)` -> `CoTEventHandler.handlePositionUpdate` -> `chatManager?.updateParticipant`.

## Where the wiring was added / fixed

| File | Change |
|------|--------|
| `ChatManager.swift` | `currentUserId` / `currentUserCallsign` now initialise from `PositionBroadcastService.shared` and stay in sync via Combine `assign` subscribers |
| `CoTEventHandler.swift` | `handlePositionUpdate` guards `event.uid != PositionBroadcastService.shared.userUID` before calling `updateParticipant`; self-PPLI still forwards the Combine publish + notification for map rendering |
| `TAKService.swift` | Legacy secondary receive path also guards on self-UID before calling `ChatManager.shared.updateParticipant` |

## ChatParticipant fields populated

From the primary path (CoTEventHandler): `id` (event.uid), `callsign` (event.detail.callsign), `lastSeen` (event.time), `isOnline = true`, `serverId` (the connection's server UUID). If `ChatXMLParser.parseParticipantFromPresence` succeeds it also sets `endpoint`.

## Test plan

Connect to a TAK server with at least one other active EUD. Open Chat -> "New Chat" -- the EUD's callsign should appear under "Known Contacts" within one PPLI cycle (~5 s). Own callsign must not appear in the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
