### PR TITLE
fix(plugin): ADS-B re-enable restores the overlay (symmetric toggle)

### DIFF
--- a/OmniTAKMobile/Features/ADSB/Plugin/ADSBPlugin.swift
+++ b/OmniTAKMobile/Features/ADSB/Plugin/ADSBPlugin.swift
@@ -24,6 +24,14 @@ final class ADSBPlugin: OmniTAKPlugin {
     let pluginAuthor = "Engindearing"
     let pluginDescription = "ADS-B aircraft traffic overlay"
 
+    // Symmetric-toggle state. When deactivate() turns the overlay off it
+    // stashes the prior `isEnabled` so activate() can restore the exact state
+    // the user left it in — disable-then-reenable must be a no-op for the
+    // overlay's visibility. `nil` means "never stashed" (first activation),
+    // which restores to the default-ON state matching the plugin's
+    // default-enabled posture and ADSBTrafficSettings.isEnabled = true.
+    private var stashedOverlayEnabled: Bool?
+
     func activate(host: PluginHost) {
         // Hook 1: map overlay rendered in the engine-agnostic chrome on BOTH
         // engines. ADS-B's actual aircraft markers keep coming from the two
@@ -35,12 +43,26 @@ final class ADSBPlugin: OmniTAKPlugin {
         // Hook 2: settings row → settingsContent() (the existing full ADS-B
         // settings/list screen).
         host.registerSettingsRow(label: "ADS-B", icon: "airplane.circle.fill")
+
+        // Restore the overlay to the state it was in BEFORE the plugin was
+        // disabled. We deliberately do NOT force isEnabled = true: a user who
+        // intentionally hid aircraft via the inner "Show aircraft on map"
+        // toggle (while leaving the plugin enabled) must not have that choice
+        // clobbered here or on every launch. First activation (nil stash)
+        // defaults ON to match the plugin's default-enabled state.
+        let restore = stashedOverlayEnabled ?? true
+        if ADSBTrafficService.shared.settings.isEnabled != restore {
+            var settings = ADSBTrafficService.shared.settings
+            settings.isEnabled = restore
+            ADSBTrafficService.shared.settings = settings
+        }
     }
 
     func deactivate() {
         // Bridge plugin-off → service-off, reusing the existing didSet →
-        // stopTracking() semantics. This preserves the exact behavior of the
-        // legacy ADS-B toggle.
+        // stopTracking() semantics. Remember the prior enabled state first so
+        // a later activate() can restore it — keeping the toggle symmetric.
+        stashedOverlayEnabled = ADSBTrafficService.shared.settings.isEnabled
         if ADSBTrafficService.shared.settings.isEnabled {
             var settings = ADSBTrafficService.shared.settings
             settings.isEnabled = false

--- a/OmniTAKMobileTests/PluginSDKTests.swift
+++ b/OmniTAKMobileTests/PluginSDKTests.swift
@@ -230,4 +230,75 @@ final class PluginSDKTests: XCTestCase {
         XCTAssertTrue(mgr.isRegisteredPluginEnabled("soy.engindearing.adsb"),
                       "ADS-B should default ON so first-time users see it")
     }
+
+    // MARK: - ADS-B re-enable is symmetric (overlay returns to prior state)
+
+    /// Restore the shared ADS-B service to a known enabled state after each
+    /// case so the symmetric-toggle tests don't leak into each other or into
+    /// any later test that reads the singleton.
+    private func setADSBOverlay(enabled: Bool) {
+        var s = ADSBTrafficService.shared.settings
+        s.isEnabled = enabled
+        ADSBTrafficService.shared.settings = s
+    }
+
+    /// Disabling then re-enabling the plugin must restore the overlay to the
+    /// state it was in BEFORE deactivation. When it was ON, it comes back ON.
+    func testADSBReenableRestoresOverlayWhenPreviouslyOn() {
+        let originalEnabled = ADSBTrafficService.shared.settings.isEnabled
+        defer { setADSBOverlay(enabled: originalEnabled) }
+
+        let plugin = ADSBPlugin()
+        setADSBOverlay(enabled: true)
+
+        plugin.deactivate()
+        XCTAssertFalse(ADSBTrafficService.shared.settings.isEnabled,
+                       "deactivate should turn the overlay off")
+
+        plugin.activate(host: AppPluginHost.shared)
+        XCTAssertTrue(ADSBTrafficService.shared.settings.isEnabled,
+                      "re-enabling the plugin should restore the overlay to ON")
+
+        AppPluginHost.shared.removeHooks(for: plugin.pluginId)
+    }
+
+    /// When the user had hidden aircraft (overlay OFF) but left the plugin
+    /// enabled, disabling then re-enabling the plugin must NOT force the
+    /// overlay back on — it stays OFF, exactly as the user left it.
+    func testADSBReenableRestoresOverlayWhenPreviouslyOff() {
+        let originalEnabled = ADSBTrafficService.shared.settings.isEnabled
+        defer { setADSBOverlay(enabled: originalEnabled) }
+
+        let plugin = ADSBPlugin()
+        setADSBOverlay(enabled: false)
+
+        plugin.deactivate()
+        XCTAssertFalse(ADSBTrafficService.shared.settings.isEnabled,
+                       "deactivate is a no-op for visibility when already off")
+
+        plugin.activate(host: AppPluginHost.shared)
+        XCTAssertFalse(ADSBTrafficService.shared.settings.isEnabled,
+                       "re-enabling must not clobber a user who hid aircraft")
+
+        AppPluginHost.shared.removeHooks(for: plugin.pluginId)
+    }
+
+    /// First-ever activation (no prior deactivate, nothing stashed) defaults
+    /// the overlay ON, matching the plugin's default-enabled posture so a
+    /// first-time user sees aircraft.
+    func testADSBFirstActivationDefaultsOverlayOn() {
+        let originalEnabled = ADSBTrafficService.shared.settings.isEnabled
+        defer { setADSBOverlay(enabled: originalEnabled) }
+
+        // Start from OFF and activate a fresh plugin that has never stashed a
+        // value — the nil-stash branch should restore to the default-ON state.
+        setADSBOverlay(enabled: false)
+        let plugin = ADSBPlugin()
+
+        plugin.activate(host: AppPluginHost.shared)
+        XCTAssertTrue(ADSBTrafficService.shared.settings.isEnabled,
+                      "first activation with no stash should default the overlay ON")
+
+        AppPluginHost.shared.removeHooks(for: plugin.pluginId)
+    }
 }


### PR DESCRIPTION
## Problem

The ADS-B plugin toggle is **asymmetric** (verified on-device):

- Toggling the plugin **OFF** cleanly removes the map overlay — `deactivate()` sets `ADSBTrafficService.shared.settings.isEnabled = false`.
- Toggling it back **ON** does **not** restore the overlay. `activate()` re-registers the hooks but never restores the service's enabled flag, so the user is stuck until they also flip the inner "Show aircraft on map" toggle.

## Fix — remember on deactivate, restore on activate

`ADSBPlugin` now stashes the prior `isEnabled` value when `deactivate()` turns the service off, and `activate()` restores that stashed value.

- We **do not** force `isEnabled = true`. That would clobber a user who intentionally hid aircraft while leaving the plugin enabled, and would override their choice on every launch.
- First activation (nothing stashed) defaults **ON**, matching the plugin's default-enabled posture and `ADSBTrafficSettings.isEnabled = true`.
- The inner "Show aircraft on map" toggle keeps working independently.

**Net behavior:** disable plugin → overlay gone; re-enable plugin → overlay returns to its previous on/off state; first run → on by default.

## Tests

Extended `OmniTAKMobileTests/PluginSDKTests` with three cases:

- `testADSBReenableRestoresOverlayWhenPreviouslyOn` — deactivate→activate restores ON when it was ON.
- `testADSBReenableRestoresOverlayWhenPreviouslyOff` — stays OFF when the user had hidden aircraft (no clobber).
- `testADSBFirstActivationDefaultsOverlayOn` — first activation with no stash defaults the overlay ON.

## Verification

- `xcodebuild ... build` → **BUILD SUCCEEDED**
- `xcodebuild test -only-testing:OmniTAKMobileTests/PluginSDKTests` on a booted iPhone 17 sim → **12 tests, 0 failures** (incl. the 3 new ones).
- No new files; both edits are to files already in the Xcode target (confirmed idempotent via `scripts/add_plugin_sdk_files.rb` — no pbxproj change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)