### PR TITLE
feat: OmniTAKPlugin SDK + ADS-B reference plugin (ios)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thanks for your interest in contributing.
 - For new features or larger changes, open an issue first so we can align on scope.
 - Security issues — see [SECURITY.md](SECURITY.md), do not file public issues.
 - Translating OmniTAK into your language? No coding needed — see [TRANSLATING.md](TRANSLATING.md).
+- Writing a plugin? See the [Plugin Authoring Guide](docs/PLUGIN_AUTHORING.md). Plugins are compile-time Swift modules (no dynamic code, store-compliant) that run in-process with the host's permissions. Add yours and open a PR, or **fork and sign your own build** (step 4 below) to ship a private plugin.
 
 ## Development setup
 

--- a/OmniTAKMobile.xcodeproj/project.pbxproj
+++ b/OmniTAKMobile.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		2F9034902998C844AA7E4C4F /* SUSP-------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 05AC64D605838B84290656CE /* SUSP-------.svg */; };
 		3026CC323DB5601B76A69A3C /* RemoteIdAppBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA65513B351E6E8D864A945A /* RemoteIdAppBridge.swift */; };
 		3192FC7F36458549D30B2536 /* OpenDroneIdMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2AA945C069E5E828101C96C /* OpenDroneIdMessage.swift */; };
+		323ACB8B767580D6B6193160 /* AppPluginHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A42F35542E714D9F02B359A /* AppPluginHost.swift */; };
 		326BFC60CF089F263DCD8E18 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D7BCCB87FE00A332286EAC /* ChatView.swift */; };
 		329823348C9D66C984345C11 /* SFGPUULF---.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6C8830EBB6B5623DB27B735A /* SFGPUULF---.svg */; };
 		32CE502758D1839A0036DBA4 /* SHGPUCF----.svg in Resources */ = {isa = PBXBuildFile; fileRef = C9D615A7D81FA6D8E304FD83 /* SHGPUCF----.svg */; };
@@ -108,6 +109,7 @@
 		40BF731A8AEC6898ECF72D6E /* UASManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF6C46A0E3F79DB84E2969DE /* UASManager.swift */; };
 		40D04307B87189E2E4A15118 /* KMZHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1103C5349FE3EE31708711A /* KMZHandler.swift */; };
 		42B40E22FFA4AE412996AE66 /* ToolbarAddPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE9342858430C8B11A6138F /* ToolbarAddPalette.swift */; };
+		42DCF526B899E93E4340934B /* ADSBStatusOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5821A1F45BE3F2985B6BAB51 /* ADSBStatusOverlay.swift */; };
 		4675EBCE9576F085769447EC /* SHGPEV-----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7D35639DBB6AB10DBC043C4B /* SHGPEV-----.svg */; };
 		480EBBF20019DACA98438F45 /* SNGPEVC----.svg in Resources */ = {isa = PBXBuildFile; fileRef = A041F038EB4BDB2644B549B4 /* SNGPEVC----.svg */; };
 		48D6F14168132D11BD618DF3 /* DataPackageBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0BF08DA781B87F179C32EF /* DataPackageBootstrap.swift */; };
@@ -142,6 +144,7 @@
 		664F8613B5F60B743FBF798E /* SUA---------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8D6AFD4385B2CB747A74C320 /* SUA---------.svg */; };
 		6671B330ED4920A501C466DB /* SHSPN------.svg in Resources */ = {isa = PBXBuildFile; fileRef = B1A726FDC5E3383C783799A5 /* SHSPN------.svg */; };
 		669DCCE82BC14EE536DD18ED /* MeshtasticDevicePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D37E8D6422BE44C712E352 /* MeshtasticDevicePickerView.swift */; };
+		66EDD846BBB4E19FA31C4F4C /* OmniTAKPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7461A51CEB529C4EF2633B /* OmniTAKPlugin.swift */; };
 		67D3B55F33075F852EB28D49 /* TeamStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800C09D831D949B6F1EDAEC8 /* TeamStorageManager.swift */; };
 		699963A931BB1144AA2450EB /* MissionSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03640AD0D5107F1549F5ED69 /* MissionSyncManager.swift */; };
 		6A462FF3940BB68E22278B37 /* SFFPG------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 00359DE8F222FE7021D1936A /* SFFPG------.svg */; };
@@ -177,6 +180,8 @@
 		7A561F6FD16BAD7A833D3763 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D159CF2A7D23BFC860F0010 /* Foundation.framework */; };
 		7BFF2B6B31AB35C047B293DD /* LassoSelectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E14DC8F84F9C7A9721FDD03 /* LassoSelectionService.swift */; };
 		7D14F0452B6D98AD5FB1FC0D /* ConversationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D15E6FD65F0D6C4467F8C3D /* ConversationView.swift */; };
+		7E069116B694B15B5EFDE612 /* DiagnosticsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F55D934522295329FE6400 /* DiagnosticsPlugin.swift */; };
+		7E5C86C855523AF841D45383 /* PluginHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6A1EA71D839AA2F8A09BAE /* PluginHost.swift */; };
 		7EDBE9DF6FFCE3C341C5E915 /* DigitalPointerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C09CF368D064E2DA8CDF9BA /* DigitalPointerView.swift */; };
 		7FB3B16574296B84A7731FF4 /* LassoShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01560943F910CBC6CC9CA56B /* LassoShareSheet.swift */; };
 		80428D117637BA916DE86564 /* SUAPMF-----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 32A0B14AA6AE2A4EA6F01207 /* SUAPMF-----.svg */; };
@@ -269,6 +274,7 @@
 		BA99585B9C229B3644590571 /* SUGPU------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 48F59F0E2FEC5B9DA32F3AC8 /* SUGPU------.svg */; };
 		BAE1A69DAA51A73F27D59B30 /* MissionPackageModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46167ED785145DB9FB57E36B /* MissionPackageModels.swift */; };
 		BBA4E00E6B526C5939CA07A8 /* GeofenceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F2DB9AB5D80CD00790B99A /* GeofenceService.swift */; };
+		BD5ED2F273C06C32FB3CAA0E /* ADSBPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E000347E77659FB9483E560 /* ADSBPlugin.swift */; };
 		BDD83D4EA1EAB1CD33C2F952 /* SFGPUCC----.svg in Resources */ = {isa = PBXBuildFile; fileRef = A4D85637E0B5D71017B5C838 /* SFGPUCC----.svg */; };
 		BE1302070F2B180A654031B8 /* SFAPACF----.svg in Resources */ = {isa = PBXBuildFile; fileRef = C2DAE3A8F3F0D5B7D8036B3E /* SFAPACF----.svg */; };
 		BF606D9CA4F7B9161B76A81A /* RouteModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82EDDDAEBCE973D79E5F5EE /* RouteModels.swift */; };
@@ -324,6 +330,7 @@
 		DE13E8D462F0655B012B5AB0 /* RadialMenuModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBC2615A833D70CD96C5723 /* RadialMenuModels.swift */; };
 		DE33389B8145869804340112 /* BNGConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5160EE3247DE0377F3E6CE8 /* BNGConverter.swift */; };
 		DFE26C2C7FD86309FED7802E /* MapDrawingAnnotations.swift in Sources */ = {isa = PBXBuildFile; fileRef = F27DAD8386D9D7209EE02AA9 /* MapDrawingAnnotations.swift */; };
+		DFE366B176992E3CE85E10BF /* PluginRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D95E31A4FB55F17B88EDA43 /* PluginRegistry.swift */; };
 		E1F2A3B4C5D6E7F809182930 /* PointMarkerEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B4C5D6E7F809182931 /* PointMarkerEditView.swift */; };
 		E3397D517A54F6F76789C606 /* MeshtasticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E7E03CF8CE1ECA81C1AA86 /* MeshtasticManager.swift */; };
 		E5F60718293A4B5C6D7E8F90 /* ToolRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F60718293A4B5C6D7E8F91 /* ToolRegistry.swift */; };
@@ -352,6 +359,7 @@
 		F66BDCCD78E7446A9737057C /* SNAPCF-----.svg in Resources */ = {isa = PBXBuildFile; fileRef = D4AAA687C9A021C584BE3F52 /* SNAPCF-----.svg */; };
 		F720E811AF90DCA402FF9A0A /* SFAPMFL----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 899C0E42F58AE75FEE792EF9 /* SFAPMFL----.svg */; };
 		F81269402CB71F4BF231A86B /* DataPackageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27AFF7080BC1929C0AFE3ACB /* DataPackageManager.swift */; };
+		F831B10A1D135F2E88925F52 /* PluginSDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5B1610A03C98F73C6517BA8 /* PluginSDKTests.swift */; };
 		F887E26E229854DF18D1F96B /* SFAPMHQ----.svg in Resources */ = {isa = PBXBuildFile; fileRef = AE725B92EA137887258221CB /* SFAPMHQ----.svg */; };
 		F9A4209563B079DBC2B05FD7 /* SHGPUC-----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 2E68A74AC57A313668A716ED /* SHGPUC-----.svg */; };
 		F9E1491477B06406FB3F8370 /* SFGPUULC---.svg in Resources */ = {isa = PBXBuildFile; fileRef = D4EB93CD70E0285BEEAFF8C2 /* SFGPUULC---.svg */; };
@@ -431,7 +439,9 @@
 		1D159CF2A7D23BFC860F0010 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		1D1C7A259A982FE51C314BC9 /* SUAPMFQ----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUAPMFQ----.svg"; sourceTree = "<group>"; };
 		1D9483CD3E2E5125BE1AA9E6 /* SNGPUCA----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNGPUCA----.svg"; sourceTree = "<group>"; };
+		1D95E31A4FB55F17B88EDA43 /* PluginRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PluginRegistry.swift; path = OmniTAKMobile/Core/Plugin/PluginRegistry.swift; sourceTree = "<group>"; };
 		1DC0C8D80513324CC26F57F5 /* SFGPEVU----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPEVU----.svg"; sourceTree = "<group>"; };
+		1E000347E77659FB9483E560 /* ADSBPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ADSBPlugin.swift; path = OmniTAKMobile/Features/ADSB/Plugin/ADSBPlugin.swift; sourceTree = "<group>"; };
 		1EBC84DF2F7B1C325E9B3B16 /* SHGPUCA----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGPUCA----.svg"; sourceTree = "<group>"; };
 		21ECE157083843DC0D219677 /* ADSBTrafficView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ADSBTrafficView.swift; path = OmniTAKMobile/Features/ADSB/Views/ADSBTrafficView.swift; sourceTree = "<group>"; };
 		2272CD08893F8EF861E29ED6 /* DrawingPersistence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DrawingPersistence.swift; path = OmniTAKMobile/Storage/DrawingPersistence.swift; sourceTree = "<group>"; };
@@ -468,6 +478,7 @@
 		38E9D249C5D2CAAAC7C659D8 /* SUGPUCF----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUGPUCF----.svg"; sourceTree = "<group>"; };
 		397C16C7CEF45EB144B930F7 /* MeshTopologyView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshTopologyView.swift; path = OmniTAKMobile/Features/Meshtastic/Views/MeshTopologyView.swift; sourceTree = "<group>"; };
 		39F6E5D7A7C95BE91E8BE483 /* QuickActionToolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickActionToolbar.swift; path = OmniTAKMobile/Shared/UI/Components/QuickActionToolbar.swift; sourceTree = "<group>"; };
+		3A42F35542E714D9F02B359A /* AppPluginHost.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppPluginHost.swift; path = OmniTAKMobile/Core/Plugin/AppPluginHost.swift; sourceTree = "<group>"; };
 		3B72EF5EEBCC4E173B3AE30D /* SNSPX------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNSPX------.svg"; sourceTree = "<group>"; };
 		3B8D46995079943866D66720 /* CSRGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CSRGenerator.swift; path = OmniTAKMobile/Features/Networking/Managers/CSRGenerator.swift; sourceTree = "<group>"; };
 		3C25D7BA7181F30D138606EF /* MarkerCoTGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MarkerCoTGenerator.swift; path = OmniTAKMobile/CoT/Generators/MarkerCoTGenerator.swift; sourceTree = "<group>"; };
@@ -497,6 +508,7 @@
 		4DDD8DDEB436C02547BD18EF /* TacticalMapView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TacticalMapView.swift; path = OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift; sourceTree = "<group>"; };
 		4EDF33D868687EC0C282728B /* VideoFeedListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VideoFeedListView.swift; path = OmniTAKMobile/Features/Video/Views/VideoFeedListView.swift; sourceTree = "<group>"; };
 		4EF946351E50BE67B043D862 /* EmergencyBeaconView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EmergencyBeaconView.swift; path = OmniTAKMobile/Features/Tracking/Views/EmergencyBeaconView.swift; sourceTree = "<group>"; };
+		4F6A1EA71D839AA2F8A09BAE /* PluginHost.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PluginHost.swift; path = OmniTAKMobile/Core/Plugin/PluginHost.swift; sourceTree = "<group>"; };
 		4F8ACF5C79A664EA965A8201 /* SNAPMHQ----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNAPMHQ----.svg"; sourceTree = "<group>"; };
 		50F7DBC520F74BA47052BCB7 /* ATAKLoadingScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ATAKLoadingScreen.swift; path = OmniTAKMobile/Shared/UI/Components/ATAKLoadingScreen.swift; sourceTree = "<group>"; };
 		5139B0026D3BA5CE25F70D1C /* RemoteIdTrackStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RemoteIdTrackStore.swift; path = OmniTAKMobile/Features/RemoteID/Services/RemoteIdTrackStore.swift; sourceTree = "<group>"; };
@@ -506,6 +518,7 @@
 		55AC5270E9592B701917919E /* MeasurementCalculator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeasurementCalculator.swift; path = OmniTAKMobile/Utilities/Calculators/MeasurementCalculator.swift; sourceTree = "<group>"; };
 		56AC5271E9592B701917920E /* UnitPreferences.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UnitPreferences.swift; path = OmniTAKMobile/Utilities/Preferences/UnitPreferences.swift; sourceTree = "<group>"; };
 		57D7BCCB87FE00A332286EAC /* ChatView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatView.swift; path = OmniTAKMobile/Features/Chat/Views/ChatView.swift; sourceTree = "<group>"; };
+		5821A1F45BE3F2985B6BAB51 /* ADSBStatusOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ADSBStatusOverlay.swift; path = OmniTAKMobile/Features/ADSB/Plugin/ADSBStatusOverlay.swift; sourceTree = "<group>"; };
 		5D0010AE2E37C9E003C21B22 /* SFGPEVL----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPEVL----.svg"; sourceTree = "<group>"; };
 		5D2A5DFDD7975D09495FA81A /* TrackOverlayRenderer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TrackOverlayRenderer.swift; path = OmniTAKMobile/Features/Map/Overlays/TrackOverlayRenderer.swift; sourceTree = "<group>"; };
 		5D88231F174B75D559DD2B4A /* LocationManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocationManager.swift; path = OmniTAKMobile/Features/Map/Controllers/LocationManager.swift; sourceTree = "<group>"; };
@@ -584,6 +597,7 @@
 		8E63BBCFD2826242AD21153A /* OmniTAKMobile.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; path = OmniTAKMobile.xcframework; sourceTree = "<group>"; };
 		8E9F6D6CCA2BD4F9DC7AB527 /* ElevationProfileService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElevationProfileService.swift; path = OmniTAKMobile/Features/Measurement/Services/ElevationProfileService.swift; sourceTree = "<group>"; };
 		8F3B7BEB56FAFB09686EF170 /* RadialMenuView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadialMenuView.swift; path = OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuView.swift; sourceTree = "<group>"; };
+		8F7461A51CEB529C4EF2633B /* OmniTAKPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OmniTAKPlugin.swift; path = OmniTAKMobile/Core/Plugin/OmniTAKPlugin.swift; sourceTree = "<group>"; };
 		9001E88B5E1060AC73E893AF /* SFAPACR----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFAPACR----.svg"; sourceTree = "<group>"; };
 		90C26A4593204D06AECCDD22 /* MapLibreService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MapLibreService.swift; path = OmniTAKMobile/Features/Map/MapLibre/MapLibreService.swift; sourceTree = "<group>"; };
 		910FF6E5A809EA603DD125C4 /* Config.base.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Config.base.xcconfig; sourceTree = "<group>"; };
@@ -662,9 +676,11 @@
 		C354E89D594F3D222E851AAC /* MAVLinkCodec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MAVLinkCodec.swift; path = OmniTAKMobile/Features/UAS/Services/MAVLinkCodec.swift; sourceTree = "<group>"; };
 		C3D4E5F60718293A4B5C6D7F /* TAKTLSSessionDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TAKTLSSessionDelegate.swift; path = OmniTAKMobile/Features/Networking/Services/TAKTLSSessionDelegate.swift; sourceTree = "<group>"; };
 		C4C6755C8B6629F45526C18E /* SUAPMHQ----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUAPMHQ----.svg"; sourceTree = "<group>"; };
+		C5B1610A03C98F73C6517BA8 /* PluginSDKTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PluginSDKTests.swift; path = OmniTAKMobileTests/PluginSDKTests.swift; sourceTree = "<group>"; };
 		C644AA06A8883B0013638A4E /* OpenDroneIdParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OpenDroneIdParserTests.swift; path = OmniTAKMobileTests/OpenDroneIdParserTests.swift; sourceTree = "<group>"; };
 		C79FECE8C2536E714592CD83 /* SHGPUCS----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGPUCS----.svg"; sourceTree = "<group>"; };
 		C7E7E03CF8CE1ECA81C1AA86 /* MeshtasticManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshtasticManager.swift; path = OmniTAKMobile/Features/Meshtastic/Managers/MeshtasticManager.swift; sourceTree = "<group>"; };
+		C7F55D934522295329FE6400 /* DiagnosticsPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DiagnosticsPlugin.swift; path = OmniTAKMobile/Core/Plugin/DiagnosticsPlugin.swift; sourceTree = "<group>"; };
 		C9061E709C3A3E96A69BE03F /* SUAPCF-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUAPCF-----.svg"; sourceTree = "<group>"; };
 		C97F12CEA4D82BCF13A41600 /* SFAPMHA----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFAPMHA----.svg"; sourceTree = "<group>"; };
 		C9D615A7D81FA6D8E304FD83 /* SHGPUCF----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGPUCF----.svg"; sourceTree = "<group>"; };
@@ -1856,6 +1872,14 @@
 				BFF18F129EFC1CBA15C256D1 /* OmniTAKMobileUITests */,
 				910FF6E5A809EA603DD125C4 /* Config.base.xcconfig */,
 				1D3ED0E6F3C20B29A5C0C506 /* OmniTAKMobileTests */,
+				8F7461A51CEB529C4EF2633B /* OmniTAKPlugin.swift */,
+				4F6A1EA71D839AA2F8A09BAE /* PluginHost.swift */,
+				1D95E31A4FB55F17B88EDA43 /* PluginRegistry.swift */,
+				3A42F35542E714D9F02B359A /* AppPluginHost.swift */,
+				C7F55D934522295329FE6400 /* DiagnosticsPlugin.swift */,
+				1E000347E77659FB9483E560 /* ADSBPlugin.swift */,
+				5821A1F45BE3F2985B6BAB51 /* ADSBStatusOverlay.swift */,
+				C5B1610A03C98F73C6517BA8 /* PluginSDKTests.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2637,6 +2661,7 @@
 				1412A35EC6121F54838D6CCA /* ServerValidatorTests.swift in Sources */,
 				B4862ADC1DD9D4427C0DB504 /* TAKPacketCodecTests.swift in Sources */,
 				4DF8129B40825E01D7F5BA79 /* TAKServiceTests.swift in Sources */,
+				F831B10A1D135F2E88925F52 /* PluginSDKTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2865,6 +2890,13 @@
 				F16F23716C9A564FD3B17635 /* TacticalMapView.swift in Sources */,
 				DFE26C2C7FD86309FED7802E /* MapDrawingAnnotations.swift in Sources */,
 				D242ADA51531BB1EBAD15446 /* CesiumMainMap.swift in Sources */,
+				66EDD846BBB4E19FA31C4F4C /* OmniTAKPlugin.swift in Sources */,
+				7E5C86C855523AF841D45383 /* PluginHost.swift in Sources */,
+				DFE366B176992E3CE85E10BF /* PluginRegistry.swift in Sources */,
+				323ACB8B767580D6B6193160 /* AppPluginHost.swift in Sources */,
+				7E069116B694B15B5EFDE612 /* DiagnosticsPlugin.swift in Sources */,
+				BD5ED2F273C06C32FB3CAA0E /* ADSBPlugin.swift in Sources */,
+				42DCF526B899E93E4340934B /* ADSBStatusOverlay.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OmniTAKMobile/CoT/CoTEventHandler.swift
+++ b/OmniTAKMobile/CoT/CoTEventHandler.swift
@@ -187,6 +187,9 @@ class CoTEventHandler: ObservableObject {
                 object: self,
                 userInfo: ["event": event]
             )
+            // Plugin SDK — fire registered CoT handlers AFTER the core store
+            // ingested the event (runs on main, same as the rest of handle()).
+            _ = AppPluginHost.shared.dispatchCoT(event)
             takService?.onCoTReceived?(event)
             return
         }
@@ -225,6 +228,11 @@ class CoTEventHandler: ObservableObject {
             object: self,
             userInfo: ["event": event]
         )
+
+        // Plugin SDK — fire registered CoT handlers AFTER the core store
+        // ingested the event (and after the core publishers). Handlers run on
+        // main; a handler returning true marks the event consumed.
+        _ = AppPluginHost.shared.dispatchCoT(event)
 
         // Trigger callback
         takService?.onCoTReceived?(event)

--- a/OmniTAKMobile/Core/App/OmniTAKMobileApp.swift
+++ b/OmniTAKMobile/Core/App/OmniTAKMobileApp.swift
@@ -35,6 +35,14 @@ struct OmniTAKMobileApp: App {
         // Wire the external gyb_detect sensor bridge (BLE GATT WiFi-RID
         // stream). On/off mirrors @AppStorage("gybDetectorEnabled") below.
         _ = GybManager.shared
+
+        // Plugin SDK — populate the COMPILE-TIME registry and activate the
+        // plugins the user has enabled. There is NO dynamic / downloadable
+        // code: bundled plugins are Swift types linked into the binary
+        // (loadBundledPlugins) — App-Store compliant. Plugins run IN-PROCESS
+        // with the host's full permissions; there is no sandbox.
+        PluginRegistry.shared.loadBundledPlugins()
+        PluginRegistry.shared.activateEnabled(host: AppPluginHost.shared)
     }
 
     var body: some Scene {

--- a/OmniTAKMobile/Core/Plugin/AppPluginHost.swift
+++ b/OmniTAKMobile/Core/Plugin/AppPluginHost.swift
@@ -1,0 +1,132 @@
+//
+//  AppPluginHost.swift
+//  OmniTAKMobile
+//
+//  Concrete `PluginHost`. Holds the registered hooks from all active plugins
+//  and exposes them to the four real seams:
+//    - map overlays  → MapViewController.mapChrome (both engines)
+//    - radial actions → RadialMenuMapCoordinator / RadialMenuActionExecutor
+//    - CoT handlers   → CoTEventHandler.handlePositionUpdate (post-ingest)
+//    - settings rows  → PluginsListView
+//
+//  Every registration is tagged with the pluginId the registry is currently
+//  activating (set via `currentlyActivating`), so `removeHooks(for:)` can
+//  cleanly tear down a single plugin on deactivate.
+//
+
+import SwiftUI
+import CoreLocation
+import Combine
+
+final class AppPluginHost: ObservableObject, PluginHost {
+    static let shared = AppPluginHost()
+
+    // MARK: - Registered hooks (observed by the UI seams)
+
+    struct OverlayEntry: Identifiable {
+        let id: String          // "<pluginId>#<index>"
+        let pluginId: String
+        let view: () -> AnyView
+    }
+
+    struct SettingsRowEntry: Identifiable {
+        let id: String          // "<pluginId>#<index>"
+        let pluginId: String
+        let label: String
+        let icon: String
+    }
+
+    struct RadialEntry {
+        let pluginId: String
+        let item: RadialMenuItem
+        let onSelect: (CLLocationCoordinate2D) -> Void
+    }
+
+    struct CoTHandlerEntry {
+        let pluginId: String
+        let handler: (CoTEvent) -> Bool
+    }
+
+    /// Map overlays rendered in the engine-agnostic chrome on BOTH engines.
+    @Published private(set) var mapOverlays: [OverlayEntry] = []
+    /// Rows shown in Settings → Plugins (navigate into settingsContent()).
+    @Published private(set) var settingsRows: [SettingsRowEntry] = []
+    /// Radial menu items appended to the empty-map long-press menu.
+    private(set) var radialActions: [RadialEntry] = []
+    /// Handlers fired after the core store ingests an inbound CoT event.
+    private(set) var cotHandlers: [CoTHandlerEntry] = []
+
+    /// The pluginId the registry is currently activating. Every register*
+    /// call tags its hook with this so deactivate can remove it cleanly.
+    var currentlyActivating: String?
+
+    private init() {}
+
+    // MARK: - PluginHost
+
+    func registerMapOverlay(_ overlay: @escaping () -> AnyView) {
+        let owner = currentlyActivating ?? "unknown"
+        let entry = OverlayEntry(id: "\(owner)#\(mapOverlays.count)",
+                                 pluginId: owner,
+                                 view: overlay)
+        mapOverlays.append(entry)
+    }
+
+    func registerRadialAction(_ action: RadialMenuItem,
+                              onSelect: @escaping (CLLocationCoordinate2D) -> Void) {
+        let owner = currentlyActivating ?? "unknown"
+        radialActions.append(RadialEntry(pluginId: owner, item: action, onSelect: onSelect))
+    }
+
+    func registerCoTHandler(_ handler: @escaping (CoTEvent) -> Bool) {
+        let owner = currentlyActivating ?? "unknown"
+        cotHandlers.append(CoTHandlerEntry(pluginId: owner, handler: handler))
+    }
+
+    func registerSettingsRow(label: String, icon: String) {
+        let owner = currentlyActivating ?? "unknown"
+        let entry = SettingsRowEntry(id: "\(owner)#\(settingsRows.count)",
+                                     pluginId: owner,
+                                     label: label,
+                                     icon: icon)
+        settingsRows.append(entry)
+    }
+
+    // MARK: - Teardown
+
+    /// Remove every hook a plugin registered. Called from the registry on
+    /// `deactivate(pluginId:)`.
+    func removeHooks(for pluginId: String) {
+        mapOverlays.removeAll { $0.pluginId == pluginId }
+        settingsRows.removeAll { $0.pluginId == pluginId }
+        radialActions.removeAll { $0.pluginId == pluginId }
+        cotHandlers.removeAll { $0.pluginId == pluginId }
+    }
+
+    // MARK: - CoT dispatch
+
+    /// Fire every registered CoT handler in order. Short-circuits and returns
+    /// `true` as soon as a handler consumes the event. Called from
+    /// CoTEventHandler AFTER the core store ingests the event.
+    @discardableResult
+    func dispatchCoT(_ event: CoTEvent) -> Bool {
+        for entry in cotHandlers {
+            if entry.handler(event) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Look up a registered radial action by its `.custom(identifier)` value
+    /// and invoke its onSelect with the pressed coordinate. Returns true when
+    /// a matching registered action was found and fired.
+    @discardableResult
+    func fireRadialAction(identifier: String, at coordinate: CLLocationCoordinate2D) -> Bool {
+        for entry in radialActions where entry.item.action.identifier == identifier {
+            entry.onSelect(coordinate)
+            return true
+        }
+        return false
+    }
+}

--- a/OmniTAKMobile/Core/Plugin/DiagnosticsPlugin.swift
+++ b/OmniTAKMobile/Core/Plugin/DiagnosticsPlugin.swift
@@ -1,0 +1,54 @@
+//
+//  DiagnosticsPlugin.swift
+//  OmniTAKMobile
+//
+//  A tiny internal plugin that exercises the OTHER two host hooks the ADS-B
+//  reference plugin doesn't need: `registerRadialAction` and
+//  `registerCoTHandler`. Together with ADS-B (overlay + settings row) this
+//  wires the ENTIRE host surface so the whole SDK is exercised end-to-end.
+//
+//  It is DISABLED by default (see PluginSettingsManager.registeredDisabledByDefault)
+//  so it never affects shipping users — it only proves the surface works, and
+//  is covered by PluginSDKTests regardless of its enable state.
+//
+
+import SwiftUI
+import CoreLocation
+
+final class DiagnosticsPlugin: OmniTAKPlugin {
+    let pluginId = "soy.engindearing.diagnostics"
+    let displayName = "Diagnostics"
+    let pluginVersion = "1.0.0"
+    let pluginAuthor = "Engindearing"
+    let pluginDescription = "Internal SDK diagnostics — radial probe + CoT event counter (off by default)"
+
+    /// Count of inbound CoT events seen by the registered handler. Useful as a
+    /// liveness probe when the plugin is enabled during development.
+    private(set) var cotEventCount = 0
+
+    func activate(host: PluginHost) {
+        // Hook 3: radial action. Adds a "Diag" entry to the empty-map
+        // long-press menu; tapping it logs the pressed coordinate.
+        host.registerRadialAction(
+            RadialMenuItem(
+                icon: "ladybug",
+                label: "Diag",
+                action: .custom("plugin_diag")
+            ),
+            onSelect: { coordinate in
+                print("[DiagnosticsPlugin] radial action at \(coordinate.latitude), \(coordinate.longitude)")
+            }
+        )
+
+        // Hook 4: CoT handler. Counts inbound position events and returns
+        // false (does NOT consume) so the rest of the pipeline is untouched.
+        host.registerCoTHandler { [weak self] _ in
+            self?.cotEventCount += 1
+            return false
+        }
+    }
+
+    func deactivate() {
+        cotEventCount = 0
+    }
+}

--- a/OmniTAKMobile/Core/Plugin/OmniTAKPlugin.swift
+++ b/OmniTAKMobile/Core/Plugin/OmniTAKPlugin.swift
@@ -1,0 +1,62 @@
+//
+//  OmniTAKPlugin.swift
+//  OmniTAKMobile
+//
+//  The OmniTAK plugin SDK — protocol every bundled plugin conforms to.
+//
+//  STORE-COMPLIANCE: plugins are COMPILE-TIME Swift types. There is no
+//  dynamic / downloadable code, no dylib loading, no remote execution. A
+//  plugin is just a class that conforms to this protocol and gets registered
+//  at app start in `PluginRegistry.loadBundledPlugins()`. This keeps the SDK
+//  App-Store compliant.
+//
+//  TRUST MODEL: a plugin runs IN-PROCESS with the host app's full
+//  permissions. There is no sandbox. Authors (and reviewers) must treat a
+//  plugin's code as part of the app. See docs/PLUGIN_AUTHORING.md.
+//
+
+import SwiftUI
+
+/// A bundled OmniTAK plugin. Conform a final class to this protocol, then
+/// register it in `PluginRegistry.loadBundledPlugins()`.
+///
+/// The shape is intentionally identical to the Android `OmniTAKPlugin`
+/// interface so a plugin ports across platforms in roughly a day — the same
+/// `pluginId` (reverse-DNS, e.g. "soy.engindearing.adsb") drives settings
+/// persistence on both platforms.
+protocol OmniTAKPlugin: AnyObject {
+    /// Stable reverse-DNS identifier, e.g. "soy.engindearing.adsb". Used as
+    /// the persistence key for the enable flag and to tag every registered
+    /// hook with its owner. MUST be unique and stable across releases.
+    var pluginId: String { get }
+
+    /// Human-readable name shown in Settings → Plugins.
+    var displayName: String { get }
+
+    /// Semantic version of the plugin, e.g. "1.0.0".
+    var pluginVersion: String { get }
+
+    /// Plugin author / vendor.
+    var pluginAuthor: String { get }
+
+    /// One-line description shown under the plugin row.
+    var pluginDescription: String { get }
+
+    /// Called when the plugin is activated (at app start if enabled, or when
+    /// the user toggles it on). Register the plugin's hooks on `host` here.
+    func activate(host: PluginHost)
+
+    /// Called when the plugin is deactivated (user toggles it off). Stop any
+    /// work the plugin started; the registry removes the plugin's registered
+    /// hooks from the host automatically.
+    func deactivate()
+
+    /// Optional settings UI. Returns a type-erased SwiftUI view shown when the
+    /// user taps into the plugin row in Settings → Plugins. Default: `nil`.
+    func settingsContent() -> AnyView?
+}
+
+extension OmniTAKPlugin {
+    /// Default: no settings UI.
+    func settingsContent() -> AnyView? { nil }
+}

--- a/OmniTAKMobile/Core/Plugin/PluginHost.swift
+++ b/OmniTAKMobile/Core/Plugin/PluginHost.swift
@@ -1,0 +1,42 @@
+//
+//  PluginHost.swift
+//  OmniTAKMobile
+//
+//  The surface a plugin uses to register hooks into the host app. Passed to
+//  `OmniTAKPlugin.activate(host:)`. There are exactly four hooks, mirrored
+//  1:1 on Android so plugins port across platforms.
+//
+
+import SwiftUI
+import CoreLocation
+
+/// The four host hooks a plugin can register through during `activate(host:)`.
+///
+/// All registrations are tagged with the currently-activating plugin's
+/// `pluginId` by the host, so `deactivate(pluginId:)` can cleanly remove just
+/// that plugin's hooks.
+protocol PluginHost: AnyObject {
+    /// Register a SwiftUI overlay rendered in the engine-agnostic map chrome
+    /// layer. The closure is invoked each render pass; return a type-erased
+    /// view. The overlay sits ABOVE the map and BELOW the radial menu, on
+    /// BOTH map engines (Cesium 3D + Mapbox 2D), because it mounts in the
+    /// shared `mapChrome` seam — never inside a single engine.
+    func registerMapOverlay(_ overlay: @escaping () -> AnyView)
+
+    /// Register an entry in the map long-press radial menu (empty-map
+    /// context). `onSelect` fires with the pressed map coordinate when the
+    /// operator taps the entry. The entry is still subject to the per-plugin
+    /// enable filter.
+    func registerRadialAction(_ action: RadialMenuItem,
+                              onSelect: @escaping (CLLocationCoordinate2D) -> Void)
+
+    /// Register a handler called for every inbound CoT position event AFTER
+    /// the core store ingests it. Return `true` to mark the event consumed
+    /// (short-circuits remaining handlers). Handlers run on the main thread —
+    /// keep them cheap and non-blocking.
+    func registerCoTHandler(_ handler: @escaping (CoTEvent) -> Bool)
+
+    /// Register a row in Settings → Plugins that navigates to the plugin's
+    /// `settingsContent()`. `icon` is an SF Symbol name.
+    func registerSettingsRow(label: String, icon: String)
+}

--- a/OmniTAKMobile/Core/Plugin/PluginRegistry.swift
+++ b/OmniTAKMobile/Core/Plugin/PluginRegistry.swift
@@ -1,0 +1,86 @@
+//
+//  PluginRegistry.swift
+//  OmniTAKMobile
+//
+//  The compile-time plugin registry. Bundled plugins are registered at app
+//  start in `loadBundledPlugins()` — there is NO dynamic loading. Enablement
+//  is delegated to `PluginSettingsManager` so registered plugins share the
+//  exact same toggle-persistence system as the fixed-capability plugins.
+//
+
+import Foundation
+
+final class PluginRegistry {
+    static let shared = PluginRegistry()
+
+    /// All registered plugins, in registration order.
+    private(set) var plugins: [OmniTAKPlugin] = []
+
+    /// pluginIds that are currently activated (hooks live on the host).
+    private(set) var activated: Set<String> = []
+
+    private init() {}
+
+    // MARK: - Registration
+
+    /// Register a plugin. Idempotent by pluginId.
+    func register(_ plugin: OmniTAKPlugin) {
+        guard !plugins.contains(where: { $0.pluginId == plugin.pluginId }) else { return }
+        plugins.append(plugin)
+    }
+
+    /// All registered plugins.
+    func all() -> [OmniTAKPlugin] { plugins }
+
+    /// Find a registered plugin by id.
+    func plugin(withId pluginId: String) -> OmniTAKPlugin? {
+        plugins.first { $0.pluginId == pluginId }
+    }
+
+    func isActivated(_ pluginId: String) -> Bool {
+        activated.contains(pluginId)
+    }
+
+    // MARK: - Bundled plugins (COMPILE-TIME — store compliant)
+
+    /// Register the plugins shipped inside the app binary. This is the ONLY
+    /// place plugins enter the registry; adding a plugin means adding a line
+    /// here (plus the new Swift file in the Xcode target). No dynamic code.
+    func loadBundledPlugins() {
+        register(ADSBPlugin())
+        register(DiagnosticsPlugin())
+    }
+
+    // MARK: - Activation
+
+    /// Activate exactly the plugins the user has enabled (per
+    /// PluginSettingsManager). Called once at app start after
+    /// `loadBundledPlugins()`.
+    func activateEnabled(host: AppPluginHost) {
+        for plugin in plugins {
+            if PluginSettingsManager.shared.isRegisteredPluginEnabled(plugin.pluginId) {
+                activate(pluginId: plugin.pluginId, host: host)
+            }
+        }
+    }
+
+    /// Activate a single plugin: tag the host with its id, call activate, and
+    /// record it. Idempotent.
+    func activate(pluginId: String, host: AppPluginHost) {
+        guard let plugin = plugin(withId: pluginId) else { return }
+        guard !activated.contains(pluginId) else { return }
+        host.currentlyActivating = pluginId
+        plugin.activate(host: host)
+        host.currentlyActivating = nil
+        activated.insert(pluginId)
+    }
+
+    /// Deactivate a single plugin: call its deactivate(), strip its hooks from
+    /// the host, and forget it. Idempotent.
+    func deactivate(pluginId: String, host: AppPluginHost) {
+        guard activated.contains(pluginId) else { return }
+        plugin(withId: pluginId)?.deactivate()
+        host.removeHooks(for: pluginId)
+        activated.remove(pluginId)
+    }
+}

--- a/OmniTAKMobile/Features/ADSB/Plugin/ADSBPlugin.swift
+++ b/OmniTAKMobile/Features/ADSB/Plugin/ADSBPlugin.swift
@@ -1,0 +1,55 @@
+//
+//  ADSBPlugin.swift
+//  OmniTAKMobile
+//
+//  REFERENCE PLUGIN. Wraps the existing ADS-B feature as an OmniTAKPlugin
+//  with ZERO behavior change.
+//
+//  WHY THE RENDERING PATH IS UNTOUCHED: ADS-B does not draw through a SwiftUI
+//  overlay. Aircraft flow as a `[Aircraft]` data array straight into BOTH map
+//  engines (TacticalMapView + CesiumMainMap), gated by
+//  `ADSBTrafficService.shared.settings.isEnabled`. That proven pipeline stays
+//  byte-identical. The plugin only ADDS the SDK wrapper: a map-overlay hook
+//  (a thin status surface) and a settings row that opens the existing
+//  ADSBTrafficView verbatim. The single source of truth remains
+//  `ADSBTrafficService.shared`.
+//
+
+import SwiftUI
+
+final class ADSBPlugin: OmniTAKPlugin {
+    let pluginId = "soy.engindearing.adsb"
+    let displayName = "ADS-B"
+    let pluginVersion = "1.0.0"
+    let pluginAuthor = "Engindearing"
+    let pluginDescription = "ADS-B aircraft traffic overlay"
+
+    func activate(host: PluginHost) {
+        // Hook 1: map overlay rendered in the engine-agnostic chrome on BOTH
+        // engines. ADS-B's actual aircraft markers keep coming from the two
+        // engines as a data array, so this overlay is an unobtrusive status
+        // surface (default: nothing rendered) — guaranteeing zero visual
+        // change vs the pre-plugin app.
+        host.registerMapOverlay { AnyView(ADSBStatusOverlay()) }
+
+        // Hook 2: settings row → settingsContent() (the existing full ADS-B
+        // settings/list screen).
+        host.registerSettingsRow(label: "ADS-B", icon: "airplane.circle.fill")
+    }
+
+    func deactivate() {
+        // Bridge plugin-off → service-off, reusing the existing didSet →
+        // stopTracking() semantics. This preserves the exact behavior of the
+        // legacy ADS-B toggle.
+        if ADSBTrafficService.shared.settings.isEnabled {
+            var settings = ADSBTrafficService.shared.settings
+            settings.isEnabled = false
+            ADSBTrafficService.shared.settings = settings
+        }
+    }
+
+    func settingsContent() -> AnyView? {
+        // Reuse the existing settings/list view verbatim — no new UI.
+        AnyView(ADSBTrafficView())
+    }
+}

--- a/OmniTAKMobile/Features/ADSB/Plugin/ADSBStatusOverlay.swift
+++ b/OmniTAKMobile/Features/ADSB/Plugin/ADSBStatusOverlay.swift
@@ -1,0 +1,23 @@
+//
+//  ADSBStatusOverlay.swift
+//  OmniTAKMobile
+//
+//  The map-overlay surface the ADS-B reference plugin registers. Aircraft
+//  markers themselves are NOT drawn here — they keep flowing as the
+//  `[Aircraft]` data array into the two map engines. This overlay renders
+//  NOTHING (EmptyView) so the refactor is a guaranteed zero-visual-change.
+//
+//  It exists to demonstrate the `registerMapOverlay` hook with a real plugin
+//  surface mounted in the engine-agnostic chrome on BOTH engines. A plugin
+//  author can replace the body with their own markers/HUD.
+//
+
+import SwiftUI
+
+struct ADSBStatusOverlay: View {
+    var body: some View {
+        // Intentionally empty — ADS-B's aircraft render via the engines'
+        // data-array path; this keeps the visual output byte-identical.
+        EmptyView()
+    }
+}

--- a/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
@@ -34,6 +34,9 @@ struct ATAKMapView: View {
     @StateObject private var mapStateManager = MapStateManager()
     @StateObject private var measurementManager = MeasurementManager()
     @ObservedObject private var adsbService = ADSBTrafficService.shared
+    // Plugin SDK — registered map overlays render in the engine-agnostic
+    // chrome (see `registeredPluginOverlays`), so they appear on BOTH engines.
+    @ObservedObject private var pluginHost = AppPluginHost.shared
     @ObservedObject private var pointDropperService = PointDropperService.shared
     @ObservedObject private var serverManager = ServerManager.shared
     // Issue #16 — lasso multi-select. Singleton so the pill, ring
@@ -1203,11 +1206,33 @@ struct ATAKMapView: View {
         sidePanels
         statusIndicators
         mapOverlayComponents
+        registeredPluginOverlays
         radialMenu
         gpsFollowButton
         lassoSelectionPill
         measurementChrome
         routeNavigationChrome
+    }
+
+    /// Plugin SDK map-overlay seam. Renders every overlay a plugin registered
+    /// via `host.registerMapOverlay(...)`. Because it mounts inside the
+    /// engine-agnostic `mapChrome` (NOT inside cesiumEngineView /
+    /// mapboxEngineView), every plugin overlay shows on BOTH engines. zIndex
+    /// 1500 keeps it above the map / static chrome and below the radial menu
+    /// (3000). Overlays are non-interactive by default so they never steal
+    /// map gestures; a plugin that needs hit-testing renders its own
+    /// interactive controls.
+    @ViewBuilder
+    private var registeredPluginOverlays: some View {
+        if !pluginHost.mapOverlays.isEmpty {
+            ForEach(pluginHost.mapOverlays) { entry in
+                Color.clear
+                    .overlay(entry.view())
+                    .ignoresSafeArea()
+                    .allowsHitTesting(false)
+                    .zIndex(1500)
+            }
+        }
     }
 
     private var modalSheets: some View {

--- a/OmniTAKMobile/Features/Settings/Views/PluginsListView.swift
+++ b/OmniTAKMobile/Features/Settings/Views/PluginsListView.swift
@@ -11,9 +11,19 @@ struct PluginsListView: View {
     @Environment(\.dismiss) var dismiss
     @ObservedObject private var pluginManager = PluginSettingsManager.shared
 
+    // Registered OmniTAKPlugins from the SDK registry. ADS-B lives here now
+    // (not in FEATURES) — listed exactly once.
+    private var registeredPlugins: [OmniTAKPlugin] { PluginRegistry.shared.all() }
+
     var body: some View {
         NavigationView {
             List {
+                Section("PLUGINS") {
+                    ForEach(registeredPlugins, id: \.pluginId) { plugin in
+                        RegisteredPluginRow(plugin: plugin, pluginManager: pluginManager)
+                    }
+                }
+
                 Section("FEATURES") {
                     ForEach(PluginID.allCases, id: \.self) { plugin in
                         PluginRow(plugin: plugin, pluginManager: pluginManager)
@@ -89,5 +99,68 @@ struct PluginRow: View {
                 .labelsHidden()
         }
         .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Registered Plugin Row (SDK)
+
+/// A row for a registered OmniTAKPlugin. Shows icon + name + version +
+/// description with an enable Toggle. If the plugin ships a settingsContent(),
+/// the row becomes a NavigationLink into that screen.
+struct RegisteredPluginRow: View {
+    let plugin: OmniTAKPlugin
+    @ObservedObject var pluginManager: PluginSettingsManager
+
+    private var isEnabled: Bool {
+        pluginManager.isRegisteredPluginEnabled(plugin.pluginId)
+    }
+
+    var body: some View {
+        if let settings = plugin.settingsContent() {
+            NavigationLink {
+                settings.navigationTitle(plugin.displayName)
+            } label: {
+                rowContent
+            }
+        } else {
+            rowContent
+        }
+    }
+
+    private var rowContent: some View {
+        HStack {
+            Image(systemName: iconName)
+                .font(.system(size: 24))
+                .foregroundColor(isEnabled ? .blue : .gray)
+                .frame(width: 40)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(plugin.displayName)
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(isEnabled ? .primary : .gray)
+                    Text("v\(plugin.pluginVersion)")
+                        .font(.system(size: 11))
+                        .foregroundColor(.gray)
+                }
+                Text(plugin.pluginDescription)
+                    .font(.system(size: 12))
+                    .foregroundColor(.gray)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: pluginManager.registeredBinding(for: plugin.pluginId))
+                .labelsHidden()
+        }
+        .padding(.vertical, 4)
+    }
+
+    /// Prefer a settings-row icon the plugin registered for itself; fall back
+    /// to a generic puzzle-piece glyph.
+    private var iconName: String {
+        AppPluginHost.shared.settingsRows
+            .first { $0.pluginId == plugin.pluginId }?.icon
+            ?? "puzzlepiece.extension.fill"
     }
 }

--- a/OmniTAKMobile/Shared/Services/PluginSettingsManager.swift
+++ b/OmniTAKMobile/Shared/Services/PluginSettingsManager.swift
@@ -28,7 +28,10 @@ enum PluginID: String, CaseIterable {
     case spotrep = "spotrep"
     case view3d = "3dview"
     case turnByTurn = "turnbyturn"
-    case adsb = "adsb"
+    // NOTE: `.adsb` was REMOVED here — ADS-B is now a registered
+    // OmniTAKPlugin (ADSBPlugin, "soy.engindearing.adsb"). It is listed once,
+    // under Settings → Plugins → PLUGINS, not in this fixed FEATURES enum.
+    // See PluginRegistry + the registered-plugin API below.
 
     var displayName: String {
         switch self {
@@ -50,7 +53,6 @@ enum PluginID: String, CaseIterable {
         case .spotrep: return "SPOTREP"
         case .view3d: return "3D View"
         case .turnByTurn: return "Navigation"
-        case .adsb: return "ADS-B"
         }
     }
 
@@ -74,7 +76,6 @@ enum PluginID: String, CaseIterable {
         case .spotrep: return "doc.text.fill"
         case .view3d: return "view.3d"
         case .turnByTurn: return "location.north.line.fill"
-        case .adsb: return "airplane.circle.fill"
         }
     }
 
@@ -98,7 +99,6 @@ enum PluginID: String, CaseIterable {
         case .spotrep: return "Quick tactical spot report"
         case .view3d: return "Real 3D terrain visualization with MapLibre"
         case .turnByTurn: return "Turn-by-turn voice navigation"
-        case .adsb: return "ADS-B aircraft traffic overlay"
         }
     }
 }
@@ -120,8 +120,68 @@ class PluginSettingsManager: ObservableObject {
         .video,         // Video streaming - requires TAK server video feeds
     ]
 
+    // MARK: - Registered OmniTAKPlugins (SDK)
+
+    /// Registered plugins (by reverse-DNS pluginId) that should be OFF on
+    /// first run. Everything else defaults ON so first-time users see plugin
+    /// features. ADS-B is intentionally absent → defaults ON.
+    private static let registeredDisabledByDefault: Set<String> = [
+        "soy.engindearing.diagnostics",   // internal SDK probe, never on for shipping users
+    ]
+
+    /// One-time migration: copy any legacy fixed-capability ADS-B enable flag
+    /// (`plugin_enabled_adsb`) onto the new registered-plugin key
+    /// (`plugin_enabled_soy.engindearing.adsb`) so existing testers keep their
+    /// toggle when ADS-B becomes a registered plugin.
+    private static let adsbMigrationDoneKey = "plugin_migrated_adsb_to_registered_v1"
+
     private init() {
+        migrateLegacyADSBEnableFlagIfNeeded()
         loadSettings()
+    }
+
+    private func migrateLegacyADSBEnableFlagIfNeeded() {
+        guard !userDefaults.bool(forKey: Self.adsbMigrationDoneKey) else { return }
+        let legacyKey = keyPrefix + "adsb"   // plugin_enabled_adsb
+        let newKey = keyPrefix + "soy.engindearing.adsb"
+        if userDefaults.object(forKey: legacyKey) != nil,
+           userDefaults.object(forKey: newKey) == nil {
+            userDefaults.set(userDefaults.bool(forKey: legacyKey), forKey: newKey)
+        }
+        userDefaults.set(true, forKey: Self.adsbMigrationDoneKey)
+    }
+
+    /// Whether a registered OmniTAKPlugin is enabled. Keyed by pluginId under
+    /// the SAME `plugin_enabled_` prefix the fixed capabilities use, so the
+    /// whole toggle system is one consistent store.
+    func isRegisteredPluginEnabled(_ pluginId: String) -> Bool {
+        let key = keyPrefix + pluginId
+        if userDefaults.object(forKey: key) == nil {
+            return !Self.registeredDisabledByDefault.contains(pluginId)
+        }
+        return userDefaults.bool(forKey: key)
+    }
+
+    /// Persist a registered plugin's enable state.
+    func setRegisteredPlugin(_ pluginId: String, enabled: Bool) {
+        userDefaults.set(enabled, forKey: keyPrefix + pluginId)
+        objectWillChange.send()
+    }
+
+    /// Binding for a registered plugin's Toggle. The `set` side persists the
+    /// flag AND drives live activation/deactivation through the registry.
+    func registeredBinding(for pluginId: String) -> Binding<Bool> {
+        Binding(
+            get: { self.isRegisteredPluginEnabled(pluginId) },
+            set: { enabled in
+                self.setRegisteredPlugin(pluginId, enabled: enabled)
+                if enabled {
+                    PluginRegistry.shared.activate(pluginId: pluginId, host: AppPluginHost.shared)
+                } else {
+                    PluginRegistry.shared.deactivate(pluginId: pluginId, host: AppPluginHost.shared)
+                }
+            }
+        )
     }
 
     /// Load settings from UserDefaults
@@ -156,6 +216,14 @@ class PluginSettingsManager: ObservableObject {
         // Map tool ID to plugin
         if let plugin = PluginID(rawValue: toolID) {
             return isEnabled(plugin)
+        }
+
+        // Registered OmniTAKPlugin (reverse-DNS id, e.g. a radial action's
+        // owning pluginId from RadialMenuAction.pluginToolID) — gate by the
+        // registered-plugin enable flag so a disabled plugin's radial entry
+        // is filtered out exactly like a fixed capability's.
+        if toolID.contains(".") {
+            return isRegisteredPluginEnabled(toolID)
         }
 
         // Unknown tools default to enabled

--- a/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuActionExecutor.swift
+++ b/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuActionExecutor.swift
@@ -665,6 +665,16 @@ class RadialMenuActionExecutor {
             return true
 
         default:
+            // Plugin SDK — registered radial action. `RadialMenuAction.custom`
+            // wraps the identifier as "custom_<id>"; look it up in the host and
+            // fire its onSelect with the pressed coordinate.
+            if AppPluginHost.shared.fireRadialAction(
+                identifier: "custom_\(identifier)",
+                at: context.mapCoordinate
+            ) {
+                return true
+            }
+
             NotificationCenter.default.post(
                 name: .radialMenuCustomAction,
                 object: nil,

--- a/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuMapCoordinator.swift
+++ b/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuMapCoordinator.swift
@@ -130,7 +130,12 @@ class RadialMenuMapCoordinator: ObservableObject {
     // MARK: - Menu Configuration
 
     private func configureMapMenu(at coordinate: CLLocationCoordinate2D) {
-        menuConfiguration = .mapContextMenu(at: coordinate)
+        var config = RadialMenuConfiguration.mapContextMenu(at: coordinate)
+        // Plugin SDK — append every registered plugin radial action to the
+        // empty-map menu. Appended BEFORE the caller's filteringDisabledPlugins()
+        // pass so a disabled plugin's entry is still dropped.
+        config.items += AppPluginHost.shared.radialActions.map { $0.item }
+        menuConfiguration = config
     }
 
     private func configureMarkerMenu(for marker: PointMarker) {

--- a/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuModels.swift
+++ b/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuModels.swift
@@ -417,6 +417,13 @@ extension RadialMenuAction {
             return "alert"
         case .custom(let id) where id == "meshtastic":
             return "meshtastic"
+        case .custom(let id) where id.hasPrefix("plugin_"):
+            // Plugin SDK radial actions. Resolve to the OWNING plugin's
+            // reverse-DNS id so the entry is gated by that plugin's enable
+            // flag (a disabled plugin must not leak its radial entry).
+            return AppPluginHost.shared.radialActions
+                .first { $0.item.action.identifier == "custom_\(id)" }?
+                .pluginId
         default:
             return nil
         }

--- a/OmniTAKMobileTests/PluginSDKTests.swift
+++ b/OmniTAKMobileTests/PluginSDKTests.swift
@@ -1,0 +1,233 @@
+//
+//  PluginSDKTests.swift
+//  OmniTAKMobileTests
+//
+//  Exercises the entire OmniTAKPlugin host surface — all four hooks
+//  (registerMapOverlay / registerRadialAction / registerCoTHandler /
+//  registerSettingsRow) — proving each fires, that dispatchCoT short-circuits
+//  on a consuming handler, that deactivate removes a plugin's hooks, and that
+//  the registry honors PluginSettingsManager enablement.
+//
+
+import XCTest
+import SwiftUI
+import CoreLocation
+@testable import OmniTAKMobile
+
+// MARK: - Fake plugin exercising all four hooks
+
+private final class AllHooksPlugin: OmniTAKPlugin {
+    let pluginId = "test.plugin.allhooks"
+    let displayName = "All Hooks"
+    let pluginVersion = "9.9.9"
+    let pluginAuthor = "Tests"
+    let pluginDescription = "Exercises every host hook"
+
+    let consumesCoT: Bool
+    private(set) var cotSeen = 0
+    private(set) var radialFired = false
+    private(set) var deactivated = false
+
+    init(consumesCoT: Bool = false) {
+        self.consumesCoT = consumesCoT
+    }
+
+    func activate(host: PluginHost) {
+        host.registerMapOverlay { AnyView(EmptyView()) }
+        host.registerRadialAction(
+            RadialMenuItem(icon: "star", label: "Test", action: .custom("plugin_test")),
+            onSelect: { _ in self.radialFired = true }
+        )
+        host.registerCoTHandler { _ in
+            self.cotSeen += 1
+            return self.consumesCoT
+        }
+        host.registerSettingsRow(label: "Test", icon: "star")
+    }
+
+    func deactivate() { deactivated = true }
+
+    func settingsContent() -> AnyView? { AnyView(Text("settings")) }
+}
+
+private final class NoSettingsPlugin: OmniTAKPlugin {
+    let pluginId = "test.plugin.nosettings"
+    let displayName = "No Settings"
+    let pluginVersion = "1.0.0"
+    let pluginAuthor = "Tests"
+    let pluginDescription = "Has no settings UI"
+    func activate(host: PluginHost) {}
+    func deactivate() {}
+}
+
+final class PluginSDKTests: XCTestCase {
+
+    private func makeCoTEvent(uid: String = "TEST-1") -> CoTEvent {
+        CoTEvent(
+            uid: uid,
+            type: "a-f-G-U-C",
+            time: Date(),
+            point: CoTPoint(lat: 40.64, lon: -73.78, hae: 0, ce: 0, le: 0),
+            detail: CoTDetail(callsign: "TEST", team: nil, teamRole: nil,
+                              speed: nil, course: nil, remarks: nil,
+                              battery: nil, device: nil, platform: nil)
+        )
+    }
+
+    // MARK: - All four hooks register through the host
+
+    func testAllFourHooksRegister() {
+        let host = AppPluginHost.shared
+        host.removeHooks(for: "test.plugin.allhooks")
+
+        let plugin = AllHooksPlugin()
+        host.currentlyActivating = plugin.pluginId
+        plugin.activate(host: host)
+        host.currentlyActivating = nil
+
+        XCTAssertTrue(host.mapOverlays.contains { $0.pluginId == plugin.pluginId },
+                      "registerMapOverlay should append an overlay")
+        XCTAssertTrue(host.settingsRows.contains { $0.pluginId == plugin.pluginId },
+                      "registerSettingsRow should append a settings row")
+        XCTAssertTrue(host.radialActions.contains { $0.pluginId == plugin.pluginId },
+                      "registerRadialAction should append a radial action")
+        XCTAssertTrue(host.cotHandlers.contains { $0.pluginId == plugin.pluginId },
+                      "registerCoTHandler should append a CoT handler")
+
+        host.removeHooks(for: plugin.pluginId)
+    }
+
+    // MARK: - CoT dispatch fires the handler
+
+    func testCoTHandlerFires() {
+        let host = AppPluginHost.shared
+        host.removeHooks(for: "test.plugin.allhooks")
+
+        let plugin = AllHooksPlugin(consumesCoT: false)
+        host.currentlyActivating = plugin.pluginId
+        plugin.activate(host: host)
+        host.currentlyActivating = nil
+
+        let consumed = host.dispatchCoT(makeCoTEvent())
+        XCTAssertEqual(plugin.cotSeen, 1, "the registered CoT handler should be called")
+        XCTAssertFalse(consumed, "a non-consuming handler should not mark the event consumed")
+
+        host.removeHooks(for: plugin.pluginId)
+    }
+
+    // MARK: - CoT dispatch short-circuits on a consuming handler
+
+    func testCoTDispatchShortCircuits() {
+        let host = AppPluginHost.shared
+        host.removeHooks(for: "test.plugin.allhooks")
+
+        let consumer = AllHooksPlugin(consumesCoT: true)
+        host.currentlyActivating = consumer.pluginId
+        consumer.activate(host: host)
+        host.currentlyActivating = nil
+
+        XCTAssertTrue(host.dispatchCoT(makeCoTEvent()),
+                      "a consuming handler should mark the event consumed")
+
+        host.removeHooks(for: consumer.pluginId)
+    }
+
+    // MARK: - Radial onSelect fires by identifier
+
+    func testRadialActionFires() {
+        let host = AppPluginHost.shared
+        host.removeHooks(for: "test.plugin.allhooks")
+
+        let plugin = AllHooksPlugin()
+        host.currentlyActivating = plugin.pluginId
+        plugin.activate(host: host)
+        host.currentlyActivating = nil
+
+        // .custom("plugin_test") → identifier "custom_plugin_test"
+        let fired = host.fireRadialAction(
+            identifier: "custom_plugin_test",
+            at: CLLocationCoordinate2D(latitude: 1, longitude: 2)
+        )
+        XCTAssertTrue(fired, "fireRadialAction should locate the registered action")
+        XCTAssertTrue(plugin.radialFired, "the registered onSelect closure should run")
+
+        host.removeHooks(for: plugin.pluginId)
+    }
+
+    // MARK: - Deactivate removes a plugin's hooks
+
+    func testDeactivateRemovesHooks() {
+        let host = AppPluginHost.shared
+        host.removeHooks(for: "test.plugin.allhooks")
+
+        let plugin = AllHooksPlugin()
+        host.currentlyActivating = plugin.pluginId
+        plugin.activate(host: host)
+        host.currentlyActivating = nil
+
+        XCTAssertFalse(host.mapOverlays.filter { $0.pluginId == plugin.pluginId }.isEmpty)
+        host.removeHooks(for: plugin.pluginId)
+
+        XCTAssertTrue(host.mapOverlays.filter { $0.pluginId == plugin.pluginId }.isEmpty)
+        XCTAssertTrue(host.settingsRows.filter { $0.pluginId == plugin.pluginId }.isEmpty)
+        XCTAssertTrue(host.radialActions.filter { $0.pluginId == plugin.pluginId }.isEmpty)
+        XCTAssertTrue(host.cotHandlers.filter { $0.pluginId == plugin.pluginId }.isEmpty)
+    }
+
+    // MARK: - Registry honors PluginSettingsManager enablement
+
+    func testActivateEnabledRespectsSettings() {
+        let host = AppPluginHost.shared
+        let registry = PluginRegistry.shared
+
+        let enabledPlugin = AllHooksPlugin()
+        let disabledPlugin = NoSettingsPlugin()
+        registry.register(enabledPlugin)
+        registry.register(disabledPlugin)
+
+        PluginSettingsManager.shared.setRegisteredPlugin(enabledPlugin.pluginId, enabled: true)
+        PluginSettingsManager.shared.setRegisteredPlugin(disabledPlugin.pluginId, enabled: false)
+
+        registry.activateEnabled(host: host)
+
+        XCTAssertTrue(registry.isActivated(enabledPlugin.pluginId),
+                      "an enabled plugin should be activated")
+        XCTAssertFalse(registry.isActivated(disabledPlugin.pluginId),
+                       "a disabled plugin should NOT be activated")
+
+        // Cleanup
+        registry.deactivate(pluginId: enabledPlugin.pluginId, host: host)
+        host.removeHooks(for: enabledPlugin.pluginId)
+    }
+
+    // MARK: - Plugins without settingsContent return nil by default
+
+    func testDefaultSettingsContentIsNil() {
+        XCTAssertNil(NoSettingsPlugin().settingsContent(),
+                     "the protocol-extension default should return nil")
+    }
+
+    // MARK: - Bundled plugins register ADS-B + Diagnostics
+
+    func testBundledPluginsRegistered() {
+        let registry = PluginRegistry.shared
+        registry.loadBundledPlugins()
+        XCTAssertNotNil(registry.plugin(withId: "soy.engindearing.adsb"),
+                        "ADS-B reference plugin should be registered")
+        XCTAssertNotNil(registry.plugin(withId: "soy.engindearing.diagnostics"),
+                        "Diagnostics test plugin should be registered")
+    }
+
+    // MARK: - Diagnostics is disabled by default; ADS-B enabled by default
+
+    func testRegisteredDefaults() {
+        let mgr = PluginSettingsManager.shared
+        // Clear any persisted value to test the first-run default.
+        UserDefaults.standard.removeObject(forKey: "plugin_enabled_soy.engindearing.diagnostics")
+        XCTAssertFalse(mgr.isRegisteredPluginEnabled("soy.engindearing.diagnostics"),
+                       "DiagnosticsPlugin should default OFF")
+        UserDefaults.standard.removeObject(forKey: "plugin_enabled_soy.engindearing.adsb")
+        XCTAssertTrue(mgr.isRegisteredPluginEnabled("soy.engindearing.adsb"),
+                      "ADS-B should default ON so first-time users see it")
+    }
+}

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -1,0 +1,146 @@
+# OmniTAK Plugin SDK — Authoring Guide (iOS)
+
+This describes the **shipped** OmniTAK plugin SDK on iOS: the `OmniTAKPlugin`
+protocol, the four host hooks, the ADS-B reference plugin, and how to add your
+own plugin.
+
+The SDK is deliberately the same shape on Android (same hook names, same
+reverse-DNS `pluginId`) so a plugin ports across platforms in about a day.
+
+---
+
+## What a plugin is (and the two hard rules)
+
+A plugin is a **compile-time Swift class** that conforms to `OmniTAKPlugin`
+and is registered at app start. Two non-negotiable constraints follow from
+shipping on the App Store:
+
+1. **No dynamic code.** There is no DEX/dylib loading, no remote code, no
+   download-and-run. A plugin is Swift source linked into the app binary and
+   added to the registry in `PluginRegistry.loadBundledPlugins()`. This keeps
+   OmniTAK App-Store compliant.
+
+2. **No sandbox.** A plugin runs **in the host process with the host app's
+   full permissions** (network, location, files, etc.). Treat a plugin's code
+   as part of the app. Reviewers must read it the same way they'd read any
+   app code.
+
+---
+
+## The protocol
+
+```swift
+protocol OmniTAKPlugin: AnyObject {
+    var pluginId: String { get }          // reverse-DNS, e.g. "soy.engindearing.adsb"
+    var displayName: String { get }
+    var pluginVersion: String { get }     // semver, e.g. "1.0.0"
+    var pluginAuthor: String { get }
+    var pluginDescription: String { get }
+
+    func activate(host: PluginHost)        // register your hooks here
+    func deactivate()                      // stop your work; hooks auto-removed
+    func settingsContent() -> AnyView?     // optional settings UI (default nil)
+}
+```
+
+`pluginId` is the **stable key** for everything: enable-state persistence, hook
+ownership, and cross-platform settings portability. Pick it once and never
+change it.
+
+`settingsContent()` returns a **type-erased** `AnyView?` (not `some View`) so
+the registry can hold a heterogeneous list of plugins. Default is `nil`.
+
+---
+
+## The four host hooks
+
+`activate(host:)` receives a `PluginHost`. Register through it:
+
+| Hook | What it does |
+|------|--------------|
+| `registerMapOverlay { AnyView(...) }` | A SwiftUI overlay mounted in the engine-agnostic map chrome. It renders on **both** map engines (Cesium 3D + Mapbox 2D), above the map and below the radial menu. Non-interactive by default. |
+| `registerRadialAction(item, onSelect:)` | Adds an entry to the empty-map long-press **radial menu**. `onSelect(coordinate)` fires with the pressed map coordinate. The entry is gated by the plugin's enable flag. |
+| `registerCoTHandler { event in ... }` | Called for **every inbound CoT position event after the core store ingests it**. Return `true` to mark the event consumed (short-circuits remaining handlers). Runs on the **main thread** — keep it cheap. |
+| `registerSettingsRow(label:icon:)` | Adds a row to Settings → Plugins that navigates into your `settingsContent()`. `icon` is an SF Symbol name. |
+
+Hooks are tagged with your `pluginId` automatically, so `deactivate()` cleanly
+removes them — you don't have to unregister manually.
+
+---
+
+## The ADS-B reference plugin
+
+`ADSBPlugin` (`soy.engindearing.adsb`) is the canonical example. It wraps the
+existing ADS-B traffic feature **with zero behavior change**:
+
+- It uses **`registerMapOverlay`** (a thin status surface — `ADSBStatusOverlay`,
+  which renders `EmptyView`) and **`registerSettingsRow`** ("ADS-B").
+- `settingsContent()` returns the existing `ADSBTrafficView()` verbatim.
+- `deactivate()` flips `ADSBTrafficService.shared.settings.isEnabled = false`,
+  reusing the service's existing `didSet → stopTracking()`.
+
+> **Why the aircraft rendering path is untouched.** ADS-B does not draw through
+> a SwiftUI overlay — aircraft flow as a `[Aircraft]` data array straight into
+> both map engines. That proven pipeline stays byte-identical; the plugin only
+> adds discovery, enable/disable, and a settings entry point.
+
+`ADSBPlugin` registers two of the four hooks. The internal **`DiagnosticsPlugin`**
+(`soy.engindearing.diagnostics`, **off by default**) exercises the other two —
+`registerRadialAction` (a "Diag" entry) and `registerCoTHandler` (an event
+counter) — so the whole host surface is wired and tested. `PluginSDKTests`
+covers all four hooks regardless of enable state.
+
+---
+
+## How to add a plugin
+
+1. **Create a file** in a plugin group, e.g.
+   `OmniTAKMobile/Features/MyFeature/Plugin/MyPlugin.swift`.
+2. **Conform** a `final class` to `OmniTAKPlugin`. Give it a unique reverse-DNS
+   `pluginId`. Register your hooks in `activate(host:)`.
+3. **Register it** in `PluginRegistry.loadBundledPlugins()`:
+   ```swift
+   func loadBundledPlugins() {
+       register(ADSBPlugin())
+       register(DiagnosticsPlugin())
+       register(MyPlugin())   // <- add this line
+   }
+   ```
+4. **Add the file to the Xcode target.** The pbxproj uses explicit file
+   references, so a new `.swift` file must be added to the `OmniTAKMobile`
+   target's Sources build phase or it won't compile in. Use the helper:
+   ```bash
+   # edit scripts/add_plugin_sdk_files.rb to list your file, then:
+   ruby scripts/add_plugin_sdk_files.rb
+   ```
+   (or add it via Xcode's "Add Files to OmniTAKMobile…").
+5. **Default enable state.** Bundled plugins default **ON** on first run so
+   first-time users see plugin features. To ship OFF by default, add your
+   `pluginId` to `PluginSettingsManager.registeredDisabledByDefault`.
+6. **Open a PR**, or **fork and sign your own build** (see `CONTRIBUTING.md`).
+   Because plugins are compiled in, distributing a plugin means distributing a
+   build — either upstream via PR or your own signed fork.
+
+---
+
+## Where the SDK lives
+
+| File | Role |
+|------|------|
+| `OmniTAKMobile/Core/Plugin/OmniTAKPlugin.swift` | the plugin protocol |
+| `OmniTAKMobile/Core/Plugin/PluginHost.swift` | the four-hook host protocol |
+| `OmniTAKMobile/Core/Plugin/AppPluginHost.swift` | concrete host; holds registered hooks |
+| `OmniTAKMobile/Core/Plugin/PluginRegistry.swift` | compile-time registry + activation |
+| `OmniTAKMobile/Core/Plugin/DiagnosticsPlugin.swift` | internal test plugin (radial + CoT) |
+| `OmniTAKMobile/Features/ADSB/Plugin/ADSBPlugin.swift` | ADS-B reference plugin |
+| `OmniTAKMobileTests/PluginSDKTests.swift` | host-surface coverage |
+
+The four seams the host wires into:
+
+- **Map overlay** — `MapViewController.registeredPluginOverlays` (inside the
+  engine-agnostic `mapChrome`, so both engines get it).
+- **Radial** — `RadialMenuMapCoordinator.configureMapMenu` appends registered
+  items; `RadialMenuActionExecutor.executeCustomAction` fires `onSelect`.
+- **CoT** — `CoTEventHandler.handlePositionUpdate` calls `dispatchCoT` after
+  the core store ingest.
+- **Settings** — `PluginsListView` lists `PluginRegistry.shared.all()`.

--- a/scripts/add_plugin_sdk_files.rb
+++ b/scripts/add_plugin_sdk_files.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# Adds the Plugin SDK source files to the correct Xcode targets.
+# Idempotent — safe to run multiple times.
+require 'xcodeproj'
+
+project_path = File.expand_path('../OmniTAKMobile.xcodeproj', __dir__)
+project = Xcodeproj::Project.open(project_path)
+
+app_target  = project.targets.find { |t| t.name == 'OmniTAKMobile' }
+test_target = project.targets.find { |t| t.name == 'OmniTAKMobileTests' }
+abort('Could not find OmniTAKMobile target')  unless app_target
+abort('Could not find OmniTAKMobileTests target') unless test_target
+
+main_group = project.main_group
+
+# path (relative to project root) => target
+app_files = [
+  'OmniTAKMobile/Core/Plugin/OmniTAKPlugin.swift',
+  'OmniTAKMobile/Core/Plugin/PluginHost.swift',
+  'OmniTAKMobile/Core/Plugin/PluginRegistry.swift',
+  'OmniTAKMobile/Core/Plugin/AppPluginHost.swift',
+  'OmniTAKMobile/Core/Plugin/DiagnosticsPlugin.swift',
+  'OmniTAKMobile/Features/ADSB/Plugin/ADSBPlugin.swift',
+  'OmniTAKMobile/Features/ADSB/Plugin/ADSBStatusOverlay.swift',
+]
+test_files = [
+  'OmniTAKMobileTests/PluginSDKTests.swift',
+]
+
+def file_ref_for(project, main_group, path)
+  # Find an existing flat file reference by path, else create one.
+  existing = project.files.find { |f| f.path == path }
+  return existing if existing
+  ref = main_group.new_reference(path)
+  ref.name = File.basename(path)
+  ref
+end
+
+def ensure_in_target(target, ref, path)
+  already = target.source_build_phase.files.any? do |bf|
+    bf.file_ref && bf.file_ref.path == path
+  end
+  if already
+    puts "  = #{path} already in #{target.name}"
+  else
+    target.add_file_references([ref])
+    puts "  + #{path} -> #{target.name}"
+  end
+end
+
+puts 'Adding app-target files:'
+app_files.each do |path|
+  ref = file_ref_for(project, main_group, path)
+  ensure_in_target(app_target, ref, path)
+end
+
+puts 'Adding test-target files:'
+test_files.each do |path|
+  ref = file_ref_for(project, main_group, path)
+  ensure_in_target(test_target, ref, path)
+end
+
+project.save
+puts 'Saved project.'


### PR DESCRIPTION
## What this adds

A compile-time **plugin SDK** for OmniTAK iOS plus the **ADS-B reference plugin**, refactored in with **zero behavior change**. The SDK is the same shape as the Android one (same hook names, same reverse-DNS `pluginId`) so a plugin ports across platforms in roughly a day.

### Store compliance (non-negotiable)
- **No dynamic / downloadable code.** No DEX/dylib loading, no remote execution. A plugin is a Swift class linked into the binary and registered at app start in `PluginRegistry.loadBundledPlugins()`.
- **No sandbox.** Plugins run **in-process with the host's full permissions** — documented in `OmniTAKPlugin.swift` and the authoring guide. Treat plugin code as app code.

## The SDK surface

`OmniTAKPlugin`: `pluginId` (reverse-DNS), `displayName`, `pluginVersion`, `pluginAuthor`, `pluginDescription`, `activate(host:)`, `deactivate()`, `settingsContent() -> AnyView?` (default nil).

`PluginHost` — four hooks, each wired into a real seam:
- **`registerMapOverlay`** -> `MapViewController.registeredPluginOverlays`, mounted inside the engine-agnostic `mapChrome` so overlays render on **both** map engines (Cesium 3D + Mapbox 2D), above the map and below the radial menu.
- **`registerRadialAction(action, onSelect:)`** -> appended to the empty-map long-press menu in `RadialMenuMapCoordinator` (before the disabled-plugin filter), `onSelect(coordinate)` fired from `RadialMenuActionExecutor`.
- **`registerCoTHandler(handler)`** -> `CoTEventHandler.handlePositionUpdate` dispatches to handlers **after** the core store ingests the event; return `true` to consume.
- **`registerSettingsRow(label:icon:)`** -> a row in Settings > Plugins into `settingsContent()`.

`PluginRegistry`: `register`, `all`, `activateEnabled(host:)`, `activate/deactivate(pluginId:host:)`, `loadBundledPlugins()`. Enablement is delegated to the existing `PluginSettingsManager` (key `plugin_enabled_<pluginId>`), default **ON** on first run except a `registeredDisabledByDefault` set.

## ADS-B extraction (zero behavior change)

`ADSBPlugin` (`soy.engindearing.adsb`) wraps the existing feature using `registerMapOverlay` (a thin `EmptyView` status surface) + `registerSettingsRow`; `settingsContent()` returns the existing `ADSBTrafficView` verbatim; `deactivate()` flips the service's `isEnabled`.

The proven pipeline is **untouched**: aircraft keep flowing as the `[Aircraft]` data array into both engines, gated by `ADSBTrafficService.shared.settings.isEnabled` exactly as before. The fixed `PluginID.adsb` entry was removed so ADS-B is listed **once**, under PLUGINS; a one-time migration copies the legacy enable flag so existing testers keep their toggle.

Verified on simulator: app launches, map renders, and the live ADS-B aircraft-count HUD updates in real time (65→66→67) straight off the unchanged service — proof the data->engine render path is byte-identical.

## Full-surface coverage

`DiagnosticsPlugin` (off by default) exercises the **other two** hooks (radial + CoT). `PluginSDKTests` (9 tests, all green) asserts all four hooks register, `dispatchCoT` short-circuits on a consuming handler, `deactivate` removes hooks, and `activateEnabled` honors enablement.

## How to author a plugin

New file under a plugin group, conform to `OmniTAKPlugin`, register in `loadBundledPlugins()`, add the file to the `OmniTAKMobile` target (`scripts/add_plugin_sdk_files.rb` or Xcode), open a PR — or fork and sign your own build. Full guide: `docs/PLUGIN_AUTHORING.md`.

## Build / test
- `xcodebuild ... build` -> **BUILD SUCCEEDED**
- `PluginSDKTests` -> **9/9 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)