### PR TITLE
docs: drop FreeTAKServer references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Open-source TAK (Team Awareness Kit) client for iPhone and iPad, built in Swift 
 
 OmniTAK speaks Cursor-on-Target (CoT) over TLS to any TAK Server, supports data-package import, ADS-B traffic display, RTSP/SRT/HLS video feeds, Meshtastic radios, and more — designed for search-and-rescue, civil defense, and outdoor operations.
 
-> **Bring your own TAK Server.** OmniTAK is a client. Stand up [TAK Server](https://tak.gov) (community CIV edition) or [FreeTAKServer](https://github.com/FreeTAKTeam/FreeTakServer) and point OmniTAK at it.
+> **Bring your own TAK Server.** OmniTAK is a client. Stand up [TAK Server](https://tak.gov) (community CIV edition), [OpenTAKServer](https://github.com/brian7704/OpenTAKServer), or [taky](https://github.com/tkuester/taky) and point OmniTAK at it.
 
 ## Features
 
@@ -97,6 +97,6 @@ OmniTAK-iOS bundles or links the following open-source components:
 
 ## Acknowledgments
 
-Built by [Engindearing](https://engindearing.soy). Inspired by [ATAK](https://github.com/deptofdefense/AndroidTacticalAssaultKit-CIV), iTAK, [FreeTAKServer](https://github.com/FreeTAKTeam/FreeTakServer), and the broader TAK community.
+Built by [Engindearing](https://engindearing.soy). Inspired by [ATAK](https://github.com/deptofdefense/AndroidTacticalAssaultKit-CIV), iTAK, [OpenTAKServer](https://github.com/brian7704/OpenTAKServer), and the broader TAK community.
 
 OmniTAK is not affiliated with or endorsed by the U.S. Department of Defense, the TAK Product Center, or any other organization.


### PR DESCRIPTION
Replaces the two FreeTAKServer mentions in the README with OpenTAKServer/taky (community treats FreeTAKServer as dead). Mirrors the same scrub on OmniTAK-Android #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)