### PR TITLE
fix(chat/ios): always render compose box, even for empty conversations

### DIFF
--- a/OmniTAKMobile/Features/Chat/Views/ConversationView.swift
+++ b/OmniTAKMobile/Features/Chat/Views/ConversationView.swift
@@ -25,19 +25,35 @@ struct ConversationView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Messages list
+            // Messages list — or empty state when the thread is new
             ScrollViewReader { proxy in
                 ScrollView {
-                    LazyVStack(spacing: 12) {
-                        ForEach(messages) { message in
-                            MessageBubble(
-                                message: message,
-                                isFromSelf: message.isFromSelf
-                            )
-                            .id(message.id)
+                    if messages.isEmpty {
+                        // Empty-state hint so the user knows where to type.
+                        // The compose box is always rendered below; this just
+                        // fills the white void so the screen doesn't look broken.
+                        VStack(spacing: 12) {
+                            Image(systemName: "bubble.left.and.bubble.right")
+                                .font(.system(size: 48))
+                                .foregroundColor(Color(.systemGray3))
+                            Text("Send the first message")
+                                .font(.subheadline)
+                                .foregroundColor(Color(.systemGray2))
                         }
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 80)
+                    } else {
+                        LazyVStack(spacing: 12) {
+                            ForEach(messages) { message in
+                                MessageBubble(
+                                    message: message,
+                                    isFromSelf: message.isFromSelf
+                                )
+                                .id(message.id)
+                            }
+                        }
+                        .padding()
                     }
-                    .padding()
                 }
                 .onAppear {
                     scrollProxy = proxy


### PR DESCRIPTION
## Problem

When a conversation had zero messages (e.g. tapping into "All Chat Users" before any GeoChat traffic), `ConversationView` rendered blank — title + back chevron only. The compose box **was** always in the layout, but the `ScrollViewReader > ScrollView > LazyVStack` above it expanded to fill all available vertical space with nothing in it. The result was a white void that made the screen appear broken, and the compose row at the very bottom was easy to miss or invisible depending on keyboard/safe-area state.

## Root cause

No offending conditional was hiding the compose row — it was always unconditional. The real culprit: the `ScrollView` rendered a fully-expanded empty white rectangle (filling the VStack flex space) with zero visual affordance that a compose box existed below it. Users interpreted the blank scroll area as a non-functional screen.

## What changed

`ConversationView.swift` only:

- When `messages.isEmpty`, the scroll area now renders a centered empty-state instead of nothing:
  - `bubble.left.and.bubble.right` SF Symbol (48pt, gray)
  - "Send the first message" subtitle
- When messages exist, renders the existing `LazyVStack` of `MessageBubble` rows — unchanged behavior.
- The compose HStack (photo button + TextField + send button) is **unconditional** in both paths, as it already was.

## Test plan

Open Chat → tap "All Chat Users" (zero messages) → verify: empty-state hint appears, compose TextField is focused-able, typing and tapping send dispatches a GeoChat CoT message.