### PR TITLE
fix(coords/ios): self-position chip honors the shared coordinate format (DD/DMS/TWD97)

### DIFF
--- a/OmniTAKMobile/Features/Map/Views/CoordinateDisplayView.swift
+++ b/OmniTAKMobile/Features/Map/Views/CoordinateDisplayView.swift
@@ -2,13 +2,25 @@ import SwiftUI
 import CoreLocation
 
 // MARK: - Coordinate Display View
-// ATAK-style coordinate display showing multiple formats (Lat/Lon, MGRS, UTM)
+// ATAK-style coordinate readout for the operator's own position. It shares the
+// app-wide coordinate format (Settings > Coordinate Format, persisted under the
+// "coordinateDisplayFormat" key) so this chip, the cursor/center readout, and
+// the Settings picker always agree. Tapping the chip exposes the full format
+// list (DD, DM, DMS, MGRS, UTM, BNG, TWD97); picking one updates the shared
+// setting. Format conversion is delegated to CoordinateDisplayFormat so there
+// is a single conversion path across the app.
 
 struct CoordinateDisplayView: View {
     let coordinate: CLLocationCoordinate2D?
     let isVisible: Bool
-    @State private var selectedFormat: CoordinateFormat = .mgrs
+
+    // Single source of truth, shared with SettingsView and MapStateManager.
+    @AppStorage("coordinateDisplayFormat") private var formatString: String = "MGRS"
     @State private var isExpanded: Bool = false
+
+    private var selectedFormat: CoordinateDisplayFormat {
+        CoordinateDisplayFormat(rawValue: formatString) ?? .mgrs
+    }
 
     var body: some View {
         if isVisible, let coordinate = coordinate {
@@ -29,7 +41,7 @@ struct CoordinateDisplayView: View {
                 .font(.system(size: 10))
                 .foregroundColor(Color(hex: "#00FFFF"))
 
-            Text(selectedFormat.rawValue)
+            Text(selectedFormat.shortName)
                 .font(.system(size: 10, weight: .bold))
                 .foregroundColor(Color(hex: "#FFFC00"))
         }
@@ -52,23 +64,29 @@ struct CoordinateDisplayView: View {
             // Format selector buttons - scrollable for better UX
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 6) {
-                    ForEach(CoordinateFormat.allCases, id: \.self) { format in
+                    ForEach(CoordinateDisplayFormat.allCases) { format in
                         Button(action: {
                             withAnimation(.easeInOut(duration: 0.2)) {
-                                selectedFormat = format
+                                // Write the shared setting so the cursor/center
+                                // readout and Settings picker stay in sync.
+                                formatString = format.rawValue
                             }
                             // Haptic feedback
                             let generator = UIImpactFeedbackGenerator(style: .light)
                             generator.impactOccurred()
                         }) {
                             VStack(spacing: 2) {
-                                Text(format.rawValue)
+                                Text(format.shortName)
                                     .font(.system(size: 11, weight: .bold))
                                     .foregroundColor(selectedFormat == format ? .black : .white)
 
-                                // Show indicator for special formats
+                                // Show a region tag for the localized grids.
                                 if format == .bng {
                                     Text("UK")
+                                        .font(.system(size: 7, weight: .medium))
+                                        .foregroundColor(selectedFormat == format ? .black.opacity(0.7) : .white.opacity(0.5))
+                                } else if format == .twd97 {
+                                    Text("TW")
                                         .font(.system(size: 7, weight: .medium))
                                         .foregroundColor(selectedFormat == format ? .black.opacity(0.7) : .white.opacity(0.5))
                                 }
@@ -98,7 +116,7 @@ struct CoordinateDisplayView: View {
                     }
                 }
 
-                Text(formatCoordinate(coordinate, format: selectedFormat))
+                Text(selectedFormat.format(coordinate))
                     .font(.system(size: 13, weight: .bold, design: .monospaced))
                     .foregroundColor(Color(hex: "#00FFFF"))
                     .lineLimit(2)
@@ -117,105 +135,6 @@ struct CoordinateDisplayView: View {
             generator.impactOccurred()
         }
     }
-
-    private func formatCoordinate(_ coordinate: CLLocationCoordinate2D, format: CoordinateFormat) -> String {
-        switch format {
-        case .latlon:
-            return formatLatLon(coordinate)
-        case .mgrs:
-            return formatMGRS(coordinate)
-        case .utm:
-            return formatUTM(coordinate)
-        case .bng:
-            return formatBNG(coordinate)
-        case .twd97:
-            return formatTWD97(coordinate)
-        }
-    }
-
-    // MARK: - Lat/Lon Formatting
-
-    private func formatLatLon(_ coordinate: CLLocationCoordinate2D) -> String {
-        let latDirection = coordinate.latitude >= 0 ? "N" : "S"
-        let lonDirection = coordinate.longitude >= 0 ? "E" : "W"
-
-        let lat = abs(coordinate.latitude)
-        let lon = abs(coordinate.longitude)
-
-        // Degrees, Minutes, Seconds format
-        let latDeg = Int(lat)
-        let latMin = Int((lat - Double(latDeg)) * 60)
-        let latSec = Int(((lat - Double(latDeg)) * 60 - Double(latMin)) * 60)
-
-        let lonDeg = Int(lon)
-        let lonMin = Int((lon - Double(lonDeg)) * 60)
-        let lonSec = Int(((lon - Double(lonDeg)) * 60 - Double(lonMin)) * 60)
-
-        return String(format: "%02d°%02d'%02d\"%@ %03d°%02d'%02d\"%@",
-                      latDeg, latMin, latSec, latDirection,
-                      lonDeg, lonMin, lonSec, lonDirection)
-    }
-
-    // MARK: - MGRS Formatting
-
-    private func formatMGRS(_ coordinate: CLLocationCoordinate2D) -> String {
-        // Use the MGRSConverter for accurate conversion
-        if MGRSConverter.isWithinMGRSBounds(coordinate) {
-            return MGRSConverter.formatMGRS(coordinate, precision: .tenMeter, withSpaces: true)
-        } else {
-            return "Out of MGRS bounds"
-        }
-    }
-
-    // MARK: - UTM Formatting
-
-    private func formatUTM(_ coordinate: CLLocationCoordinate2D) -> String {
-        // Use the MGRSConverter for accurate conversion
-        return MGRSConverter.formatUTM(coordinate)
-    }
-
-    // MARK: - BNG Formatting
-
-    private func formatBNG(_ coordinate: CLLocationCoordinate2D) -> String {
-        // Use the BNGConverter for accurate conversion
-        if BNGConverter.isWithinBNGBounds(coordinate) {
-            return BNGConverter.formatBNG(coordinate, precision: .tenMeter, withSpaces: true)
-        } else {
-            return "Out of BNG bounds"
-        }
-    }
-
-    // MARK: - TWD97 Formatting
-
-    private func formatTWD97(_ coordinate: CLLocationCoordinate2D) -> String {
-        // Full 7+7 absolute TM2 readout; entry sheet offers the 5+5 grid mode.
-        return TWD97Converter.formatTWD97(coordinate, mode: .full7, withSpaces: true)
-    }
-}
-
-// MARK: - Coordinate Format Enum
-
-enum CoordinateFormat: String, CaseIterable {
-    case latlon = "LAT/LON"
-    case mgrs = "MGRS"
-    case utm = "UTM"
-    case bng = "BNG"
-    case twd97 = "TWD97"
-
-    var displayName: String {
-        switch self {
-        case .latlon:
-            return "Latitude/Longitude"
-        case .mgrs:
-            return "Military Grid Reference System"
-        case .utm:
-            return "Universal Transverse Mercator"
-        case .bng:
-            return "British National Grid"
-        case .twd97:
-            return "TWD97 / TM2 (Taiwan)"
-        }
-    }
 }
 
 // MARK: - Preview
@@ -226,6 +145,12 @@ struct CoordinateDisplayView_Previews: PreviewProvider {
             Color.gray.ignoresSafeArea()
 
             VStack(spacing: 40) {
+                // Taipei, Taiwan (TWD97 coverage)
+                CoordinateDisplayView(
+                    coordinate: CLLocationCoordinate2D(latitude: 25.0339, longitude: 121.5645),
+                    isVisible: true
+                )
+
                 // Washington DC
                 CoordinateDisplayView(
                     coordinate: CLLocationCoordinate2D(latitude: 38.8977, longitude: -77.0365),
@@ -235,12 +160,6 @@ struct CoordinateDisplayView_Previews: PreviewProvider {
                 // Sydney, Australia
                 CoordinateDisplayView(
                     coordinate: CLLocationCoordinate2D(latitude: -33.8688, longitude: 151.2093),
-                    isVisible: true
-                )
-
-                // Tokyo, Japan
-                CoordinateDisplayView(
-                    coordinate: CLLocationCoordinate2D(latitude: 35.6762, longitude: 139.6503),
                     isVisible: true
                 )
             }


### PR DESCRIPTION
## What

The on-map **self-position coordinate chip** (`CoordinateDisplayView`) used its own private `CoordinateFormat` enum, defaulted to MGRS, had **no decimal-degrees option at all**, and **ignored** the user's choice in **Settings → Coordinate Format**. The app actually has two coordinate readouts that disagreed:

- **Settings + cursor/center readout** (`MapStateManager.CoordinateDisplayFormat`): DD, DM, DMS, MGRS, UTM, BNG, TWD97 — correct.
- **Self-position chip** (`CoordinateDisplayView.CoordinateFormat`): Lat/Lon (DMS-only), MGRS, UTM, BNG, TWD97 — siloed, no DD, stuck on MGRS regardless of Settings.

So a user who set **DD** or **TWD97** in Settings still saw MGRS on their own position, with no way to change it there.

## Fix

Repoint the chip at the shared `CoordinateDisplayFormat`, backed by `@AppStorage("coordinateDisplayFormat")` — the same key `SettingsView` and `MapStateManager` already use. Now the chip:

- reflects the chosen format on launch,
- offers all seven formats in its picker (including **DD** and **TWD97**),
- writes back to the shared key, so picking on the chip also updates Settings and the cursor/center readout,
- delegates conversion to `CoordinateDisplayFormat.format()` (single conversion path; deletes ~113 lines of duplicated formatting).

Also adds a small **TW** tag on the TWD97 button to match the existing **UK** tag on BNG.

## Why

Reported by @GavinChangTW (Taiwan field test): coordinate selection only offered MGRS; DMS/DD/TWD97 were unreachable on the self-position readout. Note TWD97 itself shipped in v2.36.0, so this PR is specifically about the chip honoring the format selection across the app.

## Verification

- Full `xcodebuild` (Debug, iPhone 17 Pro sim): **BUILD SUCCEEDED**.
- Live in Simulator over Taipei: setting the shared `coordinateDisplayFormat` key to `TWD97` renders the correct TWD97 readout (`0306966 2769651`) — the exact key + conversion path the chip now uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
