### PR TITLE
feat(coords): TWD97 (Taiwan) grid + Go to Coordinate entry

### DIFF
--- a/OmniTAKMobile.xcodeproj/project.pbxproj
+++ b/OmniTAKMobile.xcodeproj/project.pbxproj
@@ -99,7 +99,6 @@
 		40746A5EE6624B31B2E44DB4 /* TAKRestAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9540F19EA7E0D4D8F98FC80F /* TAKRestAPIClient.swift */; };
 		408CC6660B98D38BA2A6A39C /* SHGPEVC----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7D8E2F02A147ACFC3768B6E3 /* SHGPEVC----.svg */; };
 		409D7589A76E63D323F8F8FC /* PointMarkerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F4DD664BBA1341CE945E50 /* PointMarkerModels.swift */; };
-		FEA13B1110000000FEA13B11 /* FemaIconSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA13B1110000000FEA13B22 /* FemaIconSet.swift */; };
 		40BCC83669B81473CF4AEAD6 /* MeshtasticCOTBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD37B36A231B559A5C280059 /* MeshtasticCOTBridge.swift */; };
 		40D04307B87189E2E4A15118 /* KMZHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1103C5349FE3EE31708711A /* KMZHandler.swift */; };
 		42B40E22FFA4AE412996AE66 /* ToolbarAddPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE9342858430C8B11A6138F /* ToolbarAddPalette.swift */; };
@@ -129,10 +128,12 @@
 		5B7A3F868821CF08391437E1 /* RadialMenuItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2916EA38FB5EF4B6AD096E71 /* RadialMenuItemView.swift */; };
 		5C58E7EDABC332301D2411EB /* SHAPACF----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7304715396E84696B2EB3A79 /* SHAPACF----.svg */; };
 		61DDA0586C972AA0A9F0CA5B /* TrackListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7715C9191E25CD00490DB73 /* TrackListView.swift */; };
+		61F47CA6368F4B4692FDE35B /* MissionCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2082BFE46C847409A4690BC /* MissionCreationSheet.swift */; };
 		61F9EBA32E4321879A78EEB0 /* SFGPUSX----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 604E47E40D5637CB6C3A03EB /* SFGPUSX----.svg */; };
 		627C1AF9B1833EE7F5CAFF95 /* KMLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59B3E277182EDF891B3ECAD /* KMLParser.swift */; };
 		62F0E99E6E6CC7D48A777176 /* RadialMenuActionExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C4AE7792EC101310F1483A /* RadialMenuActionExecutor.swift */; };
 		636ABF73E9E4AF843491777E /* SFGPEVC----.svg in Resources */ = {isa = PBXBuildFile; fileRef = EE2FC006021B8F5CE7D6554F /* SFGPEVC----.svg */; };
+		636B2050F7414B9F51ED24C1 /* CoordinateEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9EF53FB6EBD8EDF3F86897D /* CoordinateEntryView.swift */; };
 		664F8613B5F60B743FBF798E /* SUA---------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8D6AFD4385B2CB747A74C320 /* SUA---------.svg */; };
 		6671B330ED4920A501C466DB /* SHSPN------.svg in Resources */ = {isa = PBXBuildFile; fileRef = B1A726FDC5E3383C783799A5 /* SHSPN------.svg */; };
 		669DCCE82BC14EE536DD18ED /* MeshtasticDevicePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D37E8D6422BE44C712E352 /* MeshtasticDevicePickerView.swift */; };
@@ -227,6 +228,7 @@
 		9F360AA41C05B15FC6B71F75 /* EchelonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D5A42ABFBE8EF268B187D8 /* EchelonModels.swift */; };
 		9F4D964068E0E91862AEE361 /* KMLOverlaysPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619B6C2A0B1A1C5237648ED5 /* KMLOverlaysPanel.swift */; };
 		9F975E18CC49BBAC535F8A0B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D9B49FD9370499A376CCF227 /* Localizable.strings */; };
+		A0E27883B3902B6F2FF2FE1C /* TWD97Converter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9E2E310096E7DE7907558F /* TWD97Converter.swift */; };
 		A1645CC72ECC172B00B71E89 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		A1645CC82ECC172B00B71E89 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		A1645CC92ECC172B00B71E89 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
@@ -262,7 +264,6 @@
 		B36DDDD310CB010C14A8DED6 /* EnhancedCoTMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7522ED76D659E2CAEA384D5 /* EnhancedCoTMarker.swift */; };
 		B4930D30352FB62914534BB0 /* TAKService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0E8333659DB4D3BE2BF699 /* TAKService.swift */; };
 		B6DB49544A68E8CE29BAFEDC /* MissionSyncView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D2FE0C197835A47A6E72903 /* MissionSyncView.swift */; };
-		61F47CA6368F4B4692FDE35B /* MissionCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2082BFE46C847409A4690BC /* MissionCreationSheet.swift */; };
 		B70B11FC36F270C4832E614C /* SFGPEV-----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 1C073B77D30C122325D6E02D /* SFGPEV-----.svg */; };
 		B7EF06AABA74804FDBA3131B /* SUSPCL-----.svg in Resources */ = {isa = PBXBuildFile; fileRef = EF7BBAAC9A11F9C68877EBD3 /* SUSPCL-----.svg */; };
 		B80AB7E3B230EE4B07BA73F2 /* MeasurementToolView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5771FBA69E70A6E4BD4764 /* MeasurementToolView.swift */; };
@@ -371,6 +372,7 @@
 		FD86FD4271B91FA6D0759278 /* SHGPEVM----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 31EEBE771BCDBC1102F3FD7D /* SHGPEVM----.svg */; };
 		FD9A668D450BCB86426AEBE1 /* LineOfSightModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD181F0D87FB0E91D14DFE79 /* LineOfSightModels.swift */; };
 		FE237DBC028333E6D711283B /* RangeBearingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843EB86D341D86B368711751 /* RangeBearingOverlay.swift */; };
+		FEA13B1110000000FEA13B11 /* FemaIconSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA13B1110000000FEA13B22 /* FemaIconSet.swift */; };
 		FED47954389F0EA4DB422DD7 /* LassoSelectionPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF88DFDFB03BF594EB88178A /* LassoSelectionPill.swift */; };
 		FFEC4BF9EF64D1B8B6811551 /* CoTFilterCriteria.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E512BE47CF1BD2AFEFB2097 /* CoTFilterCriteria.swift */; };
 /* End PBXBuildFile section */
@@ -404,7 +406,6 @@
 		0CAB30EF2A4D5DDC51F0D945 /* SHGPEVF----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGPEVF----.svg"; sourceTree = "<group>"; };
 		0CFC3F270A71C2F7D59AB900 /* LassoContactPickerSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Views/LassoContactPickerSheet.swift; sourceTree = "<group>"; };
 		0D2FE0C197835A47A6E72903 /* MissionSyncView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MissionSyncView.swift; path = OmniTAKMobile/Features/DataPackages/Views/MissionSyncView.swift; sourceTree = "<group>"; };
-		C2082BFE46C847409A4690BC /* MissionCreationSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MissionCreationSheet.swift; path = OmniTAKMobile/Features/DataPackages/Views/MissionCreationSheet.swift; sourceTree = "<group>"; };
 		0DADFB16189D9AD132105CFF /* SNSP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNSP-------.svg"; sourceTree = "<group>"; };
 		0E1F2A3B4C5D6E7F80910A0C /* RootTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RootTabView.swift; path = OmniTAKMobile/Core/App/RootTabView.swift; sourceTree = "<group>"; };
 		0E3E4F244163FBE4214BC0C6 /* LassoExporters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Services/LassoExporters.swift; sourceTree = "<group>"; };
@@ -426,6 +427,7 @@
 		1648B4732A5A3CEE2F302194 /* MeasurementModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeasurementModels.swift; path = OmniTAKMobile/Features/Measurement/Models/MeasurementModels.swift; sourceTree = "<group>"; };
 		17EF09598A6E3E19F6F83576 /* TileDownloader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TileDownloader.swift; path = OmniTAKMobile/Features/Map/TileSources/TileDownloader.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70801A2B3C4E /* SelfPositionMarkerImage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfPositionMarkerImage.swift; path = OmniTAKMobile/Features/Map/Markers/SelfPositionMarkerImage.swift; sourceTree = "<group>"; };
+		1A9E2E310096E7DE7907558F /* TWD97Converter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Utilities/Converters/TWD97Converter.swift; sourceTree = "<group>"; };
 		1B2F1E34DA7072A77EB08259 /* CertificateFormatConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CertificateFormatConverter.swift; path = OmniTAKMobile/Features/Networking/Managers/CertificateFormatConverter.swift; sourceTree = "<group>"; };
 		1C073B77D30C122325D6E02D /* SFGPEV-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPEV-----.svg"; sourceTree = "<group>"; };
 		1D0FA158CC7E5FC59B052C9D /* SNGPUSM----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNGPUSM----.svg"; sourceTree = "<group>"; };
@@ -583,7 +585,6 @@
 		833DDF1E94F3AD95C29CF6F9 /* NetworkMonitor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkMonitor.swift; path = OmniTAKMobile/Utilities/Network/NetworkMonitor.swift; sourceTree = "<group>"; };
 		843EB86D341D86B368711751 /* RangeBearingOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RangeBearingOverlay.swift; path = OmniTAKMobile/Features/Map/Overlays/RangeBearingOverlay.swift; sourceTree = "<group>"; };
 		84F4DD664BBA1341CE945E50 /* PointMarkerModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PointMarkerModels.swift; path = OmniTAKMobile/Features/Drawing/Models/PointMarkerModels.swift; sourceTree = "<group>"; };
-		FEA13B1110000000FEA13B22 /* FemaIconSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FemaIconSet.swift; path = OmniTAKMobile/Features/Drawing/Models/FemaIconSet.swift; sourceTree = "<group>"; };
 		8777844988BE24F80736AF5F /* RoutePlanningView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RoutePlanningView.swift; path = OmniTAKMobile/Features/Navigation/Views/RoutePlanningView.swift; sourceTree = "<group>"; };
 		88EBE224804115CEB6383CEE /* TeamCoTGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TeamCoTGenerator.swift; path = OmniTAKMobile/CoT/Generators/TeamCoTGenerator.swift; sourceTree = "<group>"; };
 		8957F8C862D78CBC8D9A10ED /* NavigationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NavigationSettingsView.swift; path = OmniTAKMobile/Features/Navigation/Views/NavigationSettingsView.swift; sourceTree = "<group>"; };
@@ -666,6 +667,7 @@
 		BFC510F398E76BD5838AB3A0 /* OfflineMapManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineMapManager.swift; path = OmniTAKMobile/Features/OfflineMaps/Managers/OfflineMapManager.swift; sourceTree = "<group>"; };
 		C046FF14CC38A998A3C9C57A /* MEDEVACRequestView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MEDEVACRequestView.swift; path = OmniTAKMobile/Features/Military/Views/MEDEVACRequestView.swift; sourceTree = "<group>"; };
 		C132B1527EDDA1CD436D2320 /* ElevationProfileModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElevationProfileModels.swift; path = OmniTAKMobile/Features/Measurement/Models/ElevationProfileModels.swift; sourceTree = "<group>"; };
+		C2082BFE46C847409A4690BC /* MissionCreationSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MissionCreationSheet.swift; path = OmniTAKMobile/Features/DataPackages/Views/MissionCreationSheet.swift; sourceTree = "<group>"; };
 		C2DAE3A8F3F0D5B7D8036B3E /* SFAPACF----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFAPACF----.svg"; sourceTree = "<group>"; };
 		C4C6755C8B6629F45526C18E /* SUAPMHQ----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUAPMHQ----.svg"; sourceTree = "<group>"; };
 		C7522ED76D659E2CAEA384D5 /* EnhancedCoTMarker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedCoTMarker.swift; path = OmniTAKMobile/Features/Map/Markers/EnhancedCoTMarker.swift; sourceTree = "<group>"; };
@@ -698,7 +700,9 @@
 		D7977ED558650BCE30E87178 /* AppStoreScreenshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppStoreScreenshotTests.swift; sourceTree = "<group>"; };
 		D8C8003EB0C35D84FCA0AE25 /* OmniTAKMobileUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OmniTAKMobileUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D927DC29FB5FDD9F156C1899 /* CoTFilterManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoTFilterManager.swift; path = OmniTAKMobile/Features/Networking/Managers/CoTFilterManager.swift; sourceTree = "<group>"; };
+		D9B49FD9370499A376CCF228 /* zh-Hant */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "OmniTAKMobile/Resources/zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		D9BD8FABAF37BB1D8BCFEBCB /* DataPackageImportView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DataPackageImportView.swift; path = OmniTAKMobile/Features/DataPackages/Views/DataPackageImportView.swift; sourceTree = "<group>"; };
+		D9EF53FB6EBD8EDF3F86897D /* CoordinateEntryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Map/Views/CoordinateEntryView.swift; sourceTree = "<group>"; };
 		DAD02BBDBC955E7953E23B56 /* SFAPMHC----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFAPMHC----.svg"; sourceTree = "<group>"; };
 		DB52A8F022DBCC0F3709FDA2 /* ADSBTrafficService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ADSBTrafficService.swift; path = OmniTAKMobile/Features/ADSB/Services/ADSBTrafficService.swift; sourceTree = "<group>"; };
 		DB5771FBA69E70A6E4BD4764 /* MeasurementToolView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeasurementToolView.swift; path = OmniTAKMobile/Features/Measurement/Views/MeasurementToolView.swift; sourceTree = "<group>"; };
@@ -719,7 +723,6 @@
 		E6426A4780DEDD91B5DA2B46 /* SFAPMFT----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFAPMFT----.svg"; sourceTree = "<group>"; };
 		E763527D180A2BFA06815720 /* SHAPMFQ----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHAPMFQ----.svg"; sourceTree = "<group>"; };
 		E7CD94F2AA3C9E1621AE6021 /* es */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = es; path = OmniTAKMobile/Resources/es.lproj/Localizable.strings; sourceTree = "<group>"; };
-		D9B49FD9370499A376CCF228 /* zh-Hant */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "OmniTAKMobile/Resources/zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		E7CED1E79EF4463A98DDA34A /* MapLibre3DSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MapLibre3DSettingsView.swift; path = OmniTAKMobile/Features/Map/MapLibre/MapLibre3DSettingsView.swift; sourceTree = "<group>"; };
 		EA171D08B8BECD16ACA18D51 /* SHGP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGP-------.svg"; sourceTree = "<group>"; };
 		EA4A86523E550E87AC1EE8A4 /* SALUTEReportView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SALUTEReportView.swift; path = OmniTAKMobile/Features/Military/Views/SALUTEReportView.swift; sourceTree = "<group>"; };
@@ -757,6 +760,7 @@
 		FE5ADEAC186F3A6CC4CB7055 /* DeepLinkHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeepLinkHandler.swift; path = OmniTAKMobile/Features/Networking/Services/DeepLinkHandler.swift; sourceTree = "<group>"; };
 		FE75C0779B00B1302E9BBE3A /* cot_types.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = cot_types.json; path = OmniTAKMobile/Shared/Resources/cot_types.json; sourceTree = "<group>"; };
 		FE87E15631B845393B2BA5AD /* SPOTREPModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPOTREPModels.swift; path = OmniTAKMobile/Features/Military/Models/SPOTREPModels.swift; sourceTree = "<group>"; };
+		FEA13B1110000000FEA13B22 /* FemaIconSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FemaIconSet.swift; path = OmniTAKMobile/Features/Drawing/Models/FemaIconSet.swift; sourceTree = "<group>"; };
 		FEDA4D79535AD84B80DECADB /* SUGPEVM----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUGPEVM----.svg"; sourceTree = "<group>"; };
 		FEF899FE86CE4947A9B6BEF0 /* MapLibre3DView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MapLibre3DView.swift; path = OmniTAKMobile/Features/Map/MapLibre/MapLibre3DView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -874,6 +878,7 @@
 			children = (
 				E5160EE3247DE0377F3E6CE8 /* BNGConverter.swift */,
 				32DDAA71A32AEB4CF7544E37 /* MGRSConverter.swift */,
+				1A9E2E310096E7DE7907558F /* TWD97Converter.swift */,
 			);
 			name = Converters;
 			sourceTree = "<group>";
@@ -1217,6 +1222,7 @@
 				A92EDCFDBF0D0ECD7A414CE6 /* MGRSGridToggleView.swift */,
 				697D89D57F2BFE738817AF87 /* Map3DSettingsView.swift */,
 				448D0EBEFF3E2A71669016D1 /* ScaleBarView.swift */,
+				D9EF53FB6EBD8EDF3F86897D /* CoordinateEntryView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -2758,6 +2764,8 @@
 				B6DB49544A68E8CE29BAFEDC /* MissionSyncView.swift in Sources */,
 				61F47CA6368F4B4692FDE35B /* MissionCreationSheet.swift in Sources */,
 				40746A5EE6624B31B2E44DB4 /* TAKRestAPIClient.swift in Sources */,
+				A0E27883B3902B6F2FF2FE1C /* TWD97Converter.swift in Sources */,
+				636B2050F7414B9F51ED24C1 /* CoordinateEntryView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OmniTAKMobile/Core/App/ToolSheetHost.swift
+++ b/OmniTAKMobile/Core/App/ToolSheetHost.swift
@@ -50,6 +50,7 @@ struct ToolSheetHost: ViewModifier {
         case "missionsync":  MissionSyncView()
         case "plugins":      PluginsListView()
         case "kml":          KMLOverlaysPanel()
+        case "gotocoord":    CoordinateEntryView()
         case "pointer":
             PointDropperSheetView(isPresented: Binding(
                 get: { active != nil },

--- a/OmniTAKMobile/Features/Drawing/Views/ToolsLauncherSheet.swift
+++ b/OmniTAKMobile/Features/Drawing/Views/ToolsLauncherSheet.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 
 struct ToolsLauncherSheet: View {
+    @EnvironmentObject private var loc: LocalizationManager
     let onLasso: () -> Void
     let onFullTools: () -> Void
     let onCustomize: () -> Void
@@ -24,8 +25,8 @@ struct ToolsLauncherSheet: View {
         ScrollView {
             VStack(spacing: 0) {
                 // Marquee row — Lasso Select.
-                row(icon: "lasso", iconColor: .orange, title: "Lasso Select",
-                    subtitle: "Long-press + drag on the map to multi-select",
+                row(icon: "lasso", iconColor: .orange, title: loc.t("toolsheet.lasso.title"),
+                    subtitle: loc.t("toolsheet.lasso.subtitle"),
                     bold: true, action: onLasso)
 
                 Divider().padding(.leading, 70)
@@ -34,10 +35,10 @@ struct ToolsLauncherSheet: View {
                 row(
                     icon: mapEngine == .cesium3D ? "map.fill" : "globe.americas.fill",
                     iconColor: mapEngine == .cesium3D ? Color(white: 0.55) : Color(red: 0.31, green: 0.66, blue: 1.0),
-                    title: mapEngine == .cesium3D ? "Switch to 2D Map" : "Switch to 3D Globe",
+                    title: mapEngine == .cesium3D ? loc.t("toolsheet.engine.to2d") : loc.t("toolsheet.engine.to3d"),
                     subtitle: mapEngine == .cesium3D
-                        ? "Currently 3D Cesium — drop to Mapbox 2D for offline / low-bandwidth"
-                        : "Currently 2D Mapbox — back to the photoreal Cesium globe",
+                        ? loc.t("toolsheet.engine.sub2d")
+                        : loc.t("toolsheet.engine.sub3d"),
                     bold: false,
                     action: {
                         let next: MapEngine = mapEngine == .cesium3D ? .mapbox2D : .cesium3D
@@ -50,26 +51,27 @@ struct ToolsLauncherSheet: View {
                 // grid offered, as smooth rows that keep the map live behind.
                 // Each routes through ToolSheetHost by id (.openToolSheet).
                 ForEach(Self.toolSections) { section in
-                    sectionHeader(section.title)
+                    sectionHeader(loc.t(section.titleKey))
                     ForEach(Array(section.tools.enumerated()), id: \.element.id) { idx, tool in
                         if idx > 0 { Divider().padding(.leading, 70) }
                         quickTool(icon: tool.icon, color: tool.color,
-                                  title: tool.title, subtitle: tool.subtitle, toolID: tool.id)
+                                  title: loc.t("tools.\(tool.id).title"),
+                                  subtitle: loc.t("tools.\(tool.id).subtitle"), toolID: tool.id)
                     }
                 }
 
-                sectionHeader("More")
+                sectionHeader(loc.t("tools.section.more"))
 
                 // Build-your-own-bar entry.
-                row(icon: "slider.horizontal.3", iconColor: BarTint.tools, title: "Customize Toolbar",
-                    subtitle: "Pick and arrange your own bottom-bar shortcuts",
+                row(icon: "slider.horizontal.3", iconColor: BarTint.tools, title: loc.t("toolsheet.customize.title"),
+                    subtitle: loc.t("toolsheet.customize.subtitle"),
                     bold: false, action: onCustomize)
 
                 Divider().padding(.leading, 70)
 
                 // Fallback passthrough to the legacy 5x4 grid.
-                row(icon: "square.grid.3x3.fill", iconColor: .secondary, title: "Full Tools Grid…",
-                    subtitle: "The classic grid — kept as a fallback",
+                row(icon: "square.grid.3x3.fill", iconColor: .secondary, title: loc.t("toolsheet.fullgrid.title"),
+                    subtitle: loc.t("toolsheet.fullgrid.subtitle"),
                     bold: false, action: onFullTools)
             }
             .padding(.top, 8)
@@ -92,13 +94,14 @@ struct ToolsLauncherSheet: View {
     private struct LauncherSection: Identifiable {
         let id = UUID()
         let title: String
+        let titleKey: String
         let tools: [LauncherTool]
     }
 
     /// The full catalog, grouped — mirrors every screen the legacy grid
     /// reached, so the popup can be the primary tools surface.
     private static let toolSections: [LauncherSection] = [
-        LauncherSection(title: "Markers & Terrain", tools: [
+        LauncherSection(title: "Markers & Terrain", titleKey: "tools.section.markers", tools: [
             LauncherTool(id: "pointer", icon: "mappin.circle.fill", color: BarTint.red,
                          title: "Point Drop", subtitle: "Place and label a tactical marker"),
             LauncherTool(id: "kml", icon: "square.3.layers.3d", color: BarTint.purple,
@@ -108,7 +111,7 @@ struct ToolsLauncherSheet: View {
             LauncherTool(id: "los", icon: "eye.fill", color: BarTint.teal,
                          title: "Line of Sight", subtitle: "Visibility between two points"),
         ]),
-        LauncherSection(title: "Reports", tools: [
+        LauncherSection(title: "Reports", titleKey: "tools.section.reports", tools: [
             LauncherTool(id: "casevac", icon: "cross.case.fill", color: BarTint.red,
                          title: "CASEVAC", subtitle: "Casualty evacuation request"),
             LauncherTool(id: "nineline", icon: "scope", color: BarTint.red,
@@ -118,7 +121,7 @@ struct ToolsLauncherSheet: View {
             LauncherTool(id: "alert", icon: "exclamationmark.triangle.fill", color: BarTint.red,
                          title: "Emergency Beacon", subtitle: "Broadcast an emergency alert"),
         ]),
-        LauncherSection(title: "Teams & Comms", tools: [
+        LauncherSection(title: "Teams & Comms", titleKey: "tools.section.teams", tools: [
             LauncherTool(id: "teams", icon: "person.3.fill", color: BarTint.chat,
                          title: "Teams", subtitle: "Manage team members"),
             LauncherTool(id: "contacts", icon: "person.crop.circle.fill", color: BarTint.chat,
@@ -126,7 +129,9 @@ struct ToolsLauncherSheet: View {
             LauncherTool(id: "selfsa", icon: "dot.radiowaves.left.and.right", color: BarTint.map,
                          title: "Self / Position", subtitle: "Broadcast your position (PLI)"),
         ]),
-        LauncherSection(title: "Navigation", tools: [
+        LauncherSection(title: "Navigation", titleKey: "tools.section.navigation", tools: [
+            LauncherTool(id: "gotocoord", icon: "mappin.and.ellipse", color: BarTint.map,
+                         title: "Go to Coordinate", subtitle: "Jump to a typed grid/lat-lon (TWD97, MGRS)"),
             LauncherTool(id: "routes", icon: "point.topleft.down.to.point.bottomright.curvepath.fill", color: BarTint.map,
                          title: "Routes", subtitle: "Plan and navigate routes"),
             LauncherTool(id: "turnbyturn", icon: "arrow.triangle.turn.up.right.diamond.fill", color: BarTint.map,
@@ -136,7 +141,7 @@ struct ToolsLauncherSheet: View {
             LauncherTool(id: "geofence", icon: "circle.dashed", color: BarTint.purple,
                          title: "Geofences", subtitle: "Create alert zones"),
         ]),
-        LauncherSection(title: "Air & Data", tools: [
+        LauncherSection(title: "Air & Data", titleKey: "tools.section.airdata", tools: [
             LauncherTool(id: "adsb", icon: "airplane.circle.fill", color: BarTint.mesh,
                          title: "ADS-B", subtitle: "Live aircraft tracking"),
             LauncherTool(id: "missionsync", icon: "arrow.triangle.2.circlepath", color: BarTint.servers,

--- a/OmniTAKMobile/Features/Map/Controllers/MapStateManager.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/MapStateManager.swift
@@ -58,6 +58,7 @@ enum CoordinateDisplayFormat: String, CaseIterable, Identifiable {
     case mgrs = "MGRS"
     case utm = "UTM"
     case bng = "BNG"
+    case twd97 = "TWD97"
 
     var id: String { rawValue }
 
@@ -69,6 +70,7 @@ enum CoordinateDisplayFormat: String, CaseIterable, Identifiable {
         case .mgrs: return "Military Grid Reference System"
         case .utm: return "Universal Transverse Mercator"
         case .bng: return "British National Grid"
+        case .twd97: return "TWD97 / TM2 (Taiwan)"
         }
     }
 
@@ -96,6 +98,10 @@ enum CoordinateDisplayFormat: String, CaseIterable, Identifiable {
             } else {
                 return "Out of BNG bounds"
             }
+        case .twd97:
+            // Readout uses the full 7+7 absolute coordinate; the 5+5 grid
+            // mode lives in the "Go to coordinate" entry sheet.
+            return TWD97Converter.formatTWD97(coordinate, mode: .full7, withSpaces: true)
         }
     }
 }

--- a/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
@@ -1316,6 +1316,15 @@ struct ATAKMapView: View {
             )
     }
 
+    /// Notification observers for the "Go to Coordinate" entry sheet, kept on
+    /// a separate EmptyView so they don't extend `lifecycleHandlers`' chain.
+    private var coordinateHandlers: some View {
+        EmptyView()
+            .onReceive(NotificationCenter.default.publisher(for: .goToCoordinate)) { note in
+                handleGoToCoordinate(note)
+            }
+    }
+
     private var lifecycleHandlers: some View {
         EmptyView()
             .onAppear {
@@ -1495,6 +1504,10 @@ struct ATAKMapView: View {
             .onReceive(NotificationCenter.default.publisher(for: .startNavigationToContact)) { note in
                 handleStartNavigationToContact(note)
             }
+            // Coordinate-entry handler lives on a sibling EmptyView (attached
+            // via .background) to keep this already-large modifier chain under
+            // the Swift type-checker ceiling.
+            .background(coordinateHandlers)
             .sheet(isPresented: $showAppModePicker) {
                 AppModePickerView()
             }
@@ -1968,6 +1981,31 @@ struct ATAKMapView: View {
             object: nil,
             userInfo: ["lat": target.latitude, "lon": target.longitude]
         )
+    }
+
+    /// Jump the map to a typed coordinate (from the "Go to Coordinate"
+    /// sheet), optionally dropping a marker. Centers both the 2D (MapLibre)
+    /// and 3D (Cesium) engines, mirroring handleCenterMapOnContact.
+    private func handleGoToCoordinate(_ note: Notification) {
+        guard let lat = note.userInfo?["lat"] as? Double,
+              let lon = note.userInfo?["lon"] as? Double else { return }
+        let target = CLLocationCoordinate2D(latitude: lat, longitude: lon)
+        let drop = note.userInfo?["drop"] as? Bool ?? false
+
+        withAnimation {
+            mapRegion = MKCoordinateRegion(
+                center: target,
+                span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta: 0.02)
+            )
+        }
+        NotificationCenter.default.post(
+            name: .cesiumCenterOn,
+            object: nil,
+            userInfo: ["lat": target.latitude, "lon": target.longitude]
+        )
+        if drop {
+            dropMarkerAtLocation(coordinate: target, affiliation: .unknown)
+        }
     }
 
     private func handleStartNavigationToContact(_ note: Notification) {

--- a/OmniTAKMobile/Features/Map/Views/CoordinateDisplayView.swift
+++ b/OmniTAKMobile/Features/Map/Views/CoordinateDisplayView.swift
@@ -128,6 +128,8 @@ struct CoordinateDisplayView: View {
             return formatUTM(coordinate)
         case .bng:
             return formatBNG(coordinate)
+        case .twd97:
+            return formatTWD97(coordinate)
         }
     }
 
@@ -236,6 +238,13 @@ struct CoordinateDisplayView: View {
             return "Out of BNG bounds"
         }
     }
+
+    // MARK: - TWD97 Formatting
+
+    private func formatTWD97(_ coordinate: CLLocationCoordinate2D) -> String {
+        // Full 7+7 absolute TM2 readout; entry sheet offers the 5+5 grid mode.
+        return TWD97Converter.formatTWD97(coordinate, mode: .full7, withSpaces: true)
+    }
 }
 
 // MARK: - Coordinate Format Enum
@@ -245,6 +254,7 @@ enum CoordinateFormat: String, CaseIterable {
     case mgrs = "MGRS"
     case utm = "UTM"
     case bng = "BNG"
+    case twd97 = "TWD97"
 
     var displayName: String {
         switch self {
@@ -256,6 +266,8 @@ enum CoordinateFormat: String, CaseIterable {
             return "Universal Transverse Mercator"
         case .bng:
             return "British National Grid"
+        case .twd97:
+            return "TWD97 / TM2 (Taiwan)"
         }
     }
 }

--- a/OmniTAKMobile/Features/Map/Views/CoordinateEntryView.swift
+++ b/OmniTAKMobile/Features/Map/Views/CoordinateEntryView.swift
@@ -1,0 +1,244 @@
+//
+//  CoordinateEntryView.swift
+//  OmniTAKMobile
+//
+//  "Go to Coordinate" — type a coordinate and jump the map there
+//  (optionally dropping a marker). Supports TWD97/TM2 (Taiwan) with a
+//  selectable digit-input mode (7+7 absolute vs 5+5 local grid), plus
+//  MGRS and decimal Lat/Lon.
+//
+//  Engine-agnostic: it posts `.goToCoordinate`, which MapViewController
+//  handles for both the 2D (MapLibre) and 3D (Cesium) engines.
+//
+
+import SwiftUI
+import CoreLocation
+
+struct CoordinateEntryView: View {
+    @EnvironmentObject private var loc: LocalizationManager
+    @Environment(\.dismiss) private var dismiss
+
+    enum EntryFormat: String, CaseIterable, Identifiable {
+        case twd97 = "TWD97"
+        case mgrs = "MGRS"
+        case latlon = "LAT/LON"
+        var id: String { rawValue }
+    }
+
+    @State private var format: EntryFormat = .twd97
+    @State private var digitMode: TWD97Converter.DigitMode = .full7
+
+    // TWD97 fields
+    @State private var easting: String = ""
+    @State private var northing: String = ""
+    // MGRS field
+    @State private var mgrsText: String = ""
+    // Lat/Lon fields
+    @State private var latText: String = ""
+    @State private var lonText: String = ""
+
+    @State private var dropMarker: Bool = true
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section {
+                    Picker(loc.t("coordentry.format"), selection: $format) {
+                        ForEach(EntryFormat.allCases) { f in
+                            Text(f.rawValue).tag(f)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    if format == .twd97 {
+                        Picker(loc.t("coordentry.digitmode"), selection: $digitMode) {
+                            Text("7+7").tag(TWD97Converter.DigitMode.full7)
+                            Text("5+5").tag(TWD97Converter.DigitMode.grid5)
+                        }
+                        .pickerStyle(.segmented)
+                    }
+                }
+
+                Section(header: Text(loc.t("coordentry.input"))) {
+                    inputFields
+                }
+
+                Section(header: Text(loc.t("coordentry.preview"))) {
+                    previewRows
+                }
+
+                Section {
+                    Toggle(loc.t("coordentry.dropmarker"), isOn: $dropMarker)
+                }
+            }
+            .navigationTitle(loc.t("coordentry.title"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(loc.t("common.cancel")) { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(action: { submit() }) {
+                        Text(loc.t("coordentry.go")).font(.body.weight(.semibold))
+                    }
+                    .disabled(parsedCoordinate == nil)
+                }
+            }
+        }
+    }
+
+    // MARK: - Input fields per format
+
+    @ViewBuilder
+    private var inputFields: some View {
+        switch format {
+        case .twd97:
+            let digits = digitMode.digits
+            HStack {
+                Text(loc.t("coordentry.easting"))
+                    .frame(width: 90, alignment: .leading)
+                    .foregroundColor(.secondary)
+                TextField(String(repeating: "0", count: digits), text: $easting)
+                    .keyboardType(.numberPad)
+                    .font(.system(.body, design: .monospaced))
+            }
+            HStack {
+                Text(loc.t("coordentry.northing"))
+                    .frame(width: 90, alignment: .leading)
+                    .foregroundColor(.secondary)
+                TextField(String(repeating: "0", count: digits), text: $northing)
+                    .keyboardType(.numberPad)
+                    .font(.system(.body, design: .monospaced))
+            }
+            if digitMode == .grid5 {
+                Text(loc.t("coordentry.grid5.note"))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        case .mgrs:
+            TextField("11S MS 12345 67890", text: $mgrsText)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.characters)
+                .font(.system(.body, design: .monospaced))
+        case .latlon:
+            HStack {
+                Text(loc.t("coordentry.lat"))
+                    .frame(width: 90, alignment: .leading)
+                    .foregroundColor(.secondary)
+                TextField("25.0339", text: $latText)
+                    .keyboardType(.numbersAndPunctuation)
+                    .font(.system(.body, design: .monospaced))
+            }
+            HStack {
+                Text(loc.t("coordentry.lon"))
+                    .frame(width: 90, alignment: .leading)
+                    .foregroundColor(.secondary)
+                TextField("121.5645", text: $lonText)
+                    .keyboardType(.numbersAndPunctuation)
+                    .font(.system(.body, design: .monospaced))
+            }
+        }
+    }
+
+    // MARK: - Live preview
+
+    @ViewBuilder
+    private var previewRows: some View {
+        if let coord = parsedCoordinate {
+            previewRow(loc.t("coordentry.lat"),
+                       String(format: "%.6f", coord.latitude))
+            previewRow(loc.t("coordentry.lon"),
+                       String(format: "%.6f", coord.longitude))
+            // Echo the TWD97 readback so Gavin can compare 7+7 vs 5+5.
+            if TWD97Converter.isWithinBounds(coord) {
+                previewRow("TWD97 7+7", TWD97Converter.formatTWD97(coord, mode: .full7), small: true)
+                previewRow("TWD97 5+5", TWD97Converter.formatTWD97(coord, mode: .grid5), small: true)
+            }
+        } else if hasAnyInput {
+            Text(loc.t("coordentry.invalid"))
+                .font(.caption)
+                .foregroundColor(.red)
+        } else {
+            Text(loc.t("coordentry.enterprompt"))
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    /// iOS 15-compatible label/value row (LabeledContent is iOS 16+).
+    private func previewRow(_ label: String, _ value: String, small: Bool = false) -> some View {
+        HStack {
+            Text(label)
+                .font(small ? .caption : .body)
+                .foregroundColor(.secondary)
+            Spacer()
+            Text(value)
+                .font(.system(small ? .caption : .body, design: .monospaced))
+                .foregroundColor(small ? .secondary : .primary)
+        }
+    }
+
+    private var hasAnyInput: Bool {
+        switch format {
+        case .twd97: return !easting.isEmpty || !northing.isEmpty
+        case .mgrs: return !mgrsText.isEmpty
+        case .latlon: return !latText.isEmpty || !lonText.isEmpty
+        }
+    }
+
+    // MARK: - Parsing
+
+    private var parsedCoordinate: CLLocationCoordinate2D? {
+        switch format {
+        case .twd97:
+            guard !easting.isEmpty, !northing.isEmpty else { return nil }
+            return TWD97Converter.parse(
+                eastingText: easting,
+                northingText: northing,
+                mode: digitMode,
+                reference: currentMapCenter
+            )
+        case .mgrs:
+            guard !mgrsText.isEmpty else { return nil }
+            return MGRSConverter.mgrsToLatLon(mgrsText)
+        case .latlon:
+            guard let lat = Double(latText.trimmingCharacters(in: .whitespaces)),
+                  let lon = Double(lonText.trimmingCharacters(in: .whitespaces)),
+                  lat >= -90, lat <= 90, lon >= -180, lon <= 180 else { return nil }
+            return CLLocationCoordinate2D(latitude: lat, longitude: lon)
+        }
+    }
+
+    /// Best-known current map centre (used to recover the 100 km cell for
+    /// 5+5 grid input). Falls back to central Taiwan.
+    private var currentMapCenter: CLLocationCoordinate2D {
+        if let c = MapLibreService.shared.mapView?.mapboxMap.cameraState.center,
+           CLLocationCoordinate2DIsValid(c) {
+            return c
+        }
+        return CLLocationCoordinate2D(latitude: 23.7, longitude: 121.0)
+    }
+
+    // MARK: - Submit
+
+    private func submit() {
+        guard let coord = parsedCoordinate else { return }
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        NotificationCenter.default.post(
+            name: .goToCoordinate,
+            object: nil,
+            userInfo: [
+                "lat": coord.latitude,
+                "lon": coord.longitude,
+                "drop": dropMarker
+            ]
+        )
+        dismiss()
+    }
+}
+
+extension Notification.Name {
+    /// Center the map on a typed coordinate (both engines). userInfo:
+    /// "lat": Double, "lon": Double, "drop": Bool (drop a marker too).
+    static let goToCoordinate = Notification.Name("goToCoordinate")
+}

--- a/OmniTAKMobile/Features/Settings/Views/SettingsView.swift
+++ b/OmniTAKMobile/Features/Settings/Views/SettingsView.swift
@@ -153,11 +153,17 @@ struct SettingsView: View {
                         Text("MGRS").tag("MGRS")
                         Text("UTM").tag("UTM")
                         Text(loc.t("settings.coord.bng")).tag("BNG")
+                        Text(loc.t("settings.coord.twd97")).tag("TWD97")
                     }
 
                     // Help text for coordinate formats
                     if coordinateFormatString == "BNG" {
                         Text(loc.t("settings.coord.bngHelp"))
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .padding(.top, 4)
+                    } else if coordinateFormatString == "TWD97" {
+                        Text(loc.t("settings.coord.twd97Help"))
                             .font(.caption2)
                             .foregroundColor(.secondary)
                             .padding(.top, 4)

--- a/OmniTAKMobile/Resources/en.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/en.lproj/Localizable.strings
@@ -121,3 +121,124 @@
 "quickstart.time.discover" = "< 1 min";
 "quickstart.time.quick" = "< 2 min";
 "quickstart.time.manual" = "~3 min";
+
+/* --- Bottom bar + tools shortcuts (labels). Keyed by BarItem.id ("bar.<id>").
+       Military/technical acronyms (CASEVAC, 9-Line, SPOTREP, ADS-B, Self SA,
+       Mesh) stay English per the translation conventions. --- */
+"bar.tab.map" = "Map";
+"bar.tab.chat" = "Chat";
+"bar.tab.servers" = "Servers";
+"bar.tab.mesh" = "Mesh";
+"bar.tab.settings" = "Settings";
+"bar.cmd.tools" = "Tools";
+"bar.cmd.fulltools" = "All Tools";
+"bar.cmd.droppin" = "Drop Pin";
+"bar.cmd.measure" = "Measure";
+"bar.cmd.drawing" = "Drawing";
+"bar.cmd.layers" = "Layers";
+"bar.cmd.drawingslist" = "Drawings";
+"bar.cmd.lasso" = "Select";
+"bar.cmd.engine" = "2D / 3D";
+"bar.tool.pointer" = "Point Drop";
+"bar.tool.routes" = "Routes";
+"bar.tool.navigation" = "Navigation";
+"bar.tool.teams" = "Teams";
+"bar.tool.contacts" = "Contacts";
+"bar.tool.casevac" = "CASEVAC";
+"bar.tool.nineline" = "9-Line";
+"bar.tool.spotrep" = "SPOTREP";
+"bar.tool.alert" = "Emergency";
+"bar.tool.tracks" = "Tracks";
+"bar.tool.geofence" = "Geofence";
+"bar.tool.adsb" = "ADS-B";
+"bar.tool.selfsa" = "Self SA";
+"bar.tool.elevation" = "Elevation";
+"bar.tool.los" = "Line of Sight";
+"bar.tool.missionsync" = "Mission Sync";
+"bar.tool.plugins" = "Plugins";
+"bar.tool.uas" = "Vehicles";
+
+/* --- Bottom bar edit/coachmark chrome --- */
+"bar.coachmark" = "Press & hold to build your own toolbar";
+"bar.editHint" = "Drag to reorder · tap − to remove · ＋ to add";
+"bar.done" = "Done";
+"bar.add" = "Add";
+
+/* --- Tools popup (ToolsLauncherSheet): inline rows --- */
+"toolsheet.lasso.title" = "Lasso Select";
+"toolsheet.lasso.subtitle" = "Long-press + drag on the map to multi-select";
+"toolsheet.engine.to2d" = "Switch to 2D Map";
+"toolsheet.engine.to3d" = "Switch to 3D Globe";
+"toolsheet.engine.sub2d" = "Currently 3D Cesium — drop to Mapbox 2D for offline / low-bandwidth";
+"toolsheet.engine.sub3d" = "Currently 2D Mapbox — back to the photoreal Cesium globe";
+"toolsheet.customize.title" = "Customize Toolbar";
+"toolsheet.customize.subtitle" = "Pick and arrange your own bottom-bar shortcuts";
+"toolsheet.fullgrid.title" = "Full Tools Grid…";
+"toolsheet.fullgrid.subtitle" = "The classic grid — kept as a fallback";
+
+/* --- Tools popup: section headers --- */
+"tools.section.markers" = "Markers & Terrain";
+"tools.section.reports" = "Reports";
+"tools.section.teams" = "Teams & Comms";
+"tools.section.navigation" = "Navigation";
+"tools.section.airdata" = "Air & Data";
+"tools.section.more" = "More";
+
+/* --- Tools popup: catalog (keyed by tool id) --- */
+"tools.pointer.title" = "Point Drop";
+"tools.pointer.subtitle" = "Place and label a tactical marker";
+"tools.kml.title" = "Map Overlays";
+"tools.kml.subtitle" = "Import & toggle KML/KMZ overlays";
+"tools.elevation.title" = "Elevation Profile";
+"tools.elevation.subtitle" = "Terrain profile along a path";
+"tools.los.title" = "Line of Sight";
+"tools.los.subtitle" = "Visibility between two points";
+"tools.casevac.title" = "CASEVAC";
+"tools.casevac.subtitle" = "Casualty evacuation request";
+"tools.nineline.title" = "9-Line / CAS";
+"tools.nineline.subtitle" = "Close air support request";
+"tools.spotrep.title" = "SPOTREP";
+"tools.spotrep.subtitle" = "Spot report";
+"tools.alert.title" = "Emergency Beacon";
+"tools.alert.subtitle" = "Broadcast an emergency alert";
+"tools.teams.title" = "Teams";
+"tools.teams.subtitle" = "Manage team members";
+"tools.contacts.title" = "Contacts";
+"tools.contacts.subtitle" = "Contact list & chat";
+"tools.selfsa.title" = "Self / Position";
+"tools.selfsa.subtitle" = "Broadcast your position (PLI)";
+"tools.routes.title" = "Routes";
+"tools.routes.subtitle" = "Plan and navigate routes";
+"tools.turnbyturn.title" = "Turn-by-Turn";
+"tools.turnbyturn.subtitle" = "Guided navigation";
+"tools.tracks.title" = "Track Recording";
+"tools.tracks.subtitle" = "Record & review your track";
+"tools.geofence.title" = "Geofences";
+"tools.geofence.subtitle" = "Create alert zones";
+"tools.adsb.title" = "ADS-B";
+"tools.adsb.subtitle" = "Live aircraft tracking";
+"tools.missionsync.title" = "Mission Sync";
+"tools.missionsync.subtitle" = "Sync mission packages";
+"tools.plugins.title" = "Plugins";
+"tools.plugins.subtitle" = "Manage installed plugins";
+
+/* TWD97 (Taiwan) coordinate format + Go to Coordinate entry */
+"settings.coord.twd97" = "TWD97 / TM2 (Taiwan)";
+"settings.coord.twd97Help" = "TWD97 / TM2 zone 121 for Taiwan (≈WGS84). Readout uses the full 7+7 digit coordinate; the Go to Coordinate tool also offers 5+5 local grid input.";
+"tools.gotocoord.title" = "Go to Coordinate";
+"tools.gotocoord.subtitle" = "Jump to a typed grid/lat-lon (TWD97, MGRS)";
+"common.cancel" = "Cancel";
+"coordentry.title" = "Go to Coordinate";
+"coordentry.format" = "Format";
+"coordentry.digitmode" = "Digit Mode";
+"coordentry.input" = "Input";
+"coordentry.preview" = "Preview";
+"coordentry.dropmarker" = "Drop a marker here";
+"coordentry.go" = "Go";
+"coordentry.easting" = "Easting";
+"coordentry.northing" = "Northing";
+"coordentry.lat" = "Latitude";
+"coordentry.lon" = "Longitude";
+"coordentry.grid5.note" = "5+5 is relative to the current map center (100 km cell).";
+"coordentry.invalid" = "Coordinate out of range or unparseable.";
+"coordentry.enterprompt" = "Enter a coordinate to preview the location.";

--- a/OmniTAKMobile/Resources/zh-Hant.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/zh-Hant.lproj/Localizable.strings
@@ -121,3 +121,124 @@
 "quickstart.time.discover" = "< 1 分鐘";
 "quickstart.time.quick" = "< 2 分鐘";
 "quickstart.time.manual" = "約 3 分鐘";
+
+/* --- 底部工具列與工具捷徑（標籤）。以 BarItem.id（"bar.<id>"）為鍵。
+       軍事／技術縮寫（CASEVAC、9-Line、SPOTREP、ADS-B、Self SA、Mesh）
+       依慣例保留英文。 --- */
+"bar.tab.map" = "地圖";
+"bar.tab.chat" = "聊天";
+"bar.tab.servers" = "伺服器";
+"bar.tab.mesh" = "Mesh";
+"bar.tab.settings" = "設定";
+"bar.cmd.tools" = "工具";
+"bar.cmd.fulltools" = "所有工具";
+"bar.cmd.droppin" = "放置圖釘";
+"bar.cmd.measure" = "測量";
+"bar.cmd.drawing" = "繪圖";
+"bar.cmd.layers" = "圖層";
+"bar.cmd.drawingslist" = "繪圖清單";
+"bar.cmd.lasso" = "選取";
+"bar.cmd.engine" = "2D / 3D";
+"bar.tool.pointer" = "放置標點";
+"bar.tool.routes" = "路線";
+"bar.tool.navigation" = "導航";
+"bar.tool.teams" = "隊伍";
+"bar.tool.contacts" = "聯絡人";
+"bar.tool.casevac" = "CASEVAC";
+"bar.tool.nineline" = "9-Line";
+"bar.tool.spotrep" = "SPOTREP";
+"bar.tool.alert" = "緊急";
+"bar.tool.tracks" = "軌跡";
+"bar.tool.geofence" = "地理圍欄";
+"bar.tool.adsb" = "ADS-B";
+"bar.tool.selfsa" = "Self SA";
+"bar.tool.elevation" = "海拔";
+"bar.tool.los" = "視線";
+"bar.tool.missionsync" = "任務同步";
+"bar.tool.plugins" = "外掛";
+"bar.tool.uas" = "載具";
+
+/* --- 底部工具列編輯／提示介面 --- */
+"bar.coachmark" = "長按以打造自己的工具列";
+"bar.editHint" = "拖曳以重新排序 · 點 − 移除 · ＋ 新增";
+"bar.done" = "完成";
+"bar.add" = "新增";
+
+/* --- 工具彈出視窗（ToolsLauncherSheet）：內嵌列 --- */
+"toolsheet.lasso.title" = "套索選取";
+"toolsheet.lasso.subtitle" = "在地圖上長按並拖曳以多重選取";
+"toolsheet.engine.to2d" = "切換為 2D 地圖";
+"toolsheet.engine.to3d" = "切換為 3D 地球";
+"toolsheet.engine.sub2d" = "目前為 3D Cesium，切換為 Mapbox 2D 以供離線／低頻寬使用";
+"toolsheet.engine.sub3d" = "目前為 2D Mapbox，切回擬真的 Cesium 地球";
+"toolsheet.customize.title" = "自訂工具列";
+"toolsheet.customize.subtitle" = "挑選並排列你自己的底部捷徑";
+"toolsheet.fullgrid.title" = "完整工具格…";
+"toolsheet.fullgrid.subtitle" = "經典格狀介面，保留作為備援";
+
+/* --- 工具彈出視窗：區段標題 --- */
+"tools.section.markers" = "標記與地形";
+"tools.section.reports" = "回報";
+"tools.section.teams" = "隊伍與通訊";
+"tools.section.navigation" = "導航";
+"tools.section.airdata" = "空情與資料";
+"tools.section.more" = "更多";
+
+/* --- 工具彈出視窗：工具目錄（以工具 id 為鍵） --- */
+"tools.pointer.title" = "放置標點";
+"tools.pointer.subtitle" = "放置並標註戰術標記";
+"tools.kml.title" = "地圖疊層";
+"tools.kml.subtitle" = "匯入並切換 KML/KMZ 疊層";
+"tools.elevation.title" = "高程剖面";
+"tools.elevation.subtitle" = "沿路徑的地形剖面";
+"tools.los.title" = "視線";
+"tools.los.subtitle" = "兩點之間的通視";
+"tools.casevac.title" = "CASEVAC";
+"tools.casevac.subtitle" = "傷患後送請求";
+"tools.nineline.title" = "9-Line / CAS";
+"tools.nineline.subtitle" = "近距空中支援請求";
+"tools.spotrep.title" = "SPOTREP";
+"tools.spotrep.subtitle" = "現地回報";
+"tools.alert.title" = "緊急信標";
+"tools.alert.subtitle" = "廣播緊急警示";
+"tools.teams.title" = "隊伍";
+"tools.teams.subtitle" = "管理隊伍成員";
+"tools.contacts.title" = "聯絡人";
+"tools.contacts.subtitle" = "聯絡人清單與聊天";
+"tools.selfsa.title" = "自身／位置";
+"tools.selfsa.subtitle" = "廣播你的位置 (PLI)";
+"tools.routes.title" = "路線";
+"tools.routes.subtitle" = "規劃並導航路線";
+"tools.turnbyturn.title" = "逐步導航";
+"tools.turnbyturn.subtitle" = "引導式導航";
+"tools.tracks.title" = "軌跡記錄";
+"tools.tracks.subtitle" = "記錄並檢視你的軌跡";
+"tools.geofence.title" = "地理圍欄";
+"tools.geofence.subtitle" = "建立警示區域";
+"tools.adsb.title" = "ADS-B";
+"tools.adsb.subtitle" = "即時航機追蹤";
+"tools.missionsync.title" = "任務同步";
+"tools.missionsync.subtitle" = "同步任務封包";
+"tools.plugins.title" = "外掛";
+"tools.plugins.subtitle" = "管理已安裝的外掛";
+
+/* TWD97（台灣）座標格式 + 前往座標輸入 */
+"settings.coord.twd97" = "TWD97 / TM2（台灣）";
+"settings.coord.twd97Help" = "台灣 TWD97 / TM2 二度分帶（121 分帶，≈WGS84）。座標顯示使用完整 7+7 位數；「前往座標」工具另提供 5+5 區域網格輸入。";
+"tools.gotocoord.title" = "前往座標";
+"tools.gotocoord.subtitle" = "輸入網格／經緯度快速跳轉（TWD97、MGRS）";
+"common.cancel" = "取消";
+"coordentry.title" = "前往座標";
+"coordentry.format" = "格式";
+"coordentry.digitmode" = "位數模式";
+"coordentry.input" = "輸入";
+"coordentry.preview" = "預覽";
+"coordentry.dropmarker" = "在此放置標記";
+"coordentry.go" = "前往";
+"coordentry.easting" = "橫座標 (E)";
+"coordentry.northing" = "縱座標 (N)";
+"coordentry.lat" = "緯度";
+"coordentry.lon" = "經度";
+"coordentry.grid5.note" = "5+5 以目前地圖中心（100 公里網格）為基準。";
+"coordentry.invalid" = "座標超出範圍或無法解析。";
+"coordentry.enterprompt" = "輸入座標以預覽位置。";

--- a/OmniTAKMobile/Utilities/Converters/TWD97Converter.swift
+++ b/OmniTAKMobile/Utilities/Converters/TWD97Converter.swift
@@ -1,0 +1,280 @@
+//
+//  TWD97Converter.swift
+//  OmniTAKMobile
+//
+//  TWD97 / TM2 zone 121 (Taiwan) converter — EPSG:3826
+//  Transverse Mercator on the GRS80 ellipsoid.
+//
+//  Unlike BNG (which needs a Helmert datum shift to OSGB36), TWD97 is
+//  referenced to GRS80/ITRF and is effectively identical to WGS84
+//  (towgs84 = 0,0,0,0,0,0,0 — sub-metre difference), so no datum
+//  transform is required. We project WGS84 lat/lon straight to/from TM2.
+//
+//  Projection parameters (EPSG:3826):
+//    central meridian (lon0) = 121°E
+//    scale factor (k0)       = 0.9999
+//    false easting (E0)      = 250000 m
+//    false northing (N0)     = 0 m
+//    latitude of origin      = 0°
+//
+//  Digit input modes (what Gavin asked to compare):
+//    .full7 — full absolute TM2 coordinate, 7 digits easting + 7 digits
+//             northing at 1 m (e.g. "0250000 2543210"). Unambiguous, the
+//             standard Taiwan survey ("二度分帶") input, but longer to type.
+//    .grid5 — MGRS-style truncated reference: the last 5 digits of easting
+//             and northing within the local 100 km cell (e.g. "50000 43210").
+//             Shorter and matches MGRS muscle memory, but ambiguous outside
+//             the local 100 km cell — parsing requires a reference coordinate
+//             (the map centre) to recover the 100 km prefix.
+//
+
+import Foundation
+import CoreLocation
+
+// MARK: - TWD97 Converter
+
+class TWD97Converter {
+
+    // MARK: - GRS80 Ellipsoid Constants
+
+    private static let a: Double = 6378137.0               // Semi-major axis
+    private static let f: Double = 1.0 / 298.257222101     // Flattening
+    private static let b: Double = 6378137.0 * (1.0 - 1.0 / 298.257222101) // Semi-minor axis
+    private static let e2: Double = (2.0 / 298.257222101) - (1.0 / 298.257222101) * (1.0 / 298.257222101) // First eccentricity²
+
+    // MARK: - TM2 zone 121 Projection Parameters
+
+    private static let lat0: Double = 0.0                       // True origin latitude (equator)
+    private static let lon0: Double = 121.0 * .pi / 180.0       // Central meridian (121°E)
+    private static let N0: Double = 0.0                         // False northing
+    private static let E0: Double = 250000.0                    // False easting
+    private static let F0: Double = 0.9999                      // Scale factor on central meridian
+
+    // MARK: - Taiwan Bounds (TM2 zone 121: main island + nearshore)
+    // Kinmen/Matsu use zone 119 (EPSG:3825) and are intentionally excluded.
+
+    private static let minLat: Double = 21.0
+    private static let maxLat: Double = 26.5
+    private static let minLon: Double = 119.0
+    private static let maxLon: Double = 123.0
+
+    // MARK: - Digit Input Mode
+
+    enum DigitMode {
+        case full7   // 7 + 7 absolute digits (1 m)
+        case grid5   // 5 + 5 truncated digits within local 100 km cell (1 m)
+
+        /// Number of digits shown per axis.
+        var digits: Int {
+            switch self {
+            case .full7: return 7
+            case .grid5: return 5
+            }
+        }
+
+        var label: String {
+            switch self {
+            case .full7: return "7+7"
+            case .grid5: return "5+5"
+            }
+        }
+    }
+
+    // MARK: - TWD97 Coordinate Structure
+
+    struct TWD97Coordinate {
+        let easting: Double      // Full absolute easting (metres)
+        let northing: Double     // Full absolute northing (metres)
+        let mode: DigitMode
+
+        /// Formatted grid string for the selected digit mode.
+        func formatted(withSpaces: Bool = true) -> String {
+            switch mode {
+            case .full7:
+                let e = String(format: "%07d", Int(easting.rounded()))
+                let n = String(format: "%07d", Int(northing.rounded()))
+                return withSpaces ? "\(e) \(n)" : "\(e)\(n)"
+            case .grid5:
+                let e = Int(easting.rounded()) % 100000
+                let n = Int(northing.rounded()) % 100000
+                let eStr = String(format: "%05d", e)
+                let nStr = String(format: "%05d", n)
+                return withSpaces ? "\(eStr) \(nStr)" : "\(eStr)\(nStr)"
+            }
+        }
+    }
+
+    // MARK: - WGS84 Lat/Lon → TWD97 TM2 (forward, Redfearn series)
+
+    /// Project a WGS84 coordinate to absolute TM2 easting/northing.
+    /// Returns nil if outside the Taiwan (zone 121) bounds.
+    static func latLonToTWD97(_ coord: CLLocationCoordinate2D, mode: DigitMode = .full7) -> TWD97Coordinate? {
+        guard isWithinBounds(coord) else { return nil }
+        let (easting, northing) = project(coord)
+        return TWD97Coordinate(easting: easting, northing: northing, mode: mode)
+    }
+
+    /// Raw forward projection (no bounds check). Exposed for testing/round-trips.
+    static func project(_ coord: CLLocationCoordinate2D) -> (easting: Double, northing: Double) {
+        let lat = coord.latitude * .pi / 180.0
+        let lon = coord.longitude * .pi / 180.0
+
+        let sinLat = sin(lat)
+        let cosLat = cos(lat)
+        let tanLat = tan(lat)
+
+        let n = (a - b) / (a + b)
+        let n2 = n * n
+        let n3 = n * n * n
+
+        let nu = a * F0 / sqrt(1 - e2 * sinLat * sinLat)
+        let rho = a * F0 * (1 - e2) / pow(1 - e2 * sinLat * sinLat, 1.5)
+        let eta2 = nu / rho - 1
+
+        let Ma = (1 + n + (5.0 / 4.0) * n2 + (5.0 / 4.0) * n3) * (lat - lat0)
+        let Mb = (3 * n + 3 * n2 + (21.0 / 8.0) * n3) * sin(lat - lat0) * cos(lat + lat0)
+        let Mc = ((15.0 / 8.0) * n2 + (15.0 / 8.0) * n3) * sin(2 * (lat - lat0)) * cos(2 * (lat + lat0))
+        let Md = (35.0 / 24.0) * n3 * sin(3 * (lat - lat0)) * cos(3 * (lat + lat0))
+        let M = b * F0 * (Ma - Mb + Mc - Md)
+
+        let I = M + N0
+        let II = (nu / 2) * sinLat * cosLat
+        let III = (nu / 24) * sinLat * pow(cosLat, 3) * (5 - tanLat * tanLat + 9 * eta2)
+        let IIIA = (nu / 720) * sinLat * pow(cosLat, 5) * (61 - 58 * tanLat * tanLat + pow(tanLat, 4))
+        let IV = nu * cosLat
+        let V = (nu / 6) * pow(cosLat, 3) * (nu / rho - tanLat * tanLat)
+        let VI = (nu / 120) * pow(cosLat, 5) * (5 - 18 * tanLat * tanLat + pow(tanLat, 4) + 14 * eta2 - 58 * tanLat * tanLat * eta2)
+
+        let dLon = lon - lon0
+
+        let northing = I + II * dLon * dLon + III * pow(dLon, 4) + IIIA * pow(dLon, 6)
+        let easting = E0 + IV * dLon + V * pow(dLon, 3) + VI * pow(dLon, 5)
+
+        return (easting, northing)
+    }
+
+    // MARK: - TWD97 TM2 → WGS84 Lat/Lon (inverse, Redfearn series)
+
+    /// Convert absolute TM2 easting/northing to WGS84 lat/lon.
+    static func twd97ToLatLon(easting: Double, northing: Double) -> CLLocationCoordinate2D {
+        let n = (a - b) / (a + b)
+        let n2 = n * n
+        let n3 = n * n * n
+
+        var lat = lat0
+        var M: Double = 0
+
+        // Iterate latitude until the meridional arc matches the northing.
+        repeat {
+            lat = ((northing - N0 - M) / (a * F0)) + lat
+
+            let Ma = (1 + n + (5.0 / 4.0) * n2 + (5.0 / 4.0) * n3) * (lat - lat0)
+            let Mb = (3 * n + 3 * n2 + (21.0 / 8.0) * n3) * sin(lat - lat0) * cos(lat + lat0)
+            let Mc = ((15.0 / 8.0) * n2 + (15.0 / 8.0) * n3) * sin(2 * (lat - lat0)) * cos(2 * (lat + lat0))
+            let Md = (35.0 / 24.0) * n3 * sin(3 * (lat - lat0)) * cos(3 * (lat + lat0))
+            M = b * F0 * (Ma - Mb + Mc - Md)
+
+        } while abs(northing - N0 - M) >= 0.00001
+
+        let sinLat = sin(lat)
+        let cosLat = cos(lat)
+        let tanLat = tan(lat)
+
+        let nu = a * F0 / sqrt(1 - e2 * sinLat * sinLat)
+        let rho = a * F0 * (1 - e2) / pow(1 - e2 * sinLat * sinLat, 1.5)
+        let eta2 = nu / rho - 1
+
+        let tanLat2 = tanLat * tanLat
+        let tanLat4 = tanLat2 * tanLat2
+        let tanLat6 = tanLat4 * tanLat2
+
+        let VII = tanLat / (2 * rho * nu)
+        let VIII = tanLat / (24 * rho * pow(nu, 3)) * (5 + 3 * tanLat2 + eta2 - 9 * tanLat2 * eta2)
+        let IX = tanLat / (720 * rho * pow(nu, 5)) * (61 + 90 * tanLat2 + 45 * tanLat4)
+        let X = 1.0 / (cosLat * nu)
+        let XI = 1.0 / (cosLat * 6 * pow(nu, 3)) * (nu / rho + 2 * tanLat2)
+        let XII = 1.0 / (cosLat * 120 * pow(nu, 5)) * (5 + 28 * tanLat2 + 24 * tanLat4)
+        let XIIA = 1.0 / (cosLat * 5040 * pow(nu, 7)) * (61 + 662 * tanLat2 + 1320 * tanLat4 + 720 * tanLat6)
+
+        let dE = easting - E0
+
+        let latRad = lat - VII * dE * dE + VIII * pow(dE, 4) - IX * pow(dE, 6)
+        let lonRad = lon0 + X * dE - XI * pow(dE, 3) + XII * pow(dE, 5) - XIIA * pow(dE, 7)
+
+        return CLLocationCoordinate2D(
+            latitude: latRad * 180.0 / .pi,
+            longitude: lonRad * 180.0 / .pi
+        )
+    }
+
+    // MARK: - Parsing typed input
+
+    /// Parse typed easting/northing strings into a coordinate.
+    /// - full7: strings are full absolute metres (7 digits each).
+    /// - grid5: strings are truncated to the local 100 km cell; `reference`
+    ///   (typically the current map centre) recovers the 100 km prefix.
+    ///   If no reference is supplied, the centre of Taiwan is assumed.
+    static func parse(eastingText: String,
+                      northingText: String,
+                      mode: DigitMode,
+                      reference: CLLocationCoordinate2D? = nil) -> CLLocationCoordinate2D? {
+        let eClean = eastingText.trimmingCharacters(in: .whitespaces)
+        let nClean = northingText.trimmingCharacters(in: .whitespaces)
+        guard let eVal = Double(eClean), let nVal = Double(nClean) else { return nil }
+        guard eVal >= 0, nVal >= 0 else { return nil }
+
+        let easting: Double
+        let northing: Double
+
+        switch mode {
+        case .full7:
+            easting = eVal
+            northing = nVal
+        case .grid5:
+            // Recover the 100 km prefix from the reference coordinate.
+            let ref = reference ?? CLLocationCoordinate2D(latitude: 23.7, longitude: 121.0)
+            let (refE, refN) = project(ref)
+            let e100 = floor(refE / 100000.0) * 100000.0
+            let n100 = floor(refN / 100000.0) * 100000.0
+            // Keep only the local part of the typed value (guard against >5 digits).
+            easting = e100 + eVal.truncatingRemainder(dividingBy: 100000.0)
+            northing = n100 + nVal.truncatingRemainder(dividingBy: 100000.0)
+        }
+
+        let coord = twd97ToLatLon(easting: easting, northing: northing)
+        guard coord.latitude.isFinite, coord.longitude.isFinite else { return nil }
+        return coord
+    }
+
+    // MARK: - Formatting helpers
+
+    static func formatTWD97(_ coordinate: CLLocationCoordinate2D,
+                            mode: DigitMode = .full7,
+                            withSpaces: Bool = true) -> String {
+        guard let twd = latLonToTWD97(coordinate, mode: mode) else {
+            return "Out of TWD97 bounds"
+        }
+        return twd.formatted(withSpaces: withSpaces)
+    }
+
+    // MARK: - Validation
+
+    static func isWithinBounds(_ coordinate: CLLocationCoordinate2D) -> Bool {
+        return coordinate.latitude >= minLat && coordinate.latitude <= maxLat &&
+               coordinate.longitude >= minLon && coordinate.longitude <= maxLon
+    }
+}
+
+// MARK: - Extensions
+
+extension CLLocationCoordinate2D {
+    /// Convert to a TWD97 grid string in the given digit mode.
+    func toTWD97(mode: TWD97Converter.DigitMode = .full7) -> String {
+        TWD97Converter.formatTWD97(self, mode: mode)
+    }
+
+    /// Whether this coordinate falls inside the TWD97 (zone 121) bounds.
+    var isWithinTWD97Bounds: Bool {
+        TWD97Converter.isWithinBounds(self)
+    }
+}


### PR DESCRIPTION
## Why
A Taiwanese contributor (who did the zh-Hant localization) asked for **TWD97 / TM2 (Taiwan) grid** support and specifically wants to compare two digit-entry modes — **7+7** vs **5+5**. OmniTAK previously had no way to *type* a coordinate at all (display-only / tap-to-place), so this also adds a general "Go to Coordinate" entry point.

## What
- **`TWD97Converter`** — TWD97 / TM2 zone 121 (EPSG:3826). Transverse Mercator on GRS80 (lon0=121°, k0=0.9999, FE=250000, FN=0). TWD97 is GRS80/ITRF-referenced (`towgs84=0`) so **no datum shift** is needed. Redfearn forward/inverse.
- **Two digit-input modes**
  - `full7` — 7+7 absolute metres (the Taiwan 二度分帶 standard; unambiguous).
  - `grid5` — 5+5 truncated local grid (MGRS-style; shorter, but parsing recovers the 100 km cell from the current map centre).
- **"Go to Coordinate" sheet** (TWD97 / MGRS / Lat-Lon) with the 7+7 ⟷ 5+5 toggle, a live lat/lon + 7+7/5+5 readback preview, and a drop-marker toggle. Reachable from the Tools launcher (Navigation section).
- **Display + Settings** — `.twd97` added to the coordinate-format enums and the Settings format picker (full 7+7 readout).
- **Map jump** — new `.goToCoordinate` notification centres both the 2D (MapLibre) and 3D (Cesium) engines and optionally drops a marker. Handled on a sibling `EmptyView` (via `.background`) to keep `MapViewController.body` under the Swift type-checker ceiling.
- **i18n** — en + zh-Hant strings for all new UI.

## Verification
- Converter checked against the `yychen/twd97` reference: forward off by **0.004 m**, inverse by **~2e-8°**, central-meridian easting **= 250000 exact**, Taiwan round-trips **< 1 mm**.
- `xcodebuild` (Debug, iOS Simulator) **BUILD SUCCEEDED**.
- UI rendered (7+7 and 5+5 modes) — Taipei 101 `0306966 / 2769659` → `25.033971, 121.564504`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)