### PR TITLE
feat: zh-Hant (繁體中文) localization, wired into picker

### DIFF
--- a/OmniTAKMobile.xcodeproj/project.pbxproj
+++ b/OmniTAKMobile.xcodeproj/project.pbxproj
@@ -719,6 +719,7 @@
 		E6426A4780DEDD91B5DA2B46 /* SFAPMFT----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFAPMFT----.svg"; sourceTree = "<group>"; };
 		E763527D180A2BFA06815720 /* SHAPMFQ----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHAPMFQ----.svg"; sourceTree = "<group>"; };
 		E7CD94F2AA3C9E1621AE6021 /* es */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = es; path = OmniTAKMobile/Resources/es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		D9B49FD9370499A376CCF228 /* zh-Hant */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "OmniTAKMobile/Resources/zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		E7CED1E79EF4463A98DDA34A /* MapLibre3DSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MapLibre3DSettingsView.swift; path = OmniTAKMobile/Features/Map/MapLibre/MapLibre3DSettingsView.swift; sourceTree = "<group>"; };
 		EA171D08B8BECD16ACA18D51 /* SHGP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGP-------.svg"; sourceTree = "<group>"; };
 		EA4A86523E550E87AC1EE8A4 /* SALUTEReportView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SALUTEReportView.swift; path = OmniTAKMobile/Features/Military/Views/SALUTEReportView.swift; sourceTree = "<group>"; };
@@ -2364,6 +2365,7 @@
 				de,
 				fr,
 				es,
+				"zh-Hant",
 			);
 			mainGroup = A1111111111111111111111100000071;
 			packageReferences = (
@@ -2790,6 +2792,7 @@
 				6573C607EB2B7E7F82B0B79D /* de */,
 				B1F80E89642B38A496E02F12 /* fr */,
 				E7CD94F2AA3C9E1621AE6021 /* es */,
+				D9B49FD9370499A376CCF228 /* zh-Hant */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/OmniTAKMobile/Core/Localization/LocalizationManager.swift
+++ b/OmniTAKMobile/Core/Localization/LocalizationManager.swift
@@ -44,6 +44,7 @@ final class LocalizationManager: ObservableObject {
         case german    = "de"
         case french    = "fr"
         case spanish   = "es"
+        case traditionalChinese = "zh-Hant"
 
         var id: String { rawValue }
 
@@ -57,6 +58,7 @@ final class LocalizationManager: ObservableObject {
             case .german:    return "Deutsch"
             case .french:    return "Français"
             case .spanish:   return "Español"
+            case .traditionalChinese: return "繁體中文"
             }
         }
 
@@ -70,6 +72,7 @@ final class LocalizationManager: ObservableObject {
             case .german:    return "🇩🇪"
             case .french:    return "🇫🇷"
             case .spanish:   return "🇪🇸"
+            case .traditionalChinese: return "🇹🇼"
             }
         }
     }
@@ -155,6 +158,17 @@ final class LocalizationManager: ObservableObject {
     /// OmniTAK ships. Falls back to English.
     private static func systemDefault() -> Language {
         for preferred in Locale.preferredLanguages {
+            let lower = preferred.lowercased()
+            // Script-aware match first so "zh-Hant-TW" resolves to
+            // zh-Hant rather than collapsing to a bare "zh" (which we
+            // don't ship). Longer raw values are checked naturally
+            // since a script tag only matches its own prefix.
+            if let match = Language.allCases.first(where: {
+                lower.hasPrefix($0.rawValue.lowercased())
+            }) {
+                return match
+            }
+            // Bare two-letter subtag (e.g. "fr-CA" → fr).
             let code = String(preferred.prefix(2)).lowercased()
             if let match = Language(rawValue: code) {
                 return match

--- a/OmniTAKMobile/Resources/zh-Hant.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,123 @@
+/* OmniTAK Mobile — English (base catalogue)
+   v1 scope: onboarding flow + Settings screen.
+   Other screens fall back to these English strings until later
+   localization passes extend coverage. */
+
+/* --- Onboarding navigation --- */
+"onboarding.skip" = "跳過";
+"onboarding.continue" = "繼續";
+"onboarding.getStarted" = "開始使用";
+"onboarding.back" = "返回";
+
+/* --- Onboarding page 1: Welcome --- */
+"onboarding.page1.title" = "歡迎使用 OmniTAK";
+"onboarding.page1.desc" = "專為 Team Awareness Kit (TAK) 伺服器打造的強大 iOS 客戶端。即時連線、共享與協作。";
+"onboarding.page1.feature1" = "即時位置共享";
+"onboarding.page1.feature2" = "安全通訊";
+"onboarding.page1.feature3" = "地圖态势感知";
+"onboarding.page1.feature4" = "多平台支援";
+
+/* --- Onboarding page 2: Secure & Certified --- */
+"onboarding.page2.title" = "安全與認證";
+"onboarding.page2.desc" = "OmniTAK 支援憑證式身份驗證，可安全連線至 TAK 伺服器。";
+"onboarding.page2.feature1" = "客戶端憑證支援";
+"onboarding.page2.feature2" = "TLS/SSL 加密";
+"onboarding.page2.feature3" = "鑰匙圈整合";
+"onboarding.page2.feature4" = "自動註冊";
+
+/* --- Onboarding page 3: Quick & Easy Setup --- */
+"onboarding.page3.title" = "快速簡易設定";
+"onboarding.page3.desc" = "透過智慧設定精靈，數秒內完成連線。多種連線方式因應各種情境。";
+"onboarding.page3.feature1" = "QR 碼掃描";
+"onboarding.page3.feature2" = "自動發現";
+"onboarding.page3.feature3" = "常見預設";
+"onboarding.page3.feature4" = "手動設定";
+
+/* --- Onboarding page 4: Ready to Connect --- */
+"onboarding.page4.title" = "準備連線？";
+"onboarding.page4.desc" = "讓我們將您連線至 TAK 伺服器。選擇最適合您的方式。";
+"onboarding.page4.feature1" = "30 秒內完成連線";
+"onboarding.page4.feature2" = "無需技術知識";
+"onboarding.page4.feature3" = "完整 ATAK 相容性";
+"onboarding.page4.feature4" = "相容於任何 TAK 伺服器";
+
+/* --- Quick Start Guide --- */
+"quickstart.title" = "快速入門指南";
+"quickstart.subtitle" = "選擇最適合您情況的連線方式";
+"quickstart.done" = "完成";
+"quickstart.needHelp" = "需要協助？";
+"quickstart.help.docs" = "閱讀文件";
+"quickstart.help.support" = "聯絡支援";
+"quickstart.help.videos" = "觀看教學影片";
+"quickstart.item.qr.title" = "掃描 QR 碼";
+"quickstart.item.qr.desc" = "最快速方式 — 掃描 TAK 伺服器管理員提供的註冊 QR 碼";
+"quickstart.item.discover.title" = "自動發現";
+"quickstart.item.discover.desc" = "自動偵測區域網路中的 TAK 伺服器";
+"quickstart.item.quick.title" = "快速設定";
+"quickstart.item.quick.desc" = "使用常見 TAK 伺服器組態的預設值";
+"quickstart.item.manual.title" = "手動設定";
+"quickstart.item.manual.desc" = "完整控制 — 自行設定所有連線參數";
+"quickstart.difficulty.easiest" = "最簡單";
+"quickstart.difficulty.easy" = "簡單";
+"quickstart.difficulty.advanced" = "進階";
+
+/* --- Settings --- */
+"settings.title" = "設定";
+"settings.done" = "完成";
+"settings.section.userProfile" = "使用者資料";
+"settings.callsign" = "呼號";
+"settings.name" = "姓名";
+"settings.section.servers" = "伺服器";
+"settings.manageServers" = "管理伺服器";
+"settings.section.navigation" = "導航";
+"settings.routeNavigation" = "路線導航";
+"settings.section.mapOverlays" = "地圖疊層";
+"settings.mgrsGridOverlay" = "MGRS 網格疊層";
+"settings.gridDensity" = "網格密度";
+"settings.showGridLabels" = "顯示網格標籤";
+"settings.coordinateFormat" = "座標格式";
+"settings.selfPositionMarker" = "自身位置標記";
+"settings.section.droneDetection" = "無人機偵測";
+"settings.faaRemoteIdScanner" = "FAA Remote ID 掃描器";
+"settings.section.language" = "語言";
+"settings.appLanguage" = "應用程式語言";
+"settings.section.breadcrumbTrails" = "行進軌跡";
+"settings.enableTrails" = "啟用軌跡";
+"settings.maxTrailLength" = "最大軌跡長度";
+"settings.trailColor" = "軌跡顏色";
+"settings.section.display" = "顯示";
+"settings.unitSystem" = "單位系統";
+"settings.section.performance" = "效能";
+"settings.cacheSize" = "快取大小";
+"settings.clearCache" = "清除快取";
+"settings.section.dataManagement" = "資料管理";
+"settings.importDataPackage" = "匯入資料套件";
+"settings.resetToDefaults" = "重設為預設值";
+"settings.section.dangerZone" = "危險操作";
+"settings.clearAllTeamData" = "清除所有團隊資料";
+
+/* --- Settings: picker option values + alerts (v1.1 — full text coverage) --- */
+"settings.atakStyle" = "ATAK 風格";
+"settings.coord.dd" = "十進位度數 (DD)";
+"settings.coord.dm" = "度分 (DM)";
+"settings.coord.dms" = "度分秒 (DMS)";
+"settings.coord.bng" = "英國國家網格 (BNG)";
+"settings.coord.bngHelp" = "BNG 針對英國/愛爾蘭最佳化（49°N-61°N, 9°W-2°E）。使用 OSGB36 基準與 SU、TQ、NT 等網格方格。";
+"settings.marker.milstd" = "MIL-STD 符號";
+"settings.marker.bullseye" = "靶心（舊版）";
+"settings.color.cyan" = "青色";
+"settings.color.green" = "綠色";
+"settings.color.orange" = "橘色";
+"settings.color.red" = "紅色";
+"settings.color.blue" = "藍色";
+"settings.unit.metric" = "公制（km, m, km/h）";
+"settings.unit.imperial" = "英制（mi, ft, mph）";
+"settings.trailPoints" = "%d 個點";
+"settings.cacheCleared.title" = "快取已清除";
+"settings.ok" = "確定";
+"settings.droneDetection.desc" = "監聽附近無人機（DJI Mavic、Skydio、Autel）透過藍芽廣播的 FAA Remote ID。偵測到的無人機將以未知空域 UAS 目標顯示在地圖上。可接收藍芽廣播的 Remote ID 子集；WiFi 訊號廣播需搭配 gy6 感測器。藍芽掃描會消耗電池。";
+"settings.droneDetection.permHint" = "iOS 將在掃描器首次執行時請求藍芽權限。若切換後無反應，請開啟系統設定 → OmniTAK → 藍芽 並授予存取權限。";
+"quickstart.time.qr" = "< 30 秒";
+"quickstart.time.discover" = "< 1 分鐘";
+"quickstart.time.quick" = "< 2 分鐘";
+"quickstart.time.manual" = "約 3 分鐘";

--- a/OmniTAKMobile/Resources/zh-Hant.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/zh-Hant.lproj/Localizable.strings
@@ -1,7 +1,7 @@
-/* OmniTAK Mobile — English (base catalogue)
+/* OmniTAK Mobile — Traditional Chinese (繁體中文 / zh-Hant)
    v1 scope: onboarding flow + Settings screen.
-   Other screens fall back to these English strings until later
-   localization passes extend coverage. */
+   Untranslated keys fall back to the English base catalogue until
+   later localization passes extend coverage. */
 
 /* --- Onboarding navigation --- */
 "onboarding.skip" = "跳過";


### PR DESCRIPTION
Lands @GavinChangTW's Traditional Chinese localization (#49) with the wiring needed to make it reachable in-app.

## What's included
- **Gavin's translation** (`zh-Hant.lproj/Localizable.strings`) — 103 keys, perfect parity with the English base catalogue; technical terms (TAK, ATAK, MGRS, FAA Remote ID, QR) correctly preserved
- **Wiring** so the catalogue isn't dead on arrival:
  - `traditionalChinese = "zh-Hant"` case in `LocalizationManager.Language` (displayName 繁體中文, 🇹🇼) — this is what the Settings picker iterates
  - Script-aware `systemDefault()` so a `zh-Hant-TW` device resolves to Traditional Chinese instead of collapsing to a bare `zh` we don't ship
  - `zh-Hant` registered in `knownRegions` + the `Localizable.strings` variant group so the `.lproj` actually gets bundled
  - Catalogue header fixed (was copied from the English base)

## Verification
- `xcodebuild ... build` → **BUILD SUCCEEDED** (Debug, iphonesimulator)
- Key parity check: 0 keys in en missing from zh-Hant, 0 extra

Supersedes #49 (couldn't push the wiring into the fork branch — maintainer edits not enabled). Credit to @GavinChangTW; original commit authorship preserved in history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)