### PR TITLE
fix(coords): radial copy honors the selected coordinate format (#69)

### DIFF
--- a/OmniTAK.xcodeproj/project.pbxproj
+++ b/OmniTAK.xcodeproj/project.pbxproj
@@ -264,6 +264,7 @@
 		B2C3D4E5F60718293A4B5C6D /* MilitaryReportCoT.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F60718293A4B5C6E /* MilitaryReportCoT.swift */; };
 		B31DE0874D24FB971A6F8ACC /* RemoteIdToPointMarkerConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B18AEA7E422F3C5717BF5B /* RemoteIdToPointMarkerConverter.swift */; };
 		B4862ADC1DD9D4427C0DB504 /* TAKPacketCodecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34215C77B2CE923B04AF0F5 /* TAKPacketCodecTests.swift */; };
+		9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */; };
 		B4930D30352FB62914534BB0 /* TAKService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0E8333659DB4D3BE2BF699 /* TAKService.swift */; };
 		B6DB49544A68E8CE29BAFEDC /* MissionSyncView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D2FE0C197835A47A6E72903 /* MissionSyncView.swift */; };
 		B70B11FC36F270C4832E614C /* SFGPEV-----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 1C073B77D30C122325D6E02D /* SFGPEV-----.svg */; };
@@ -534,6 +535,7 @@
 		6255D6D7C0457143CC3E570B /* SNAP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNAP-------.svg"; sourceTree = "<group>"; };
 		628B317671CF6452847569CB /* RadialMenuMapCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadialMenuMapCoordinator.swift; path = OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuMapCoordinator.swift; sourceTree = "<group>"; };
 		634644F50DF0B69A944A6048 /* PPLISchedulerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PPLISchedulerTests.swift; path = OmniTAKMobileTests/PPLISchedulerTests.swift; sourceTree = "<group>"; };
+		EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoordinateFormatTests.swift; path = OmniTAKMobileTests/CoordinateFormatTests.swift; sourceTree = "<group>"; };
 		63C4E34598B862901EB54825 /* EchelonService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EchelonService.swift; path = OmniTAKMobile/Features/Teams/Services/EchelonService.swift; sourceTree = "<group>"; };
 		64977A5E2ADECCCF61D023F2 /* OmniTAKMobile-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OmniTAKMobile-Bridging-Header.h"; path = "OmniTAKMobile/Core/OmniTAKMobile-Bridging-Header.h"; sourceTree = "<group>"; };
 		6573C607EB2B7E7F82B0B79D /* de */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = de; path = OmniTAKMobile/Resources/de.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1024,6 +1026,7 @@
 				634644F50DF0B69A944A6048 /* PPLISchedulerTests.swift */,
 				0C8884B98F8B309825903DC6 /* ServerValidatorTests.swift */,
 				D34215C77B2CE923B04AF0F5 /* TAKPacketCodecTests.swift */,
+				EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */,
 				8D3A7C46FD7B29D70D019C18 /* TAKServiceTests.swift */,
 				A99C500AFB1B09E55ABEDBBF /* Info.plist */,
 			);
@@ -2660,6 +2663,7 @@
 				D1E674552E2BFBA766EFA496 /* PPLISchedulerTests.swift in Sources */,
 				1412A35EC6121F54838D6CCA /* ServerValidatorTests.swift in Sources */,
 				B4862ADC1DD9D4427C0DB504 /* TAKPacketCodecTests.swift in Sources */,
+				9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */,
 				4DF8129B40825E01D7F5BA79 /* TAKServiceTests.swift in Sources */,
 				F831B10A1D135F2E88925F52 /* PluginSDKTests.swift in Sources */,
 			);

--- a/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuActionExecutor.swift
+++ b/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuActionExecutor.swift
@@ -720,24 +720,16 @@ class RadialMenuActionExecutor {
         return "SAVED-\(dateFormatter.string(from: Date()))"
     }
 
+    /// Format a coordinate using the app-wide selected format.
+    ///
+    /// Reads "coordinateDisplayFormat" from UserDefaults — the same key that
+    /// SettingsView, CoordinateDisplayView (self-position chip, PR #58), and
+    /// MapStateManager all share.  Falls back to DMS when the key is absent or
+    /// unrecognised (first-launch / mid-migration).
     private static func formatCoordinate(_ coord: CLLocationCoordinate2D) -> String {
-        let lat = coord.latitude
-        let lon = coord.longitude
-
-        let latDir = lat >= 0 ? "N" : "S"
-        let lonDir = lon >= 0 ? "E" : "W"
-
-        let latDeg = Int(abs(lat))
-        let latMin = Int((abs(lat) - Double(latDeg)) * 60)
-        let latSec = ((abs(lat) - Double(latDeg)) * 60 - Double(latMin)) * 60
-
-        let lonDeg = Int(abs(lon))
-        let lonMin = Int((abs(lon) - Double(lonDeg)) * 60)
-        let lonSec = ((abs(lon) - Double(lonDeg)) * 60 - Double(lonMin)) * 60
-
-        return String(format: "%d\u{00B0}%d'%.2f\"%@ %d\u{00B0}%d'%.2f\"%@",
-                     latDeg, latMin, latSec, latDir,
-                     lonDeg, lonMin, lonSec, lonDir)
+        let formatString = UserDefaults.standard.string(forKey: "coordinateDisplayFormat") ?? ""
+        let format = CoordinateDisplayFormat(rawValue: formatString) ?? .degreesMinutesSeconds
+        return format.format(coord)
     }
 }
 

--- a/OmniTAKMobileTests/CoordinateFormatTests.swift
+++ b/OmniTAKMobileTests/CoordinateFormatTests.swift
@@ -1,0 +1,127 @@
+//
+//  CoordinateFormatTests.swift
+//  OmniTAKMobileTests
+//
+//  Regression tests for CoordinateDisplayFormat.format() — the single
+//  conversion path used by the self-position chip (PR #58) and the radial-
+//  menu copy/get-info actions (PR #69).
+//
+//  Reference coordinate: Taipei 101 (25.033971, 121.564504).
+//  TWD97 values derived from TWD97Converter.project() — we call the
+//  converter directly rather than hardcoding to stay in sync with
+//  any future precision changes.
+//
+
+import XCTest
+import CoreLocation
+@testable import OmniTAK
+
+final class CoordinateFormatTests: XCTestCase {
+
+    // Taipei 101: well-known anchor inside TWD97 bounds and MGRS coverage.
+    let taipei101 = CLLocationCoordinate2D(latitude: 25.033971, longitude: 121.564504)
+
+    // MARK: - CoordinateDisplayFormat.format() per-case
+
+    func testDecimalDegreesFormat() {
+        let result = CoordinateDisplayFormat.decimalDegrees.format(taipei101)
+        // Expected: "25.033971, 121.564504"
+        XCTAssertTrue(result.contains("25.03"), "DD: should contain lat prefix; got \(result)")
+        XCTAssertTrue(result.contains("121.56"), "DD: should contain lon prefix; got \(result)")
+        XCTAssertFalse(result.contains("°"), "DD: must not contain degree symbol; got \(result)")
+    }
+
+    func testDegreesMinutesFormat() {
+        let result = CoordinateDisplayFormat.degreesMinutes.format(taipei101)
+        // Expected format: "25°02.0383'N 121°33.8702'E"
+        XCTAssertTrue(result.contains("N"), "DM: should contain N hemisphere; got \(result)")
+        XCTAssertTrue(result.contains("E"), "DM: should contain E hemisphere; got \(result)")
+        XCTAssertTrue(result.contains("°"), "DM: should contain degree symbol; got \(result)")
+        XCTAssertTrue(result.contains("'"), "DM: should contain minute symbol; got \(result)")
+        XCTAssertFalse(result.contains("\""), "DM: must not contain seconds symbol; got \(result)")
+    }
+
+    func testDegreesMinutesSecondsFormat() {
+        let result = CoordinateDisplayFormat.degreesMinutesSeconds.format(taipei101)
+        // Expected format: "25°02'02.30"N 121°33'52.21"E"
+        XCTAssertTrue(result.contains("N"), "DMS: should contain N hemisphere; got \(result)")
+        XCTAssertTrue(result.contains("E"), "DMS: should contain E hemisphere; got \(result)")
+        XCTAssertTrue(result.contains("°"), "DMS: should contain degree symbol; got \(result)")
+        XCTAssertTrue(result.contains("'"), "DMS: should contain minute symbol; got \(result)")
+        XCTAssertTrue(result.contains("\""), "DMS: should contain seconds symbol; got \(result)")
+    }
+
+    func testMGRSFormat() {
+        let result = CoordinateDisplayFormat.mgrs.format(taipei101)
+        // Taipei 101 falls in MGRS zone 51R — starts with "51R"
+        XCTAssertTrue(result.hasPrefix("51R"), "MGRS: expected zone 51R prefix; got \(result)")
+        XCTAssertFalse(result.isEmpty, "MGRS: result must not be empty")
+    }
+
+    func testUTMFormat() {
+        let result = CoordinateDisplayFormat.utm.format(taipei101)
+        // UTM zone 51 N for Taipei
+        XCTAssertTrue(result.contains("51"), "UTM: should contain zone 51; got \(result)")
+        XCTAssertFalse(result.isEmpty, "UTM: result must not be empty")
+    }
+
+    func testTWD97Format() {
+        let result = CoordinateDisplayFormat.twd97.format(taipei101)
+        // TWD97 Taipei 101 — project to get expected values from the converter
+        // so the test is authoritative against the app's own math, not a
+        // hardcoded external reference.
+        let (easting, northing) = TWD97Converter.project(taipei101)
+        let expectedE = String(format: "%07d", Int(easting.rounded()))
+        let expectedN = String(format: "%07d", Int(northing.rounded()))
+
+        XCTAssertTrue(result.contains(expectedE),
+            "TWD97: easting \(expectedE) not found in \(result)")
+        XCTAssertTrue(result.contains(expectedN),
+            "TWD97: northing \(expectedN) not found in \(result)")
+
+        // Sanity: Taipei 101 is within TWD97 bounds so must not be the error string
+        XCTAssertNotEqual(result, "Out of TWD97 bounds",
+            "TWD97: Taipei 101 must be within TWD97 bounds")
+    }
+
+    // MARK: - UserDefaults key wiring (simulates radial-menu call path)
+
+    /// Verifies that CoordinateDisplayFormat can be round-tripped through
+    /// UserDefaults — the exact mechanism the fixed formatCoordinate() uses.
+    func testUserDefaultsKeyRoundTrip() {
+        let key = "coordinateDisplayFormat"
+        let originalValue = UserDefaults.standard.string(forKey: key)
+        defer {
+            // Restore whatever was there before
+            if let orig = originalValue {
+                UserDefaults.standard.set(orig, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        for format in CoordinateDisplayFormat.allCases {
+            UserDefaults.standard.set(format.rawValue, forKey: key)
+            let stored = UserDefaults.standard.string(forKey: key)
+            let parsed = stored.flatMap { CoordinateDisplayFormat(rawValue: $0) }
+            XCTAssertEqual(parsed, format,
+                "UserDefaults round-trip failed for format \(format.rawValue)")
+        }
+    }
+
+    /// Verifies missing / unknown key falls back gracefully — no crash and
+    /// a non-empty string.  This mirrors the fallback in formatCoordinate().
+    func testMissingKeyFallback() {
+        // Simulate a completely unknown raw value (as if the key was never written).
+        let formatString = ""
+        let format = CoordinateDisplayFormat(rawValue: formatString) ?? .degreesMinutesSeconds
+        XCTAssertEqual(format, .degreesMinutesSeconds,
+            "Empty string should fall back to DMS")
+
+        let result = format.format(taipei101)
+        XCTAssertFalse(result.isEmpty, "Fallback DMS must produce non-empty output")
+        // DMS output contains degree, minute and second symbols
+        XCTAssertTrue(result.contains("°") && result.contains("'") && result.contains("\""),
+            "Fallback DMS must be in DMS format; got \(result)")
+    }
+}


### PR DESCRIPTION
## Root cause

`RadialMenuActionExecutor.formatCoordinate()` (line 723) hand-rolled DMS and never consulted `UserDefaults.standard.string(forKey: "coordinateDisplayFormat")`.  Both call sites (`executeCopyCoordinates` :531 and `executeGetInfo` :592) called this private helper, so long-press copy always produced DMS regardless of the app's selected format.  Reported by Gavin (Taiwan team): clipboard output was always DMS even when TWD97 was selected.

## Format source wired

`UserDefaults.standard.string(forKey: "coordinateDisplayFormat")` — the same key that `SettingsView`, `CoordinateDisplayView` (self-position chip, PR #58), and `MapStateManager` all share.  Parsed via `CoordinateDisplayFormat(rawValue:)` with a fallback to `.degreesMinutesSeconds` when the key is absent (first-launch / mid-migration).  Conversion is delegated to `CoordinateDisplayFormat.format()` — the single conversion path already in use everywhere else.

## PR #58 pattern followed

PR #58 (`fix(coords/ios): self-position chip honors the shared coordinate format`) established:
- Key: `"coordinateDisplayFormat"` in `UserDefaults.standard`
- Parser: `CoordinateDisplayFormat(rawValue:) ?? .mgrs` (chip defaulted to MGRS; radial falls back to DMS to match old behavior)
- Conversion: `format.format(coordinate)` — delegates to `MGRSConverter`, `BNGConverter`, `TWD97Converter` as appropriate

This PR follows that exact pattern in `RadialMenuActionExecutor`.

## Files changed

- `OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuActionExecutor.swift` — replace `formatCoordinate()` body (17 lines → 3 lines)
- `OmniTAKMobileTests/CoordinateFormatTests.swift` — new, 8 unit tests
- `OmniTAK.xcodeproj/project.pbxproj` — register new test file

## Test evidence

```
Test Suite 'CoordinateFormatTests' passed
  testDecimalDegreesFormat     passed (0.002 seconds)
  testDegreesMinutesFormat     passed (0.002 seconds)
  testDegreesMinutesSecondsFormat  passed (0.001 seconds)
  testMGRSFormat               passed (0.001 seconds)
  testMissingKeyFallback       passed (0.001 seconds)
  testTWD97Format              passed (0.001 seconds)  ← critical for Gavin
  testUserDefaultsKeyRoundTrip passed (0.006 seconds)
  testUTMFormat                passed (0.000 seconds)
Executed 8 tests, with 0 failures in 0.013 seconds
```

`xcodebuild -scheme OmniTAKMobile -destination 'generic/platform=iOS Simulator' build` → **BUILD SUCCEEDED**

Closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)