### PR TITLE
fix(chat/ios): clear floating tab bar so compose box is visible

### DIFF
--- a/OmniTAKMobile/Features/Chat/Views/ConversationView.swift
+++ b/OmniTAKMobile/Features/Chat/Views/ConversationView.swift
@@ -126,6 +126,10 @@ struct ConversationView: View {
             }
             .padding(.horizontal)
             .padding(.vertical, 8)
+            // Floating CustomToolbar (RootTabView .overlay) covers ~80pt at
+            // the bottom of every screen. Push the compose row above it so
+            // the TextField + send button aren't hidden behind the tab bar.
+            .padding(.bottom, 80)
             .background(Color(.systemBackground))
         }
         .navigationTitle(conversation.displayTitle)


### PR DESCRIPTION
## Summary

Follow-up to #43. The compose row (TextField + send button) was rendering at the bottom of \`ConversationView\` correctly, but \`RootTabView\` overlays the floating \`CustomToolbar\` capsule on top of every screen via \`.overlay(alignment: .bottom)\`. The compose row landed underneath the capsule and was invisible.

Verified by J on iPhone 17 Pro sim — empty state (#43) renders fine, but the screen below the \"Send the first message\" hint was completely blank because the compose row was hidden.

## Fix

Adds \`.padding(.bottom, 80)\` to the compose HStack to push it above the floating toolbar. 80pt approximates the visible capsule height (capsule + safe area).

## Test plan

- [ ] Tap any contact stub → DRONE-01 conversation opens with \"Send the first message\" hint AND visible compose box at bottom
- [ ] Type a message → send button enables
- [ ] Send → message bubble appears, compose still visible