### PR TITLE
MeshCore mesh framework + config profiles with QR sync

### DIFF
--- a/OmniTAK.xcodeproj/project.pbxproj
+++ b/OmniTAK.xcodeproj/project.pbxproj
@@ -374,6 +374,11 @@
 		FD9A668D450BCB86426AEBE1 /* LineOfSightModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD181F0D87FB0E91D14DFE79 /* LineOfSightModels.swift */; };
 		FEA13B1110000000FEA13B11 /* FemaIconSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA13B1110000000FEA13B22 /* FemaIconSet.swift */; };
 		FED47954389F0EA4DB422DD7 /* LassoSelectionPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF88DFDFB03BF594EB88178A /* LassoSelectionPill.swift */; };
+		CF000001B000000000000001 /* ConfigProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF000001A000000000000001 /* ConfigProfile.swift */; };
+		CF000002B000000000000001 /* ProfileQRCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF000002A000000000000001 /* ProfileQRCodec.swift */; };
+		CF000003B000000000000001 /* ProfileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF000003A000000000000001 /* ProfileStore.swift */; };
+		CF000004B000000000000001 /* ProfilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF000004A000000000000001 /* ProfilesView.swift */; };
+		CF000005B000000000000001 /* ConfigProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF000005A000000000000001 /* ConfigProfileTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -769,6 +774,11 @@
 		FE87E15631B845393B2BA5AD /* SPOTREPModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPOTREPModels.swift; path = OmniTAKMobile/Features/Military/Models/SPOTREPModels.swift; sourceTree = "<group>"; };
 		FEA13B1110000000FEA13B22 /* FemaIconSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FemaIconSet.swift; path = OmniTAKMobile/Features/Drawing/Models/FemaIconSet.swift; sourceTree = "<group>"; };
 		FEDA4D79535AD84B80DECADB /* SUGPEVM----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUGPEVM----.svg"; sourceTree = "<group>"; };
+		CF000001A000000000000001 /* ConfigProfile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConfigProfile.swift; path = OmniTAKMobile/Features/Profiles/Models/ConfigProfile.swift; sourceTree = "<group>"; };
+		CF000002A000000000000001 /* ProfileQRCodec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileQRCodec.swift; path = OmniTAKMobile/Features/Profiles/Services/ProfileQRCodec.swift; sourceTree = "<group>"; };
+		CF000003A000000000000001 /* ProfileStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileStore.swift; path = OmniTAKMobile/Features/Profiles/Services/ProfileStore.swift; sourceTree = "<group>"; };
+		CF000004A000000000000001 /* ProfilesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfilesView.swift; path = OmniTAKMobile/Features/Profiles/Views/ProfilesView.swift; sourceTree = "<group>"; };
+		CF000005A000000000000001 /* ConfigProfileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConfigProfileTests.swift; path = OmniTAKMobileTests/ConfigProfileTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1028,6 +1038,7 @@
 				D34215C77B2CE923B04AF0F5 /* TAKPacketCodecTests.swift */,
 				EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */,
 				8D3A7C46FD7B29D70D019C18 /* TAKServiceTests.swift */,
+								CF000005A000000000000001 /* ConfigProfileTests.swift */,
 				A99C500AFB1B09E55ABEDBBF /* Info.plist */,
 			);
 			name = OmniTAKMobileTests;
@@ -2666,6 +2677,7 @@
 				9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */,
 				4DF8129B40825E01D7F5BA79 /* TAKServiceTests.swift in Sources */,
 				F831B10A1D135F2E88925F52 /* PluginSDKTests.swift in Sources */,
+				CF000005B000000000000001 /* ConfigProfileTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2901,6 +2913,10 @@
 				7E069116B694B15B5EFDE612 /* DiagnosticsPlugin.swift in Sources */,
 				BD5ED2F273C06C32FB3CAA0E /* ADSBPlugin.swift in Sources */,
 				42DCF526B899E93E4340934B /* ADSBStatusOverlay.swift in Sources */,
+				CF000001B000000000000001 /* ConfigProfile.swift in Sources */,
+				CF000002B000000000000001 /* ProfileQRCodec.swift in Sources */,
+				CF000003B000000000000001 /* ProfileStore.swift in Sources */,
+				CF000004B000000000000001 /* ProfilesView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OmniTAK.xcodeproj/project.pbxproj
+++ b/OmniTAK.xcodeproj/project.pbxproj
@@ -45,7 +45,8 @@
 		2152BF37AF7F80147E73BDCB /* UASConnectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699B5990C6EA00ABB6691FB8 /* UASConnectView.swift */; };
 		221CFB201E760AE1F327AE9F /* SHAPMFQ----.svg in Resources */ = {isa = PBXBuildFile; fileRef = E763527D180A2BFA06815720 /* SHAPMFQ----.svg */; };
 		225E69B4E6B06F8CFCCC70CD /* DataPackageModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A282FADB8ACF4795AB133B /* DataPackageModels.swift */; };
-		2262EE8CA832D8F3763D6EC9 /* OmniTAKMobile/Features/Meshtastic/Views/MeshtasticTCPConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2393F697897173C8BD5B108A /* OmniTAKMobile/Features/Meshtastic/Views/MeshtasticTCPConnectionView.swift */; };
+		2262EE8CA832D8F3763D6EC9 /* MeshtasticTCPConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2393F697897173C8BD5B108A /* MeshtasticTCPConnectionView.swift */; };
+		2303D0E5E3509EE704208121 /* Meshtastic+MeshProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621CB29178D35F0EF1EE7268 /* Meshtastic+MeshProtocols.swift */; };
 		230A5E49E77C45D194BB82F0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3F9166C79C04A21BA2FDAA5 /* Assets.xcassets */; };
 		2363511BE3602F0BBEE29361 /* SUSPX------.svg in Resources */ = {isa = PBXBuildFile; fileRef = F0B36E3A750CD455EFE5AD60 /* SUSPX------.svg */; };
 		237C2BDF074F98E2885EF3E3 /* MGRSConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DDAA71A32AEB4CF7544E37 /* MGRSConverter.swift */; };
@@ -56,7 +57,7 @@
 		263C73CB7A111BC62A38D6C1 /* CertificateEnrollmentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C27B3788362A7692A3F6B70 /* CertificateEnrollmentView.swift */; };
 		265D7A1D6302893B932347C0 /* VideoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B30BD78B36AA8556AA3EC4 /* VideoSource.swift */; };
 		26E0ABCFEAF8561E21A3AFC5 /* SFGPU------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 0AE09A8DEEF0138AFC876D09 /* SFGPU------.svg */; };
-		273BAFBDAAB79C39F25835BD /* OmniTAKMobile/Features/Drawing/Services/LassoZipWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5BB3D4B491EB18FF1D1C01 /* OmniTAKMobile/Features/Drawing/Services/LassoZipWriter.swift */; };
+		273BAFBDAAB79C39F25835BD /* LassoZipWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5BB3D4B491EB18FF1D1C01 /* LassoZipWriter.swift */; };
 		2748B5AB1E5A1703D8ECA259 /* PointDropperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06A59DC9C712878830E5D23 /* PointDropperView.swift */; };
 		277D46D06A7BF886691B6F5C /* SharedUIComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C96B4A340D4B4628BBDAE89 /* SharedUIComponents.swift */; };
 		27C8F88CAA0E6E88977C276C /* SFGP-------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 0F89B3D56C89FA4871A2956F /* SFGP-------.svg */; };
@@ -88,13 +89,13 @@
 		3767932CE1360D4E75786269 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A299080EB48E2B8246EE899 /* SettingsView.swift */; };
 		38FCC16B78867B6617B2B329 /* ServerValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB754FA0C8506C4D22450CE /* ServerValidator.swift */; };
 		396485B8DEDCA74EB40645BA /* ChatModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F8125D0B514F0BD09467A8 /* ChatModels.swift */; };
-		39BFA71EE7DA696050952ECA /* OmniTAKMobile/Core/App/ToolSheetHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341557E70705872E61DF6310 /* OmniTAKMobile/Core/App/ToolSheetHost.swift */; };
+		39BFA71EE7DA696050952ECA /* ToolSheetHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341557E70705872E61DF6310 /* ToolSheetHost.swift */; };
 		39E5BA9BBA5EDD186729E499 /* GeofenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BE217D66F59D9E9606C20A /* GeofenceManager.swift */; };
 		39FEDA5607D661F389177B31 /* OmniTAKMobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E63BBCFD2826242AD21153A /* OmniTAKMobile.xcframework */; };
 		3B8DA9F0EDA91EFCA89EC904 /* SFAPC------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 52D432E4C3428F0F0A4BF379 /* SFAPC------.svg */; };
 		3BC0BAE8F7A660C4F250DC2C /* SNGPUCI----.svg in Resources */ = {isa = PBXBuildFile; fileRef = F321A46B9ECFAA7A7C739597 /* SNGPUCI----.svg */; };
 		3C4101B3AB28B70F3344FBDD /* SUGPUCI----.svg in Resources */ = {isa = PBXBuildFile; fileRef = E23A94C1C9FE550D90660BD6 /* SUGPUCI----.svg */; };
-		3C81060D2FFBB72033923002 /* OmniTAKMobile/Features/Drawing/Services/LassoExporters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3E4F244163FBE4214BC0C6 /* OmniTAKMobile/Features/Drawing/Services/LassoExporters.swift */; };
+		3C81060D2FFBB72033923002 /* LassoExporters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3E4F244163FBE4214BC0C6 /* LassoExporters.swift */; };
 		3CC71CC6036F998F1B657185 /* MeshtasticConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8106AADD977406BA4F0F47 /* MeshtasticConnectionView.swift */; };
 		3DD7F472AD7AF7BC9CB6EB29 /* SPOTREPModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE87E15631B845393B2BA5AD /* SPOTREPModels.swift */; };
 		3E18AAA98226AF54BA13A793 /* SFSPN------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7B690A36951863A447C8F3C0 /* SFSPN------.svg */; };
@@ -108,11 +109,14 @@
 		409D7589A76E63D323F8F8FC /* PointMarkerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F4DD664BBA1341CE945E50 /* PointMarkerModels.swift */; };
 		40BF731A8AEC6898ECF72D6E /* UASManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF6C46A0E3F79DB84E2969DE /* UASManager.swift */; };
 		40D04307B87189E2E4A15118 /* KMZHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1103C5349FE3EE31708711A /* KMZHandler.swift */; };
-		42B40E22FFA4AE412996AE66 /* OmniTAKMobile/Core/App/ToolbarAddPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE9342858430C8B11A6138F /* OmniTAKMobile/Core/App/ToolbarAddPalette.swift */; };
+		42B40E22FFA4AE412996AE66 /* ToolbarAddPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE9342858430C8B11A6138F /* ToolbarAddPalette.swift */; };
 		42DCF526B899E93E4340934B /* ADSBStatusOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5821A1F45BE3F2985B6BAB51 /* ADSBStatusOverlay.swift */; };
+		455571E4BBCEB4E0EA1AF5B1 /* MeshFramework.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771357A62E95D5EECDB9E041 /* MeshFramework.swift */; };
 		4675EBCE9576F085769447EC /* SHGPEV-----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7D35639DBB6AB10DBC043C4B /* SHGPEV-----.svg */; };
+		46C4106B90CE63B9AFEE077F /* MeshCoreBLETransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379B5FD869FE93AF42EDEB28 /* MeshCoreBLETransport.swift */; };
 		480EBBF20019DACA98438F45 /* SNGPEVC----.svg in Resources */ = {isa = PBXBuildFile; fileRef = A041F038EB4BDB2644B549B4 /* SNGPEVC----.svg */; };
-		48D6F14168132D11BD618DF3 /* OmniTAKMobile/Core/App/DataPackageBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0BF08DA781B87F179C32EF /* OmniTAKMobile/Core/App/DataPackageBootstrap.swift */; };
+		48D6F14168132D11BD618DF3 /* DataPackageBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0BF08DA781B87F179C32EF /* DataPackageBootstrap.swift */; };
+		49375D54457B411F0CC0E2D5 /* MeshCoreCoTConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571ED12EAF9663A7A6B01B91 /* MeshCoreCoTConverter.swift */; };
 		49A5B6C1F772F2FF591D3D1B /* CoTMessageParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADDFCAFC6CCE91DC4AA9FBF6 /* CoTMessageParser.swift */; };
 		4B3050B630557EC02D0B80A9 /* SUAPMH-----.svg in Resources */ = {isa = PBXBuildFile; fileRef = AC543153CFA99C00E8ECFC46 /* SUAPMH-----.svg */; };
 		4C8370B68A37749E00F29B13 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D159CF2A7D23BFC860F0010 /* Foundation.framework */; };
@@ -140,7 +144,8 @@
 		627C1AF9B1833EE7F5CAFF95 /* KMLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59B3E277182EDF891B3ECAD /* KMLParser.swift */; };
 		62F0E99E6E6CC7D48A777176 /* RadialMenuActionExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C4AE7792EC101310F1483A /* RadialMenuActionExecutor.swift */; };
 		636ABF73E9E4AF843491777E /* SFGPEVC----.svg in Resources */ = {isa = PBXBuildFile; fileRef = EE2FC006021B8F5CE7D6554F /* SFGPEVC----.svg */; };
-		636B2050F7414B9F51ED24C1 /* OmniTAKMobile/Features/Map/Views/CoordinateEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9EF53FB6EBD8EDF3F86897D /* OmniTAKMobile/Features/Map/Views/CoordinateEntryView.swift */; };
+		636B2050F7414B9F51ED24C1 /* CoordinateEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9EF53FB6EBD8EDF3F86897D /* CoordinateEntryView.swift */; };
+		65F8AEA3C407443E418A537F /* MeshCoreFrameCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FD474B6A8250F778891C09 /* MeshCoreFrameCodec.swift */; };
 		664F8613B5F60B743FBF798E /* SUA---------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8D6AFD4385B2CB747A74C320 /* SUA---------.svg */; };
 		6671B330ED4920A501C466DB /* SHSPN------.svg in Resources */ = {isa = PBXBuildFile; fileRef = B1A726FDC5E3383C783799A5 /* SHSPN------.svg */; };
 		669DCCE82BC14EE536DD18ED /* MeshtasticDevicePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D37E8D6422BE44C712E352 /* MeshtasticDevicePickerView.swift */; };
@@ -158,12 +163,12 @@
 		6F5B4DB2053193B5468631D0 /* SFAPMFA----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 70EA451E061A876807E914DA /* SFAPMFA----.svg */; };
 		6FE38F11F9AC0C33FA06A7C3 /* BreadcrumbTrailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9AA2203CD168813C8B8F77 /* BreadcrumbTrailService.swift */; };
 		6FE43BA548D82C170FEE6275 /* MeshBroadcastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7FB9C4E1E1A57D761DBE6B /* MeshBroadcastTests.swift */; };
-		714739C165C288B44EC3A6E8 /* OmniTAKMobile/Features/Meshtastic/Networking/MeshtasticTCPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D391707FFAE79A3046AC4505 /* OmniTAKMobile/Features/Meshtastic/Networking/MeshtasticTCPClient.swift */; };
+		714739C165C288B44EC3A6E8 /* MeshtasticTCPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D391707FFAE79A3046AC4505 /* MeshtasticTCPClient.swift */; };
 		729AB487769A2B685665B70A /* DrawingToolsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A407760F29BEEA3F0416893 /* DrawingToolsManager.swift */; };
 		730B9E168F5B40DCF1209BFB /* RoutePlanningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B550057AC0D0462051CA0B5 /* RoutePlanningService.swift */; };
 		730C9F17A6B541EDF2309CFB /* NavigationVoiceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C660158BD1E0563152CB1B6 /* NavigationVoiceService.swift */; };
 		73C474FC499785F0456D017A /* BloodhoundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3611027C930D5BCF88C9FB3B /* BloodhoundView.swift */; };
-		74906A9B2523F0EC9F6AFD80 /* OmniTAKMobile/Features/Drawing/Views/LassoContactPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFC3F270A71C2F7D59AB900 /* OmniTAKMobile/Features/Drawing/Views/LassoContactPickerSheet.swift */; };
+		74906A9B2523F0EC9F6AFD80 /* LassoContactPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFC3F270A71C2F7D59AB900 /* LassoContactPickerSheet.swift */; };
 		75448E769CF9B75E22F5E0A8 /* CoTEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D61F229B86A7E9D62B8B6DC /* CoTEventHandler.swift */; };
 		763B102741484CBEA23EEC42 /* SNGPEV-----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7AE4DA48DA1AA36C35A71343 /* SNGPEV-----.svg */; };
 		765F08BFD361C871BC9C0096 /* OpenDroneIdParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F64DCA3236DEE7586F935ED /* OpenDroneIdParser.swift */; };
@@ -183,7 +188,7 @@
 		7E069116B694B15B5EFDE612 /* DiagnosticsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F55D934522295329FE6400 /* DiagnosticsPlugin.swift */; };
 		7E5C86C855523AF841D45383 /* PluginHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6A1EA71D839AA2F8A09BAE /* PluginHost.swift */; };
 		7EDBE9DF6FFCE3C341C5E915 /* DigitalPointerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C09CF368D064E2DA8CDF9BA /* DigitalPointerView.swift */; };
-		7FB3B16574296B84A7731FF4 /* OmniTAKMobile/Features/Drawing/Views/LassoShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01560943F910CBC6CC9CA56B /* OmniTAKMobile/Features/Drawing/Views/LassoShareSheet.swift */; };
+		7FB3B16574296B84A7731FF4 /* LassoShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01560943F910CBC6CC9CA56B /* LassoShareSheet.swift */; };
 		80428D117637BA916DE86564 /* SUAPMF-----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 32A0B14AA6AE2A4EA6F01207 /* SUAPMF-----.svg */; };
 		804CCF2345FE867EE8D91EBD /* NavigationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB935C34F50FCED41AA9526D /* NavigationService.swift */; };
 		804EB04B625E53111E9AF10D /* SNAP-------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6255D6D7C0457143CC3E570B /* SNAP-------.svg */; };
@@ -192,6 +197,7 @@
 		80BE342924E4AD907E817716 /* TrackModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032A62EF89434562EEB3178B /* TrackModels.swift */; };
 		82C931405649C0A3F61F8BD5 /* RangeBearingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5FB4399952EB25310628E4 /* RangeBearingService.swift */; };
 		82F2BDD61F0B92EE280AF7CE /* GeofenceModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA957EC8A75AEFBCCFF253A /* GeofenceModels.swift */; };
+		8392967F239957719274C288 /* MeshCoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7518A46D0D0B472C491E1209 /* MeshCoreManager.swift */; };
 		83C89AB8B5F9864651DFBA7F /* OfflineMapsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C20C5734319D533A7C2227 /* OfflineMapsView.swift */; };
 		8678488239C0D1DB2116DAA1 /* OmniTAKMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DAD962E4B0A0A4D228D2467 /* OmniTAKMobileApp.swift */; };
 		89D7920E5028900C9BFE620C /* VideoFeedListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EDF33D868687EC0C282728B /* VideoFeedListView.swift */; };
@@ -216,19 +222,21 @@
 		9849457840B9B35D707D063F /* SHGPUCE----.svg in Resources */ = {isa = PBXBuildFile; fileRef = F9D70EB5B910BFFE5615493B /* SHGPUCE----.svg */; };
 		98F359A0B3B19480BA7BE805 /* VideoStreamModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73B72E19694F5ADED598A7E /* VideoStreamModels.swift */; };
 		9931084D104902FBC10263F1 /* CertificateHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA427470D4AEB92295081A7 /* CertificateHandlingTests.swift */; };
-		9B13BA7009C824D9D69DE4E8 /* OmniTAKMobile/Core/App/CustomToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD202A5275CE529F7E53F55B /* OmniTAKMobile/Core/App/CustomToolbar.swift */; };
+		9A446C624ADE62417F064DE4 /* MeshFrameworkDevicePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0006B84C15765B63E17797BD /* MeshFrameworkDevicePickerView.swift */; };
+		9B13BA7009C824D9D69DE4E8 /* CustomToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD202A5275CE529F7E53F55B /* CustomToolbar.swift */; };
 		9B53B95D7EDEE6FC5CB09995 /* TurnByTurnNavigationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF4CA147B5220C0A776A48B /* TurnByTurnNavigationService.swift */; };
 		9C5FA3DD0174828A73ABAEAA /* LineOfSightView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F269621B47884814AA5FC323 /* LineOfSightView.swift */; };
 		9D1E97C264F38CD9B0017F5A /* DrawingPropertiesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8A6851F2CB32B82BEA2817 /* DrawingPropertiesView.swift */; };
 		9D4DD979FA07D0D920CA576A /* MEDEVACRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C046FF14CC38A998A3C9C57A /* MEDEVACRequestView.swift */; };
+		9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */; };
 		9F360AA41C05B15FC6B71F75 /* EchelonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D5A42ABFBE8EF268B187D8 /* EchelonModels.swift */; };
-		9F4D964068E0E91862AEE361 /* OmniTAKMobile/Features/DataPackages/Views/KMLOverlaysPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619B6C2A0B1A1C5237648ED5 /* OmniTAKMobile/Features/DataPackages/Views/KMLOverlaysPanel.swift */; };
+		9F4D964068E0E91862AEE361 /* KMLOverlaysPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619B6C2A0B1A1C5237648ED5 /* KMLOverlaysPanel.swift */; };
 		9F975E18CC49BBAC535F8A0B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D9B49FD9370499A376CCF227 /* Localizable.strings */; };
-		A0E27883B3902B6F2FF2FE1C /* OmniTAKMobile/Utilities/Converters/TWD97Converter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9E2E310096E7DE7907558F /* OmniTAKMobile/Utilities/Converters/TWD97Converter.swift */; };
-		A1645CC72ECC172B00B71E89 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
-		A1645CC82ECC172B00B71E89 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
-		A1645CC92ECC172B00B71E89 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
-		A1645CCA2ECC172B00B71E89 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+		A0E27883B3902B6F2FF2FE1C /* TWD97Converter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9E2E310096E7DE7907558F /* TWD97Converter.swift */; };
+		A1645CC72ECC172B00B71E89 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		A1645CC82ECC172B00B71E89 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		A1645CC92ECC172B00B71E89 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		A1645CCA2ECC172B00B71E89 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		A1B2C3D4E5F60718293A4B5C /* CoTXMLBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5D /* CoTXMLBuilder.swift */; };
 		A1C234567890ABCDEF123456 /* VLCPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C234567890ABCDEF123457 /* VLCPlayerView.swift */; };
 		A20F144DC6EC67643B8C77B0 /* MEDEVACModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE1D24BFD11E3D147A90D0D /* MEDEVACModels.swift */; };
@@ -264,7 +272,6 @@
 		B2C3D4E5F60718293A4B5C6D /* MilitaryReportCoT.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F60718293A4B5C6E /* MilitaryReportCoT.swift */; };
 		B31DE0874D24FB971A6F8ACC /* RemoteIdToPointMarkerConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B18AEA7E422F3C5717BF5B /* RemoteIdToPointMarkerConverter.swift */; };
 		B4862ADC1DD9D4427C0DB504 /* TAKPacketCodecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34215C77B2CE923B04AF0F5 /* TAKPacketCodecTests.swift */; };
-		9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */; };
 		B4930D30352FB62914534BB0 /* TAKService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0E8333659DB4D3BE2BF699 /* TAKService.swift */; };
 		B6DB49544A68E8CE29BAFEDC /* MissionSyncView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D2FE0C197835A47A6E72903 /* MissionSyncView.swift */; };
 		B70B11FC36F270C4832E614C /* SFGPEV-----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 1C073B77D30C122325D6E02D /* SFGPEV-----.svg */; };
@@ -286,14 +293,15 @@
 		C245E1748500C1AE8F4DEE33 /* ChatPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD90777514477024C0CB76B /* ChatPersistence.swift */; };
 		C275C710655C5700240FA691 /* ElevationProfileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9F6D6CCA2BD4F9DC7AB527 /* ElevationProfileService.swift */; };
 		C3391DAF1A97C079DC92DDC0 /* SFSPC------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 4D22771DB86F35384204BEFE /* SFSPC------.svg */; };
-		C34D49043A5E553DDA359F8A /* OmniTAKMobile/Core/App/ToolbarCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9E95A9D23FB68454E3A330 /* OmniTAKMobile/Core/App/ToolbarCustomization.swift */; };
+		C34D49043A5E553DDA359F8A /* ToolbarCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9E95A9D23FB68454E3A330 /* ToolbarCustomization.swift */; };
 		C3CE957E2B24B3A0A79E33D1 /* SFGPEVM----.svg in Resources */ = {isa = PBXBuildFile; fileRef = BC5B44E5322E4E6E9963FD64 /* SFGPEVM----.svg */; };
 		C3D4E5F60718293A4B5C6D7E /* TAKTLSSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F60718293A4B5C6D7F /* TAKTLSSessionDelegate.swift */; };
 		C42A1451D43FC231CE037C34 /* SFGPUC-----.svg in Resources */ = {isa = PBXBuildFile; fileRef = D66621975033CAE1BF66C402 /* SFGPUC-----.svg */; };
 		C482E868B393C7F53397E60C /* RadialMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3B7BEB56FAFB09686EF170 /* RadialMenuView.swift */; };
 		C4A7E6CF5F6C4EFBB7F3EF39 /* RouteOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA920F17CA44D16A21FE01A /* RouteOverlayView.swift */; };
 		C5531F2B04C6EA133FDDF3E6 /* CSRGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B8D46995079943866D66720 /* CSRGenerator.swift */; };
-		C5B0BD228B239E4E83735254 /* OmniTAKMobile/Features/Drawing/Views/ToolsLauncherSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FDD932AB0896DCFA82D9BD /* OmniTAKMobile/Features/Drawing/Views/ToolsLauncherSheet.swift */; };
+		C5B0BD228B239E4E83735254 /* ToolsLauncherSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FDD932AB0896DCFA82D9BD /* ToolsLauncherSheet.swift */; };
+		C5C06A972D151475A44BC316 /* MeshCoreFrameCodecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2695126547C2B13F85388D57 /* MeshCoreFrameCodecTests.swift */; };
 		C5F04FC952F95D148C499140 /* DataPackageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD0915DECF434E22D068531 /* DataPackageView.swift */; };
 		C834B4EAB8F038DE7CB99099 /* DataPackageImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9BD8FABAF37BB1D8BCFEBCB /* DataPackageImportView.swift */; };
 		C8415B2453537EF92CFC3CDE /* SNGPUSM----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 1D0FA158CC7E5FC59B052C9D /* SNGPUSM----.svg */; };
@@ -334,12 +342,12 @@
 		DFE366B176992E3CE85E10BF /* PluginRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D95E31A4FB55F17B88EDA43 /* PluginRegistry.swift */; };
 		E1F2A3B4C5D6E7F809182930 /* PointMarkerEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B4C5D6E7F809182931 /* PointMarkerEditView.swift */; };
 		E3397D517A54F6F76789C606 /* MeshtasticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E7E03CF8CE1ECA81C1AA86 /* MeshtasticManager.swift */; };
-		E5F60718293A4B5C6D7E8F90 /* OmniTAKMobile/Core/App/ToolRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F60718293A4B5C6D7E8F91 /* OmniTAKMobile/Core/App/ToolRegistry.swift */; };
+		E5F60718293A4B5C6D7E8F90 /* ToolRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F60718293A4B5C6D7E8F91 /* ToolRegistry.swift */; };
 		E696090A2C20C65D83CD1F3D /* MeshtasticCoTConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1419954D52EBD5859EFA2213 /* MeshtasticCoTConverter.swift */; };
 		E77F3801C3528F7068248083 /* SHAPMHQ----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 3193AFBC53C3A33A5F23530C /* SHAPMHQ----.svg */; };
 		E8FC76F4642B0A491FDDD72E /* SFGPUSM----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 2A8886CA936AF8F6E8582BA9 /* SFGPUSM----.svg */; };
 		E913B6AFAD02D35CD5CB4E67 /* OfflineTileCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 343A9DB3612DAF9A47999950 /* OfflineTileCache.swift */; };
-		E955D31B3785A13C9CF3832E /* OmniTAKMobile/Utilities/Integration/KMLVectorOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4B8A5F29C10A6D8A88F3F9 /* OmniTAKMobile/Utilities/Integration/KMLVectorOverlay.swift */; };
+		E955D31B3785A13C9CF3832E /* KMLVectorOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4B8A5F29C10A6D8A88F3F9 /* KMLVectorOverlay.swift */; };
 		E990A725543BD219368F73D1 /* SFGPUCF----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6F1BF5D92F7208BB2FC250FF /* SFGPUCF----.svg */; };
 		EAD59D79838D8D6AF5450128 /* MeshTopologyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397C16C7CEF45EB144B930F7 /* MeshTopologyView.swift */; };
 		EB5A4DC2181AFF9ED7B346F0 /* SFFP-------.svg in Resources */ = {isa = PBXBuildFile; fileRef = BEF832712308E6D6284F0B68 /* SFFP-------.svg */; };
@@ -394,10 +402,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0006B84C15765B63E17797BD /* MeshFrameworkDevicePickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshFrameworkDevicePickerView.swift; path = OmniTAKMobile/Features/MeshCore/Views/MeshFrameworkDevicePickerView.swift; sourceTree = "<group>"; };
 		00359DE8F222FE7021D1936A /* SFFPG------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFFPG------.svg"; sourceTree = "<group>"; };
 		00459F49871153410DCE6A67 /* SHGPUCI----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGPUCI----.svg"; sourceTree = "<group>"; };
 		00CFB4EE06C47225356099DC /* RemoteIdScanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RemoteIdScanner.swift; path = OmniTAKMobile/Features/RemoteID/Services/RemoteIdScanner.swift; sourceTree = "<group>"; };
-		01560943F910CBC6CC9CA56B /* OmniTAKMobile/Features/Drawing/Views/LassoShareSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Views/LassoShareSheet.swift; sourceTree = "<group>"; };
+		01560943F910CBC6CC9CA56B /* LassoShareSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Views/LassoShareSheet.swift; sourceTree = "<group>"; };
 		01D0268915445A44EEC89107 /* RemoteIdTrack.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RemoteIdTrack.swift; path = OmniTAKMobile/Features/RemoteID/Models/RemoteIdTrack.swift; sourceTree = "<group>"; };
 		032A62EF89434562EEB3178B /* TrackModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TrackModels.swift; path = OmniTAKMobile/Features/Tracking/Models/TrackModels.swift; sourceTree = "<group>"; };
 		03640AD0D5107F1549F5ED69 /* MissionSyncManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MissionSyncManager.swift; path = OmniTAKMobile/Features/DataPackages/Services/MissionSyncManager.swift; sourceTree = "<group>"; };
@@ -412,11 +421,11 @@
 		0C27B3788362A7692A3F6B70 /* CertificateEnrollmentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CertificateEnrollmentView.swift; path = OmniTAKMobile/Features/Authentication/Views/CertificateEnrollmentView.swift; sourceTree = "<group>"; };
 		0C8884B98F8B309825903DC6 /* ServerValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServerValidatorTests.swift; path = OmniTAKMobileTests/ServerValidatorTests.swift; sourceTree = "<group>"; };
 		0CAB30EF2A4D5DDC51F0D945 /* SHGPEVF----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGPEVF----.svg"; sourceTree = "<group>"; };
-		0CFC3F270A71C2F7D59AB900 /* OmniTAKMobile/Features/Drawing/Views/LassoContactPickerSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Views/LassoContactPickerSheet.swift; sourceTree = "<group>"; };
+		0CFC3F270A71C2F7D59AB900 /* LassoContactPickerSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Views/LassoContactPickerSheet.swift; sourceTree = "<group>"; };
 		0D2FE0C197835A47A6E72903 /* MissionSyncView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MissionSyncView.swift; path = OmniTAKMobile/Features/DataPackages/Views/MissionSyncView.swift; sourceTree = "<group>"; };
 		0DADFB16189D9AD132105CFF /* SNSP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNSP-------.svg"; sourceTree = "<group>"; };
 		0E1F2A3B4C5D6E7F80910A0C /* RootTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RootTabView.swift; path = OmniTAKMobile/Core/App/RootTabView.swift; sourceTree = "<group>"; };
-		0E3E4F244163FBE4214BC0C6 /* OmniTAKMobile/Features/Drawing/Services/LassoExporters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Services/LassoExporters.swift; sourceTree = "<group>"; };
+		0E3E4F244163FBE4214BC0C6 /* LassoExporters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Services/LassoExporters.swift; sourceTree = "<group>"; };
 		0F89B3D56C89FA4871A2956F /* SFGP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGP-------.svg"; sourceTree = "<group>"; };
 		101D7C9B957410F4D6827B09 /* SFGPUST----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPUST----.svg"; sourceTree = "<group>"; };
 		103C33E3B66400D772DDE95F /* SNGP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNGP-------.svg"; sourceTree = "<group>"; };
@@ -433,7 +442,7 @@
 		1648B4732A5A3CEE2F302194 /* MeasurementModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeasurementModels.swift; path = OmniTAKMobile/Features/Measurement/Models/MeasurementModels.swift; sourceTree = "<group>"; };
 		17EF09598A6E3E19F6F83576 /* TileDownloader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TileDownloader.swift; path = OmniTAKMobile/Features/Map/TileSources/TileDownloader.swift; sourceTree = "<group>"; };
 		1A2B3C4D5E6F70801A2B3C4E /* SelfPositionMarkerImage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfPositionMarkerImage.swift; path = OmniTAKMobile/Features/Map/Markers/SelfPositionMarkerImage.swift; sourceTree = "<group>"; };
-		1A9E2E310096E7DE7907558F /* OmniTAKMobile/Utilities/Converters/TWD97Converter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Utilities/Converters/TWD97Converter.swift; sourceTree = "<group>"; };
+		1A9E2E310096E7DE7907558F /* TWD97Converter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Utilities/Converters/TWD97Converter.swift; sourceTree = "<group>"; };
 		1B2F1E34DA7072A77EB08259 /* CertificateFormatConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CertificateFormatConverter.swift; path = OmniTAKMobile/Features/Networking/Managers/CertificateFormatConverter.swift; sourceTree = "<group>"; };
 		1C073B77D30C122325D6E02D /* SFGPEV-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPEV-----.svg"; sourceTree = "<group>"; };
 		1D0FA158CC7E5FC59B052C9D /* SNGPUSM----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNGPUSM----.svg"; sourceTree = "<group>"; };
@@ -446,19 +455,20 @@
 		1EBC84DF2F7B1C325E9B3B16 /* SHGPUCA----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGPUCA----.svg"; sourceTree = "<group>"; };
 		21ECE157083843DC0D219677 /* ADSBTrafficView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ADSBTrafficView.swift; path = OmniTAKMobile/Features/ADSB/Views/ADSBTrafficView.swift; sourceTree = "<group>"; };
 		2272CD08893F8EF861E29ED6 /* DrawingPersistence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DrawingPersistence.swift; path = OmniTAKMobile/Storage/DrawingPersistence.swift; sourceTree = "<group>"; };
-		2393F697897173C8BD5B108A /* OmniTAKMobile/Features/Meshtastic/Views/MeshtasticTCPConnectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Meshtastic/Views/MeshtasticTCPConnectionView.swift; sourceTree = SOURCE_ROOT; };
+		2393F697897173C8BD5B108A /* MeshtasticTCPConnectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Meshtastic/Views/MeshtasticTCPConnectionView.swift; sourceTree = SOURCE_ROOT; };
 		2399F38E59FEB96764216BFB /* ConnectionStatusWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConnectionStatusWidget.swift; path = OmniTAKMobile/Shared/UI/Components/ConnectionStatusWidget.swift; sourceTree = "<group>"; };
 		23CA2FA2B3BB6DFD4BEC9ACE /* SNGPUUL----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNGPUUL----.svg"; sourceTree = "<group>"; };
 		2464B06E0A6D6ACAFF5AA25D /* MeshtasticModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshtasticModels.swift; path = OmniTAKMobile/Features/Meshtastic/Models/MeshtasticModels.swift; sourceTree = "<group>"; };
 		2508DC9F3697513408E4A231 /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = OmniTAKMobile/Assets.xcassets; sourceTree = "<group>"; };
 		250C3BCC832BAF93AF02580F /* CASRequestModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CASRequestModels.swift; path = OmniTAKMobile/Features/Military/Models/CASRequestModels.swift; sourceTree = "<group>"; };
 		253A787E8AE256DFB44E368F /* SUGPEVF----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUGPEVF----.svg"; sourceTree = "<group>"; };
+		2695126547C2B13F85388D57 /* MeshCoreFrameCodecTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshCoreFrameCodecTests.swift; path = OmniTAKMobileTests/MeshCoreFrameCodecTests.swift; sourceTree = "<group>"; };
 		27AFF7080BC1929C0AFE3ACB /* DataPackageManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DataPackageManager.swift; path = OmniTAKMobile/Features/DataPackages/Managers/DataPackageManager.swift; sourceTree = "<group>"; };
 		283EA22A8CB9DCD511B4A52F /* SHAPACB----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHAPACB----.svg"; sourceTree = "<group>"; };
 		28EDF644D1504F54F41752D1 /* TeamModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TeamModels.swift; path = OmniTAKMobile/Features/Teams/Models/TeamModels.swift; sourceTree = "<group>"; };
 		2A8886CA936AF8F6E8582BA9 /* SFGPUSM----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPUSM----.svg"; sourceTree = "<group>"; };
 		2B91F77004BFFFEB0B24CBD7 /* DroneState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DroneState.swift; path = OmniTAKMobile/Features/UAS/Models/DroneState.swift; sourceTree = "<group>"; };
-		2B9E95A9D23FB68454E3A330 /* OmniTAKMobile/Core/App/ToolbarCustomization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Core/App/ToolbarCustomization.swift; sourceTree = "<group>"; };
+		2B9E95A9D23FB68454E3A330 /* ToolbarCustomization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Core/App/ToolbarCustomization.swift; sourceTree = "<group>"; };
 		2C34616EDE31B56B2D08565A /* ServersView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServersView.swift; path = OmniTAKMobile/Features/Networking/Views/ServersView.swift; sourceTree = "<group>"; };
 		2D240A72682F8C0E3253BA1F /* CompassOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompassOverlayView.swift; path = OmniTAKMobile/Features/Map/Views/CompassOverlayView.swift; sourceTree = "<group>"; };
 		2D61F229B86A7E9D62B8B6DC /* CoTEventHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoTEventHandler.swift; path = OmniTAKMobile/CoT/CoTEventHandler.swift; sourceTree = "<group>"; };
@@ -472,10 +482,11 @@
 		32DDAA71A32AEB4CF7544E37 /* MGRSConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MGRSConverter.swift; path = OmniTAKMobile/Utilities/Converters/MGRSConverter.swift; sourceTree = "<group>"; };
 		3370233EDA8C5D193E4F794E /* ServerManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServerManager.swift; path = OmniTAKMobile/Features/Networking/Managers/ServerManager.swift; sourceTree = "<group>"; };
 		33BE217D66F59D9E9606C20A /* GeofenceManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GeofenceManager.swift; path = OmniTAKMobile/Features/Geofencing/Managers/GeofenceManager.swift; sourceTree = "<group>"; };
-		341557E70705872E61DF6310 /* OmniTAKMobile/Core/App/ToolSheetHost.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Core/App/ToolSheetHost.swift; sourceTree = "<group>"; };
+		341557E70705872E61DF6310 /* ToolSheetHost.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Core/App/ToolSheetHost.swift; sourceTree = "<group>"; };
 		343A9DB3612DAF9A47999950 /* OfflineTileCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineTileCache.swift; path = OmniTAKMobile/Features/Map/TileSources/OfflineTileCache.swift; sourceTree = "<group>"; };
 		358A8322D6B0A02926268368 /* SHARED_INTERFACES.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHARED_INTERFACES.swift; path = OmniTAKMobile/Resources/Documentation/SHARED_INTERFACES.swift; sourceTree = "<group>"; };
 		3611027C930D5BCF88C9FB3B /* BloodhoundView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BloodhoundView.swift; path = OmniTAKMobile/Features/Tracking/Views/BloodhoundView.swift; sourceTree = "<group>"; };
+		379B5FD869FE93AF42EDEB28 /* MeshCoreBLETransport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshCoreBLETransport.swift; path = OmniTAKMobile/Features/MeshCore/Networking/MeshCoreBLETransport.swift; sourceTree = "<group>"; };
 		38E9D249C5D2CAAAC7C659D8 /* SUGPUCF----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUGPUCF----.svg"; sourceTree = "<group>"; };
 		397C16C7CEF45EB144B930F7 /* MeshTopologyView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshTopologyView.swift; path = OmniTAKMobile/Features/Meshtastic/Views/MeshTopologyView.swift; sourceTree = "<group>"; };
 		39F6E5D7A7C95BE91E8BE483 /* QuickActionToolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickActionToolbar.swift; path = OmniTAKMobile/Shared/UI/Components/QuickActionToolbar.swift; sourceTree = "<group>"; };
@@ -517,7 +528,9 @@
 		53D5A42ABFBE8EF268B187D8 /* EchelonModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EchelonModels.swift; path = OmniTAKMobile/Features/Teams/Models/EchelonModels.swift; sourceTree = "<group>"; };
 		54CA9186E268A8145FB69667 /* ATAKToolsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ATAKToolsView.swift; path = OmniTAKMobile/Shared/UI/Components/ATAKToolsView.swift; sourceTree = "<group>"; };
 		55AC5270E9592B701917919E /* MeasurementCalculator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeasurementCalculator.swift; path = OmniTAKMobile/Utilities/Calculators/MeasurementCalculator.swift; sourceTree = "<group>"; };
+		55FD474B6A8250F778891C09 /* MeshCoreFrameCodec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshCoreFrameCodec.swift; path = OmniTAKMobile/Features/MeshCore/Services/MeshCoreFrameCodec.swift; sourceTree = "<group>"; };
 		56AC5271E9592B701917920E /* UnitPreferences.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UnitPreferences.swift; path = OmniTAKMobile/Utilities/Preferences/UnitPreferences.swift; sourceTree = "<group>"; };
+		571ED12EAF9663A7A6B01B91 /* MeshCoreCoTConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshCoreCoTConverter.swift; path = OmniTAKMobile/Features/MeshCore/Services/MeshCoreCoTConverter.swift; sourceTree = "<group>"; };
 		57D7BCCB87FE00A332286EAC /* ChatView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatView.swift; path = OmniTAKMobile/Features/Chat/Views/ChatView.swift; sourceTree = "<group>"; };
 		5821A1F45BE3F2985B6BAB51 /* ADSBStatusOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ADSBStatusOverlay.swift; path = OmniTAKMobile/Features/ADSB/Plugin/ADSBStatusOverlay.swift; sourceTree = "<group>"; };
 		5D0010AE2E37C9E003C21B22 /* SFGPEVL----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPEVL----.svg"; sourceTree = "<group>"; };
@@ -531,11 +544,11 @@
 		615F1CB7901C7BD1FDA89130 /* MilStd2525Symbols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MilStd2525Symbols.swift; path = OmniTAKMobile/Shared/UI/MilStd2525/MilStd2525Symbols.swift; sourceTree = "<group>"; };
 		618A58C89F64552E4A2F4124 /* GybDetectionParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GybDetectionParser.swift; path = OmniTAKMobile/Features/GybDetector/Services/GybDetectionParser.swift; sourceTree = SOURCE_ROOT; };
 		61913B0068875742648C74C4 /* MeshtasticBLEClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshtasticBLEClient.swift; path = OmniTAKMobile/Features/Meshtastic/Networking/MeshtasticBLEClient.swift; sourceTree = SOURCE_ROOT; };
-		619B6C2A0B1A1C5237648ED5 /* OmniTAKMobile/Features/DataPackages/Views/KMLOverlaysPanel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/DataPackages/Views/KMLOverlaysPanel.swift; sourceTree = "<group>"; };
+		619B6C2A0B1A1C5237648ED5 /* KMLOverlaysPanel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/DataPackages/Views/KMLOverlaysPanel.swift; sourceTree = "<group>"; };
+		621CB29178D35F0EF1EE7268 /* Meshtastic+MeshProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Meshtastic+MeshProtocols.swift"; path = "OmniTAKMobile/Features/Mesh/Protocols/Meshtastic+MeshProtocols.swift"; sourceTree = "<group>"; };
 		6255D6D7C0457143CC3E570B /* SNAP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNAP-------.svg"; sourceTree = "<group>"; };
 		628B317671CF6452847569CB /* RadialMenuMapCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadialMenuMapCoordinator.swift; path = OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuMapCoordinator.swift; sourceTree = "<group>"; };
 		634644F50DF0B69A944A6048 /* PPLISchedulerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PPLISchedulerTests.swift; path = OmniTAKMobileTests/PPLISchedulerTests.swift; sourceTree = "<group>"; };
-		EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoordinateFormatTests.swift; path = OmniTAKMobileTests/CoordinateFormatTests.swift; sourceTree = "<group>"; };
 		63C4E34598B862901EB54825 /* EchelonService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EchelonService.swift; path = OmniTAKMobile/Features/Teams/Services/EchelonService.swift; sourceTree = "<group>"; };
 		64977A5E2ADECCCF61D023F2 /* OmniTAKMobile-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "OmniTAKMobile-Bridging-Header.h"; path = "OmniTAKMobile/Core/OmniTAKMobile-Bridging-Header.h"; sourceTree = "<group>"; };
 		6573C607EB2B7E7F82B0B79D /* de */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = de; path = OmniTAKMobile/Resources/de.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -561,10 +574,12 @@
 		7304715396E84696B2EB3A79 /* SHAPACF----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHAPACF----.svg"; sourceTree = "<group>"; };
 		73475124B5F208920CB87732 /* SHAPMH-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHAPMH-----.svg"; sourceTree = "<group>"; };
 		743A8E555F95C2902C263102 /* SHGPU------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGPU------.svg"; sourceTree = "<group>"; };
+		7518A46D0D0B472C491E1209 /* MeshCoreManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshCoreManager.swift; path = OmniTAKMobile/Features/MeshCore/Managers/MeshCoreManager.swift; sourceTree = "<group>"; };
 		751D3A5EF96A28BFB73F0122 /* PhotoPickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PhotoPickerView.swift; path = OmniTAKMobile/Shared/UI/Components/PhotoPickerView.swift; sourceTree = "<group>"; };
 		753DFA3A49FA2E282FBDBEA1 /* MAVLinkConnection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MAVLinkConnection.swift; path = OmniTAKMobile/Features/UAS/Services/MAVLinkConnection.swift; sourceTree = "<group>"; };
 		7545CAC8E7D57583BCDAB1CE /* LocalizationManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalizationManager.swift; path = OmniTAKMobile/Core/Localization/LocalizationManager.swift; sourceTree = "<group>"; };
 		76EE71ECBA829946C5219664 /* ChatXMLGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatXMLGenerator.swift; path = OmniTAKMobile/CoT/Parsers/ChatXMLGenerator.swift; sourceTree = "<group>"; };
+		771357A62E95D5EECDB9E041 /* MeshFramework.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshFramework.swift; path = OmniTAKMobile/Features/Mesh/Protocols/MeshFramework.swift; sourceTree = "<group>"; };
 		7740DF1463CF041207C4772B /* RegionSelectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RegionSelectionView.swift; path = OmniTAKMobile/Features/OfflineMaps/Views/RegionSelectionView.swift; sourceTree = "<group>"; };
 		7773A5DF20505E3BE995732E /* ChatManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatManager.swift; path = OmniTAKMobile/Features/Chat/Managers/ChatManager.swift; sourceTree = "<group>"; };
 		786486F562966ED005A6E978 /* AppPreviewRecordingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppPreviewRecordingTests.swift; sourceTree = "<group>"; };
@@ -576,7 +591,7 @@
 		7C96B4A340D4B4628BBDAE89 /* SharedUIComponents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SharedUIComponents.swift; path = OmniTAKMobile/Shared/UI/Components/SharedUIComponents.swift; sourceTree = "<group>"; };
 		7CC8AA92E93DC47AA18BE168 /* LineOfSightService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LineOfSightService.swift; path = OmniTAKMobile/Features/Measurement/Services/LineOfSightService.swift; sourceTree = "<group>"; };
 		7D35639DBB6AB10DBC043C4B /* SHGPEV-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGPEV-----.svg"; sourceTree = "<group>"; };
-		7D5BB3D4B491EB18FF1D1C01 /* OmniTAKMobile/Features/Drawing/Services/LassoZipWriter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Services/LassoZipWriter.swift; sourceTree = "<group>"; };
+		7D5BB3D4B491EB18FF1D1C01 /* LassoZipWriter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Services/LassoZipWriter.swift; sourceTree = "<group>"; };
 		7D8E2F02A147ACFC3768B6E3 /* SHGPEVC----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGPEVC----.svg"; sourceTree = "<group>"; };
 		7DA060C3ECA91A61479E7373 /* SFFPGS-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFFPGS-----.svg"; sourceTree = "<group>"; };
 		7DAD962E4B0A0A4D228D2467 /* OmniTAKMobileApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OmniTAKMobileApp.swift; path = OmniTAKMobile/Core/App/OmniTAKMobileApp.swift; sourceTree = "<group>"; };
@@ -593,7 +608,7 @@
 		8B550057AC0D0462051CA0B5 /* RoutePlanningService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RoutePlanningService.swift; path = OmniTAKMobile/Features/Navigation/Services/RoutePlanningService.swift; sourceTree = "<group>"; };
 		8BDF5ED16742882F42B9896D /* SUGPUSM----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUGPUSM----.svg"; sourceTree = "<group>"; };
 		8C660158BD1E0563152CB1B6 /* NavigationVoiceService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationVoiceService.swift; path = OmniTAKMobile/Features/Navigation/Services/NavigationVoiceService.swift; sourceTree = "<group>"; };
-		8CE9342858430C8B11A6138F /* OmniTAKMobile/Core/App/ToolbarAddPalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Core/App/ToolbarAddPalette.swift; sourceTree = "<group>"; };
+		8CE9342858430C8B11A6138F /* ToolbarAddPalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Core/App/ToolbarAddPalette.swift; sourceTree = "<group>"; };
 		8D3A7C46FD7B29D70D019C18 /* TAKServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TAKServiceTests.swift; path = OmniTAKMobileTests/TAKServiceTests.swift; sourceTree = "<group>"; };
 		8D6AFD4385B2CB747A74C320 /* SUA---------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUA---------.svg"; sourceTree = "<group>"; };
 		8E63BBCFD2826242AD21153A /* OmniTAKMobile.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; path = OmniTAKMobile.xcframework; sourceTree = "<group>"; };
@@ -608,7 +623,7 @@
 		9450DBDE52BFDA77D0BBA9DE /* EmergencyBeaconService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EmergencyBeaconService.swift; path = OmniTAKMobile/Features/Tracking/Services/EmergencyBeaconService.swift; sourceTree = "<group>"; };
 		9540F19EA7E0D4D8F98FC80F /* TAKRestAPIClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TAKRestAPIClient.swift; path = OmniTAKMobile/Features/Networking/Services/TAKRestAPIClient.swift; sourceTree = "<group>"; };
 		9802858282CB5E929AD75F07 /* CoTMessageParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoTMessageParserTests.swift; path = OmniTAKMobileTests/CoTMessageParserTests.swift; sourceTree = "<group>"; };
-		98FDD932AB0896DCFA82D9BD /* OmniTAKMobile/Features/Drawing/Views/ToolsLauncherSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Views/ToolsLauncherSheet.swift; sourceTree = "<group>"; };
+		98FDD932AB0896DCFA82D9BD /* ToolsLauncherSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Views/ToolsLauncherSheet.swift; sourceTree = "<group>"; };
 		9A9BEB1C723F75F83398705E /* SHSPCL-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHSPCL-----.svg"; sourceTree = "<group>"; };
 		9F574EC82B38F9A8107A6205 /* SFGPUUL----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPUUL----.svg"; sourceTree = "<group>"; };
 		9F64DCA3236DEE7586F935ED /* OpenDroneIdParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OpenDroneIdParser.swift; path = OmniTAKMobile/Features/RemoteID/Services/OpenDroneIdParser.swift; sourceTree = "<group>"; };
@@ -642,7 +657,7 @@
 		AA0CDC96A00B3693A51C3CCB /* TerrainVisualizationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TerrainVisualizationService.swift; path = OmniTAKMobile/Features/Map/Services/TerrainVisualizationService.swift; sourceTree = "<group>"; };
 		AA1150DC85BAA1B76738C687 /* RouteStorageManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RouteStorageManager.swift; path = OmniTAKMobile/Storage/RouteStorageManager.swift; sourceTree = "<group>"; };
 		AC543153CFA99C00E8ECFC46 /* SUAPMH-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUAPMH-----.svg"; sourceTree = "<group>"; };
-		AD202A5275CE529F7E53F55B /* OmniTAKMobile/Core/App/CustomToolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Core/App/CustomToolbar.swift; sourceTree = "<group>"; };
+		AD202A5275CE529F7E53F55B /* CustomToolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Core/App/CustomToolbar.swift; sourceTree = "<group>"; };
 		AD3B3966EEC56487F6A0C2FB /* SNAPMH-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNAPMH-----.svg"; sourceTree = "<group>"; };
 		ADDFCAFC6CCE91DC4AA9FBF6 /* CoTMessageParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoTMessageParser.swift; path = OmniTAKMobile/CoT/CoTMessageParser.swift; sourceTree = "<group>"; };
 		AE725B92EA137887258221CB /* SFAPMHQ----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFAPMHQ----.svg"; sourceTree = "<group>"; };
@@ -664,7 +679,7 @@
 		B9AB820E688425E45EE60103 /* CertificateImportPipeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CertificateImportPipeline.swift; path = OmniTAKMobile/Features/Networking/Managers/CertificateImportPipeline.swift; sourceTree = "<group>"; };
 		BA0E8333659DB4D3BE2BF699 /* TAKService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TAKService.swift; path = OmniTAKMobile/Features/Networking/Services/TAKService.swift; sourceTree = "<group>"; };
 		BB82A68BE625612A8B0E94DC /* PluginSettingsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PluginSettingsManager.swift; path = OmniTAKMobile/Shared/Services/PluginSettingsManager.swift; sourceTree = "<group>"; };
-		BC4B8A5F29C10A6D8A88F3F9 /* OmniTAKMobile/Utilities/Integration/KMLVectorOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Utilities/Integration/KMLVectorOverlay.swift; sourceTree = "<group>"; };
+		BC4B8A5F29C10A6D8A88F3F9 /* KMLVectorOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Utilities/Integration/KMLVectorOverlay.swift; sourceTree = "<group>"; };
 		BC5B44E5322E4E6E9963FD64 /* SFGPEVM----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPEVM----.svg"; sourceTree = "<group>"; };
 		BC8C1CB4DFB9C4743BBC4FFB /* SHSP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHSP-------.svg"; sourceTree = "<group>"; };
 		BDA920F17CA44D16A21FE01A /* RouteOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RouteOverlayView.swift; path = OmniTAKMobile/Features/Navigation/Views/RouteOverlayView.swift; sourceTree = "<group>"; };
@@ -697,7 +712,7 @@
 		D177EF1E8B82D4771CC765F1 /* SUSPN------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUSPN------.svg"; sourceTree = "<group>"; };
 		D1F628D2ABD2498188D0EACD /* KMLOverlayManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KMLOverlayManager.swift; path = OmniTAKMobile/Utilities/Integration/KMLOverlayManager.swift; sourceTree = "<group>"; };
 		D34215C77B2CE923B04AF0F5 /* TAKPacketCodecTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TAKPacketCodecTests.swift; path = OmniTAKMobileTests/TAKPacketCodecTests.swift; sourceTree = "<group>"; };
-		D391707FFAE79A3046AC4505 /* OmniTAKMobile/Features/Meshtastic/Networking/MeshtasticTCPClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Meshtastic/Networking/MeshtasticTCPClient.swift; sourceTree = SOURCE_ROOT; };
+		D391707FFAE79A3046AC4505 /* MeshtasticTCPClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Meshtastic/Networking/MeshtasticTCPClient.swift; sourceTree = SOURCE_ROOT; };
 		D3F9166C79C04A21BA2FDAA5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = OmniTAKMobile/Assets.xcassets; sourceTree = "<group>"; };
 		D452667B584032AAC6C0C1FB /* PointDropperService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PointDropperService.swift; path = OmniTAKMobile/Features/Drawing/Services/PointDropperService.swift; sourceTree = "<group>"; };
 		D4AAA687C9A021C584BE3F52 /* SNAPCF-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNAPCF-----.svg"; sourceTree = "<group>"; };
@@ -710,7 +725,7 @@
 		D8C8003EB0C35D84FCA0AE25 /* OmniTAKUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OmniTAKUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9B49FD9370499A376CCF228 /* zh-Hant */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "OmniTAKMobile/Resources/zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		D9BD8FABAF37BB1D8BCFEBCB /* DataPackageImportView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DataPackageImportView.swift; path = OmniTAKMobile/Features/DataPackages/Views/DataPackageImportView.swift; sourceTree = "<group>"; };
-		D9EF53FB6EBD8EDF3F86897D /* OmniTAKMobile/Features/Map/Views/CoordinateEntryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Map/Views/CoordinateEntryView.swift; sourceTree = "<group>"; };
+		D9EF53FB6EBD8EDF3F86897D /* CoordinateEntryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Map/Views/CoordinateEntryView.swift; sourceTree = "<group>"; };
 		DAD02BBDBC955E7953E23B56 /* SFAPMHC----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFAPMHC----.svg"; sourceTree = "<group>"; };
 		DB52A8F022DBCC0F3709FDA2 /* ADSBTrafficService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ADSBTrafficService.swift; path = OmniTAKMobile/Features/ADSB/Services/ADSBTrafficService.swift; sourceTree = "<group>"; };
 		DB5771FBA69E70A6E4BD4764 /* MeasurementToolView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeasurementToolView.swift; path = OmniTAKMobile/Features/Measurement/Views/MeasurementToolView.swift; sourceTree = "<group>"; };
@@ -730,13 +745,14 @@
 		E3A623059B1B6B76D3B2D875 /* GybDetectorView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GybDetectorView.swift; path = OmniTAKMobile/Features/GybDetector/Views/GybDetectorView.swift; sourceTree = SOURCE_ROOT; };
 		E438B334DFC6353E3C21C7DD /* AircraftIcons.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AircraftIcons.swift; path = OmniTAKMobile/Features/ADSB/Models/AircraftIcons.swift; sourceTree = "<group>"; };
 		E5160EE3247DE0377F3E6CE8 /* BNGConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BNGConverter.swift; path = OmniTAKMobile/Utilities/Converters/BNGConverter.swift; sourceTree = "<group>"; };
-		E5F60718293A4B5C6D7E8F91 /* OmniTAKMobile/Core/App/ToolRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Core/App/ToolRegistry.swift; sourceTree = "<group>"; };
+		E5F60718293A4B5C6D7E8F91 /* ToolRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Core/App/ToolRegistry.swift; sourceTree = "<group>"; };
 		E6426A4780DEDD91B5DA2B46 /* SFAPMFT----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFAPMFT----.svg"; sourceTree = "<group>"; };
 		E763527D180A2BFA06815720 /* SHAPMFQ----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHAPMFQ----.svg"; sourceTree = "<group>"; };
 		E7CD94F2AA3C9E1621AE6021 /* es */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = es; path = OmniTAKMobile/Resources/es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		EA171D08B8BECD16ACA18D51 /* SHGP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGP-------.svg"; sourceTree = "<group>"; };
 		EA4A86523E550E87AC1EE8A4 /* SALUTEReportView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SALUTEReportView.swift; path = OmniTAKMobile/Features/Military/Views/SALUTEReportView.swift; sourceTree = "<group>"; };
 		EA65513B351E6E8D864A945A /* RemoteIdAppBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RemoteIdAppBridge.swift; path = OmniTAKMobile/Features/RemoteID/Services/RemoteIdAppBridge.swift; sourceTree = "<group>"; };
+		EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoordinateFormatTests.swift; path = OmniTAKMobileTests/CoordinateFormatTests.swift; sourceTree = "<group>"; };
 		EC5FB4399952EB25310628E4 /* RangeBearingService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RangeBearingService.swift; path = OmniTAKMobile/Features/Measurement/Services/RangeBearingService.swift; sourceTree = "<group>"; };
 		ED51505084DDA26949BB854D /* EchelonHierarchyView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EchelonHierarchyView.swift; path = OmniTAKMobile/Features/Teams/Views/EchelonHierarchyView.swift; sourceTree = "<group>"; };
 		EE2FC006021B8F5CE7D6554F /* SFGPEVC----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPEVC----.svg"; sourceTree = "<group>"; };
@@ -763,7 +779,7 @@
 		FCD90777514477024C0CB76B /* ChatPersistence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChatPersistence.swift; path = OmniTAKMobile/Storage/ChatPersistence.swift; sourceTree = "<group>"; };
 		FD181F0D87FB0E91D14DFE79 /* LineOfSightModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LineOfSightModels.swift; path = OmniTAKMobile/Features/Measurement/Models/LineOfSightModels.swift; sourceTree = "<group>"; };
 		FD9F8A771AD5292E85B04E77 /* CASRequestView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CASRequestView.swift; path = OmniTAKMobile/Features/Military/Views/CASRequestView.swift; sourceTree = "<group>"; };
-		FE0BF08DA781B87F179C32EF /* OmniTAKMobile/Core/App/DataPackageBootstrap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Core/App/DataPackageBootstrap.swift; sourceTree = "<group>"; };
+		FE0BF08DA781B87F179C32EF /* DataPackageBootstrap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Core/App/DataPackageBootstrap.swift; sourceTree = "<group>"; };
 		FE5ADEAC186F3A6CC4CB7055 /* DeepLinkHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DeepLinkHandler.swift; path = OmniTAKMobile/Features/Networking/Services/DeepLinkHandler.swift; sourceTree = "<group>"; };
 		FE75C0779B00B1302E9BBE3A /* cot_types.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = cot_types.json; path = OmniTAKMobile/Shared/Resources/cot_types.json; sourceTree = "<group>"; };
 		FE87E15631B845393B2BA5AD /* SPOTREPModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SPOTREPModels.swift; path = OmniTAKMobile/Features/Military/Models/SPOTREPModels.swift; sourceTree = "<group>"; };
@@ -777,10 +793,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				A6CEA9E02F31C917002D96E2 /* MapboxMaps in Frameworks */,
-				A1645CC72ECC172B00B71E89 /* (null) in Frameworks */,
-				A1645CC82ECC172B00B71E89 /* (null) in Frameworks */,
-				A1645CC92ECC172B00B71E89 /* (null) in Frameworks */,
-				A1645CCA2ECC172B00B71E89 /* (null) in Frameworks */,
+				A1645CC72ECC172B00B71E89 /* BuildFile in Frameworks */,
+				A1645CC82ECC172B00B71E89 /* BuildFile in Frameworks */,
+				A1645CC92ECC172B00B71E89 /* BuildFile in Frameworks */,
+				A1645CCA2ECC172B00B71E89 /* BuildFile in Frameworks */,
 				39FEDA5607D661F389177B31 /* OmniTAKMobile.xcframework in Frameworks */,
 				F318050C070B48CB83D1915A /* VLCKitSPM in Frameworks */,
 			);
@@ -899,7 +915,7 @@
 			children = (
 				E5160EE3247DE0377F3E6CE8 /* BNGConverter.swift */,
 				32DDAA71A32AEB4CF7544E37 /* MGRSConverter.swift */,
-				1A9E2E310096E7DE7907558F /* OmniTAKMobile/Utilities/Converters/TWD97Converter.swift */,
+				1A9E2E310096E7DE7907558F /* TWD97Converter.swift */,
 			);
 			name = Converters;
 			sourceTree = "<group>";
@@ -1198,8 +1214,8 @@
 			isa = PBXGroup;
 			children = (
 				5E14DC8F84F9C7A9721FDD03 /* LassoSelectionService.swift */,
-				0E3E4F244163FBE4214BC0C6 /* OmniTAKMobile/Features/Drawing/Services/LassoExporters.swift */,
-				7D5BB3D4B491EB18FF1D1C01 /* OmniTAKMobile/Features/Drawing/Services/LassoZipWriter.swift */,
+				0E3E4F244163FBE4214BC0C6 /* LassoExporters.swift */,
+				7D5BB3D4B491EB18FF1D1C01 /* LassoZipWriter.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -1264,7 +1280,7 @@
 				2D240A72682F8C0E3253BA1F /* CompassOverlayView.swift */,
 				6A0A793E185CC30595DAB79B /* CoordinateDisplayView.swift */,
 				448D0EBEFF3E2A71669016D1 /* ScaleBarView.swift */,
-				D9EF53FB6EBD8EDF3F86897D /* OmniTAKMobile/Features/Map/Views/CoordinateEntryView.swift */,
+				D9EF53FB6EBD8EDF3F86897D /* CoordinateEntryView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -1516,7 +1532,7 @@
 		6A0CC0556CB362F5809DA186 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
-				D391707FFAE79A3046AC4505 /* OmniTAKMobile/Features/Meshtastic/Networking/MeshtasticTCPClient.swift */,
+				D391707FFAE79A3046AC4505 /* MeshtasticTCPClient.swift */,
 				61913B0068875742648C74C4 /* MeshtasticBLEClient.swift */,
 			);
 			name = Networking;
@@ -1528,7 +1544,7 @@
 			children = (
 				D9BD8FABAF37BB1D8BCFEBCB /* DataPackageImportView.swift */,
 				AFD0915DECF434E22D068531 /* DataPackageView.swift */,
-				619B6C2A0B1A1C5237648ED5 /* OmniTAKMobile/Features/DataPackages/Views/KMLOverlaysPanel.swift */,
+				619B6C2A0B1A1C5237648ED5 /* KMLOverlaysPanel.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -1653,9 +1669,9 @@
 			isa = PBXGroup;
 			children = (
 				CF88DFDFB03BF594EB88178A /* LassoSelectionPill.swift */,
-				98FDD932AB0896DCFA82D9BD /* OmniTAKMobile/Features/Drawing/Views/ToolsLauncherSheet.swift */,
-				0CFC3F270A71C2F7D59AB900 /* OmniTAKMobile/Features/Drawing/Views/LassoContactPickerSheet.swift */,
-				01560943F910CBC6CC9CA56B /* OmniTAKMobile/Features/Drawing/Views/LassoShareSheet.swift */,
+				98FDD932AB0896DCFA82D9BD /* ToolsLauncherSheet.swift */,
+				0CFC3F270A71C2F7D59AB900 /* LassoContactPickerSheet.swift */,
+				01560943F910CBC6CC9CA56B /* LassoShareSheet.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -1702,7 +1718,7 @@
 		872B202E6F7CE42DEEC26D95 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				2393F697897173C8BD5B108A /* OmniTAKMobile/Features/Meshtastic/Views/MeshtasticTCPConnectionView.swift */,
+				2393F697897173C8BD5B108A /* MeshtasticTCPConnectionView.swift */,
 				B4A0DCCEFB04D08FB298E2FD /* MeshNodeMapView.swift */,
 			);
 			name = Views;
@@ -1883,6 +1899,14 @@
 				1E000347E77659FB9483E560 /* ADSBPlugin.swift */,
 				5821A1F45BE3F2985B6BAB51 /* ADSBStatusOverlay.swift */,
 				C5B1610A03C98F73C6517BA8 /* PluginSDKTests.swift */,
+				771357A62E95D5EECDB9E041 /* MeshFramework.swift */,
+				621CB29178D35F0EF1EE7268 /* Meshtastic+MeshProtocols.swift */,
+				55FD474B6A8250F778891C09 /* MeshCoreFrameCodec.swift */,
+				571ED12EAF9663A7A6B01B91 /* MeshCoreCoTConverter.swift */,
+				379B5FD869FE93AF42EDEB28 /* MeshCoreBLETransport.swift */,
+				7518A46D0D0B472C491E1209 /* MeshCoreManager.swift */,
+				0006B84C15765B63E17797BD /* MeshFrameworkDevicePickerView.swift */,
+				2695126547C2B13F85388D57 /* MeshCoreFrameCodecTests.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2192,7 +2216,7 @@
 			isa = PBXGroup;
 			children = (
 				D1F628D2ABD2498188D0EACD /* KMLOverlayManager.swift */,
-				BC4B8A5F29C10A6D8A88F3F9 /* OmniTAKMobile/Utilities/Integration/KMLVectorOverlay.swift */,
+				BC4B8A5F29C10A6D8A88F3F9 /* KMLVectorOverlay.swift */,
 				097DAF0444ABFD1021CA104E /* RasterOverlay.swift */,
 				A05DD82C18EEA904C365C6B4 /* MBTilesOverlay.swift */,
 			);
@@ -2338,12 +2362,12 @@
 			children = (
 				7DAD962E4B0A0A4D228D2467 /* OmniTAKMobileApp.swift */,
 				0E1F2A3B4C5D6E7F80910A0C /* RootTabView.swift */,
-				FE0BF08DA781B87F179C32EF /* OmniTAKMobile/Core/App/DataPackageBootstrap.swift */,
-				2B9E95A9D23FB68454E3A330 /* OmniTAKMobile/Core/App/ToolbarCustomization.swift */,
-				341557E70705872E61DF6310 /* OmniTAKMobile/Core/App/ToolSheetHost.swift */,
-				E5F60718293A4B5C6D7E8F91 /* OmniTAKMobile/Core/App/ToolRegistry.swift */,
-				AD202A5275CE529F7E53F55B /* OmniTAKMobile/Core/App/CustomToolbar.swift */,
-				8CE9342858430C8B11A6138F /* OmniTAKMobile/Core/App/ToolbarAddPalette.swift */,
+				FE0BF08DA781B87F179C32EF /* DataPackageBootstrap.swift */,
+				2B9E95A9D23FB68454E3A330 /* ToolbarCustomization.swift */,
+				341557E70705872E61DF6310 /* ToolSheetHost.swift */,
+				E5F60718293A4B5C6D7E8F91 /* ToolRegistry.swift */,
+				AD202A5275CE529F7E53F55B /* CustomToolbar.swift */,
+				8CE9342858430C8B11A6138F /* ToolbarAddPalette.swift */,
 			);
 			name = App;
 			sourceTree = "<group>";
@@ -2666,6 +2690,7 @@
 				9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */,
 				4DF8129B40825E01D7F5BA79 /* TAKServiceTests.swift in Sources */,
 				F831B10A1D135F2E88925F52 /* PluginSDKTests.swift in Sources */,
+				C5C06A972D151475A44BC316 /* MeshCoreFrameCodecTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2832,8 +2857,8 @@
 				7931902509B5936FBA2B5226 /* ServersView.swift in Sources */,
 				DA38337220E9661125D0036D /* DeepLinkHandler.swift in Sources */,
 				38FCC16B78867B6617B2B329 /* ServerValidator.swift in Sources */,
-				714739C165C288B44EC3A6E8 /* OmniTAKMobile/Features/Meshtastic/Networking/MeshtasticTCPClient.swift in Sources */,
-				2262EE8CA832D8F3763D6EC9 /* OmniTAKMobile/Features/Meshtastic/Views/MeshtasticTCPConnectionView.swift in Sources */,
+				714739C165C288B44EC3A6E8 /* MeshtasticTCPClient.swift in Sources */,
+				2262EE8CA832D8F3763D6EC9 /* MeshtasticTCPConnectionView.swift in Sources */,
 				6DA119F217E6DEA6623A7EB8 /* MeshtasticBLEClient.swift in Sources */,
 				E696090A2C20C65D83CD1F3D /* MeshtasticCoTConverter.swift in Sources */,
 				A7AC00010000000000B00001 /* ATAKPluginParser.swift in Sources */,
@@ -2857,19 +2882,19 @@
 				1C9137217214B1713429C1F8 /* LocalizationManager.swift in Sources */,
 				7BFF2B6B31AB35C047B293DD /* LassoSelectionService.swift in Sources */,
 				FED47954389F0EA4DB422DD7 /* LassoSelectionPill.swift in Sources */,
-				C5B0BD228B239E4E83735254 /* OmniTAKMobile/Features/Drawing/Views/ToolsLauncherSheet.swift in Sources */,
-				48D6F14168132D11BD618DF3 /* OmniTAKMobile/Core/App/DataPackageBootstrap.swift in Sources */,
-				3C81060D2FFBB72033923002 /* OmniTAKMobile/Features/Drawing/Services/LassoExporters.swift in Sources */,
-				273BAFBDAAB79C39F25835BD /* OmniTAKMobile/Features/Drawing/Services/LassoZipWriter.swift in Sources */,
-				74906A9B2523F0EC9F6AFD80 /* OmniTAKMobile/Features/Drawing/Views/LassoContactPickerSheet.swift in Sources */,
-				7FB3B16574296B84A7731FF4 /* OmniTAKMobile/Features/Drawing/Views/LassoShareSheet.swift in Sources */,
-				C34D49043A5E553DDA359F8A /* OmniTAKMobile/Core/App/ToolbarCustomization.swift in Sources */,
-				39BFA71EE7DA696050952ECA /* OmniTAKMobile/Core/App/ToolSheetHost.swift in Sources */,
-				E5F60718293A4B5C6D7E8F90 /* OmniTAKMobile/Core/App/ToolRegistry.swift in Sources */,
-				9B13BA7009C824D9D69DE4E8 /* OmniTAKMobile/Core/App/CustomToolbar.swift in Sources */,
-				42B40E22FFA4AE412996AE66 /* OmniTAKMobile/Core/App/ToolbarAddPalette.swift in Sources */,
-				E955D31B3785A13C9CF3832E /* OmniTAKMobile/Utilities/Integration/KMLVectorOverlay.swift in Sources */,
-				9F4D964068E0E91862AEE361 /* OmniTAKMobile/Features/DataPackages/Views/KMLOverlaysPanel.swift in Sources */,
+				C5B0BD228B239E4E83735254 /* ToolsLauncherSheet.swift in Sources */,
+				48D6F14168132D11BD618DF3 /* DataPackageBootstrap.swift in Sources */,
+				3C81060D2FFBB72033923002 /* LassoExporters.swift in Sources */,
+				273BAFBDAAB79C39F25835BD /* LassoZipWriter.swift in Sources */,
+				74906A9B2523F0EC9F6AFD80 /* LassoContactPickerSheet.swift in Sources */,
+				7FB3B16574296B84A7731FF4 /* LassoShareSheet.swift in Sources */,
+				C34D49043A5E553DDA359F8A /* ToolbarCustomization.swift in Sources */,
+				39BFA71EE7DA696050952ECA /* ToolSheetHost.swift in Sources */,
+				E5F60718293A4B5C6D7E8F90 /* ToolRegistry.swift in Sources */,
+				9B13BA7009C824D9D69DE4E8 /* CustomToolbar.swift in Sources */,
+				42B40E22FFA4AE412996AE66 /* ToolbarAddPalette.swift in Sources */,
+				E955D31B3785A13C9CF3832E /* KMLVectorOverlay.swift in Sources */,
+				9F4D964068E0E91862AEE361 /* KMLOverlaysPanel.swift in Sources */,
 				A9F13CD1E9534A25ECA3B7A9 /* RasterOverlay.swift in Sources */,
 				11BA3FB0A26AA4AE1789CF30 /* MBTilesOverlay.swift in Sources */,
 				699963A931BB1144AA2450EB /* MissionSyncManager.swift in Sources */,
@@ -2887,8 +2912,8 @@
 				009E60B0DFCDE840692E67BA /* GybBLEClient.swift in Sources */,
 				3563F0662BD6434A15A3D821 /* GybManager.swift in Sources */,
 				5D471A897ED1FBD0C5BEB754 /* GybDetectorView.swift in Sources */,
-				A0E27883B3902B6F2FF2FE1C /* OmniTAKMobile/Utilities/Converters/TWD97Converter.swift in Sources */,
-				636B2050F7414B9F51ED24C1 /* OmniTAKMobile/Features/Map/Views/CoordinateEntryView.swift in Sources */,
+				A0E27883B3902B6F2FF2FE1C /* TWD97Converter.swift in Sources */,
+				636B2050F7414B9F51ED24C1 /* CoordinateEntryView.swift in Sources */,
 				617462BB009B1420CCADF5C6 /* ATAKMapChrome.swift in Sources */,
 				A94B9754063A94BA0CF96C37 /* LocationManager.swift in Sources */,
 				F16F23716C9A564FD3B17635 /* TacticalMapView.swift in Sources */,
@@ -2901,6 +2926,13 @@
 				7E069116B694B15B5EFDE612 /* DiagnosticsPlugin.swift in Sources */,
 				BD5ED2F273C06C32FB3CAA0E /* ADSBPlugin.swift in Sources */,
 				42DCF526B899E93E4340934B /* ADSBStatusOverlay.swift in Sources */,
+				455571E4BBCEB4E0EA1AF5B1 /* MeshFramework.swift in Sources */,
+				2303D0E5E3509EE704208121 /* Meshtastic+MeshProtocols.swift in Sources */,
+				65F8AEA3C407443E418A537F /* MeshCoreFrameCodec.swift in Sources */,
+				49375D54457B411F0CC0E2D5 /* MeshCoreCoTConverter.swift in Sources */,
+				46C4106B90CE63B9AFEE077F /* MeshCoreBLETransport.swift in Sources */,
+				8392967F239957719274C288 /* MeshCoreManager.swift in Sources */,
+				9A446C624ADE62417F064DE4 /* MeshFrameworkDevicePickerView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3167,7 +3199,7 @@
 					"$(PROJECT_DIR)/OmniTAKMobile/ThirdParty/Unishox2",
 				);
 				INFOPLIST_FILE = OmniTAKMobile/Resources/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "OmniTAK";
+				INFOPLIST_KEY_CFBundleDisplayName = OmniTAK;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "OmniTAK uses Bluetooth to connect to Meshtastic LoRa devices for off-grid mesh networking and TAK communications, and to detect nearby drones broadcasting FAA Remote ID.";
@@ -3220,7 +3252,7 @@
 					"$(PROJECT_DIR)/OmniTAKMobile/ThirdParty/Unishox2",
 				);
 				INFOPLIST_FILE = OmniTAKMobile/Resources/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "OmniTAK";
+				INFOPLIST_KEY_CFBundleDisplayName = OmniTAK;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "OmniTAK uses Bluetooth to connect to Meshtastic LoRa devices for off-grid mesh networking and TAK communications, and to detect nearby drones broadcasting FAA Remote ID.";

--- a/OmniTAKMobile/Core/App/OmniTAKMobileApp.swift
+++ b/OmniTAKMobile/Core/App/OmniTAKMobileApp.swift
@@ -112,6 +112,14 @@ struct OmniTAKMobileApp: App {
                         }
                 }
             }
+            // Deep-link config-profile confirmation: mirrors the scanner path so
+            // the user reviews settings before they are applied.
+            .sheet(item: $deepLinkHandler.pendingDeepLinkProfile) { profile in
+                ProfileImportPreviewView(profile: profile) { confirmed in
+                    deepLinkHandler.confirmPendingProfile(profile, confirmed: confirmed)
+                }
+                .environmentObject(LocalizationManager.shared)
+            }
             .onOpenURL { url in
                 // KML/KMZ opened from Files / Mail / AirDrop / "Open with
                 // OmniTAK" → import through the robust vector overlay path.

--- a/OmniTAKMobile/Core/App/OmniTAKMobileApp.swift
+++ b/OmniTAKMobile/Core/App/OmniTAKMobileApp.swift
@@ -24,7 +24,12 @@ struct OmniTAKMobileApp: App {
         // into TAKService at launch. Without this, mesh nodes would only
         // appear on the map after a Meshtastic view is opened.
         _ = MeshtasticManager.shared
-        Logger.meshtastic.info("MeshtasticManager + CoT bridge initialized at launch")
+        // MeshCore is the second mesh framework (companion BLE). Eagerly create
+        // its manager too so its CoT bridge is wired regardless of which
+        // framework the operator has selected; the active framework is chosen
+        // via @AppStorage("selectedMeshFramework").
+        if #available(iOS 13.0, *) { _ = MeshCoreManager.shared }
+        Logger.meshtastic.info("Meshtastic + MeshCore managers initialized at launch")
 
         // Wire the FAA Remote ID scanner. The actual on/off state is
         // pulled from UserDefaults below via `.task` so the @AppStorage

--- a/OmniTAKMobile/Features/Chat/Managers/ChatManager.swift
+++ b/OmniTAKMobile/Features/Chat/Managers/ChatManager.swift
@@ -160,13 +160,13 @@ class ChatManager: ObservableObject {
         }
 
         // --- Mesh off-grid GeoChat ---
-        // Mirror the text message over the active Meshtastic radio so peers
-        // with no server can see the chat.  MeshtasticManager is @MainActor.
+        // Mirror the text message over the active mesh radio so peers with no
+        // server can see the chat. Route via the active framework
+        // (selectedMeshFramework key) — Meshtastic or MeshCore.
         let meshText = text
         let meshCallsign = currentUserCallsign
         let meshLocation = locationManager?.location
         Task { @MainActor in
-            guard MeshtasticManager.shared.isConnected else { return }
             let point = CoTPoint(
                 lat: meshLocation?.coordinate.latitude ?? 0.0,
                 lon: meshLocation?.coordinate.longitude ?? 0.0,
@@ -192,7 +192,14 @@ class ChatManager: ObservableObject {
                 point: point,
                 detail: detail
             )
-            MeshtasticManager.shared.sendCoTOverMesh(event)
+            let frameworkKey = UserDefaults.standard.string(forKey: MeshFramework.storageKey) ?? ""
+            if #available(iOS 13.0, *),
+               frameworkKey == MeshFramework.meshcore.rawValue,
+               MeshCoreManager.shared.isConnected {
+                MeshCoreManager.shared.sendCoTOverMesh(event)
+            } else if MeshtasticManager.shared.isConnected {
+                MeshtasticManager.shared.sendCoTOverMesh(event)
+            }
             #if DEBUG
             print("📡 Mesh GeoChat: sent '\(meshText)' from \(meshCallsign) over mesh")
             #endif
@@ -271,7 +278,6 @@ class ChatManager: ObservableObject {
             let meshCallsign = currentUserCallsign
             let meshLocation = locationManager?.location
             Task { @MainActor in
-                guard MeshtasticManager.shared.isConnected else { return }
                 let point = CoTPoint(
                     lat: meshLocation?.coordinate.latitude ?? 0.0,
                     lon: meshLocation?.coordinate.longitude ?? 0.0,
@@ -297,7 +303,14 @@ class ChatManager: ObservableObject {
                     point: point,
                     detail: detail
                 )
-                MeshtasticManager.shared.sendCoTOverMesh(event)
+                let frameworkKey = UserDefaults.standard.string(forKey: MeshFramework.storageKey) ?? ""
+                if #available(iOS 13.0, *),
+                   frameworkKey == MeshFramework.meshcore.rawValue,
+                   MeshCoreManager.shared.isConnected {
+                    MeshCoreManager.shared.sendCoTOverMesh(event)
+                } else if MeshtasticManager.shared.isConnected {
+                    MeshtasticManager.shared.sendCoTOverMesh(event)
+                }
                 #if DEBUG
                 print("📡 Mesh GeoChat (image msg text): sent '\(meshText)' over mesh")
                 #endif

--- a/OmniTAKMobile/Features/Mesh/Protocols/MeshFramework.swift
+++ b/OmniTAKMobile/Features/Mesh/Protocols/MeshFramework.swift
@@ -1,0 +1,107 @@
+//
+//  MeshFramework.swift
+//  OmniTAK Mobile
+//
+//  Framework-neutral mesh abstractions. OmniTAK supports two mesh radio
+//  families that both bridge to CoT: Meshtastic (protobuf streaming) and
+//  MeshCore (companion BLE protocol). The app picks the active framework via
+//  @AppStorage("selectedMeshFramework"); the rest of the app talks to whichever
+//  manager conforms to `MeshManager`.
+//
+//  These protocols are deliberately thin and match the public surface the
+//  existing MeshtasticManager / Meshtastic clients already expose, so adopting
+//  them does NOT change Meshtastic behavior — it just names the seam.
+//
+
+import Foundation
+import Combine
+import CoreBluetooth
+
+// MARK: - Mesh Framework Selection
+
+/// Which mesh radio family the operator has selected. Persisted via
+/// `@AppStorage("selectedMeshFramework")` using `rawValue`.
+public enum MeshFramework: String, CaseIterable, Identifiable, Codable {
+    case meshtastic
+    case meshcore
+
+    public var id: String { rawValue }
+
+    /// UserDefaults / @AppStorage key shared across the app.
+    public static let storageKey = "selectedMeshFramework"
+
+    public var displayName: String {
+        switch self {
+        case .meshtastic: return "Meshtastic"
+        case .meshcore:   return "MeshCore"
+        }
+    }
+
+    public var iconName: String {
+        switch self {
+        case .meshtastic: return "antenna.radiowaves.left.and.right"
+        case .meshcore:   return "dot.radiowaves.left.and.right"
+        }
+    }
+}
+
+// MARK: - Mesh Transport
+
+/// A byte-level link to a mesh radio (BLE or TCP). Conformed by the Meshtastic
+/// BLE/TCP clients and by `MeshCoreBLETransport`.
+///
+/// The Meshtastic clients already publish these via `@Published` on
+/// `ObservableObject`; the protocol simply records that contract. Transports
+/// own framing/parsing internally and surface decoded nodes through `nodes`.
+@available(iOS 13.0, *)
+protocol MeshTransport: AnyObject {
+    /// True once the link is up and ready for I/O.
+    var isConnected: Bool { get }
+
+    /// Decoded node table keyed by a framework-local node id.
+    var nodes: [UInt32: MeshNode] { get }
+
+    /// This radio's own node number (0 until known).
+    var myNodeNum: UInt32 { get }
+
+    /// Tear the link down.
+    func disconnect()
+}
+
+// MARK: - Mesh Manager
+
+/// The app-facing manager for a mesh framework — owns its transport(s), exposes
+/// an observable node list and connection state, bridges inbound traffic to CoT,
+/// and can push OmniTAK's self-position / GeoChat back onto the mesh.
+///
+/// `MeshtasticManager` already implements this surface; `MeshCoreManager`
+/// mirrors it. Both are `@MainActor ObservableObject` singletons so SwiftUI
+/// views can `@ObservedObject` them directly.
+@MainActor
+protocol MeshManager: ObservableObject {
+    /// Which framework this manager drives.
+    var framework: MeshFramework { get }
+
+    /// True when a radio is connected.
+    var isConnected: Bool { get }
+
+    /// Human-readable connection state ("Disconnected", "Connecting…", …).
+    var connectionState: String { get }
+
+    /// This radio's own node number (0 until known).
+    var myNodeNum: UInt32 { get }
+
+    /// All known mesh nodes (with or without positions).
+    var meshNodes: [MeshNode] { get }
+
+    /// Disconnect from the current radio.
+    func disconnect()
+
+    /// Push every known node with a position onto the TAK map.
+    func publishMeshNodesToMap()
+
+    /// Bridge a CoT event out over the mesh (PLI / GeoChat). Returns true if the
+    /// payload was dispatched to the radio.
+    @discardableResult
+    func sendCoTOverMesh(_ event: CoTEvent, channelIndex: UInt32) -> Bool
+}

--- a/OmniTAKMobile/Features/Mesh/Protocols/Meshtastic+MeshProtocols.swift
+++ b/OmniTAKMobile/Features/Mesh/Protocols/Meshtastic+MeshProtocols.swift
@@ -1,0 +1,36 @@
+//
+//  Meshtastic+MeshProtocols.swift
+//  OmniTAK Mobile
+//
+//  Conform the existing Meshtastic types to the framework-neutral mesh
+//  protocols WITHOUT touching their implementations. Meshtastic already exposes
+//  every member these protocols require, so these are pure retroactive
+//  conformances — Meshtastic behavior is unchanged.
+//
+
+import Foundation
+import CoreBluetooth
+
+// MARK: - MeshManager
+
+@available(iOS 13.0, *)
+extension MeshtasticManager: MeshManager {
+    /// Meshtastic is the framework this manager drives.
+    public var framework: MeshFramework { .meshtastic }
+    // isConnected, connectionState, myNodeNum, meshNodes, disconnect(),
+    // publishMeshNodesToMap(), sendCoTOverMesh(_:channelIndex:) are all already
+    // declared on MeshtasticManager.
+}
+
+// MARK: - MeshTransport
+
+@available(iOS 13.0, *)
+extension MeshtasticBLEClient: MeshTransport {
+    // isConnected, nodes, myNodeNum, disconnect() already exist.
+}
+
+@available(iOS 13.0, *)
+extension MeshtasticTCPClient: MeshTransport {
+    // MeshtasticTCPClient exposes isConnected, nodes, myNodeNum and disconnect()
+    // already; this conformance just names the seam.
+}

--- a/OmniTAKMobile/Features/MeshCore/Managers/MeshCoreManager.swift
+++ b/OmniTAKMobile/Features/MeshCore/Managers/MeshCoreManager.swift
@@ -187,6 +187,11 @@ public final class MeshCoreManager: ObservableObject, MeshManager {
         case .battery(_, let percent):
             if percent >= 0 { batteryPercent = percent }
 
+        case .deviceInfo(let info):
+            #if DEBUG
+            print("MeshCore: device hw=\(info.hwModel) rev=\(info.hwRevision) fw='\(info.firmwareVersion)'")
+            #endif
+
         case .messagesWaiting:
             if #available(iOS 13.0, *) { transport.send(MeshCoreFrameCodec.encodeGetNextMessage()) }
 
@@ -201,19 +206,23 @@ public final class MeshCoreManager: ObservableObject, MeshManager {
         let nodeId = MeshCoreFrameCodec.nodeId(fromPubKeyHex: contact.pubKeyHex)
         guard nodeId != 0 else { return }
         // Don't plot our own advert as a separate contact.
+        // Use the 6-byte (12-hex-char) prefix — the firmware keys contacts on
+        // the 6-byte prefix, so a 4-byte check would over-match short-prefix collisions.
         if !selfPubKeyHex.isEmpty,
            contact.pubKeyHex.lowercased().hasPrefix(String(selfPubKeyHex.prefix(12)).lowercased()) {
             return
         }
         contactsByNodeId[nodeId] = contact
 
+        // Build a stable short name from the 6-byte (12-hex-char) prefix.
+        let keyPrefix12 = String(contact.pubKeyHex.prefix(12)).uppercased()
         let position: MeshPosition? = contact.hasValidPosition
             ? MeshPosition(latitude: contact.latitude, longitude: contact.longitude, altitude: nil)
             : nil
         let node = MeshNode(
             id: nodeId,
-            shortName: String(contact.pubKeyHex.prefix(8)).uppercased(),
-            longName: contact.name.isEmpty ? "MeshCore \(String(contact.pubKeyHex.prefix(8)))" : contact.name,
+            shortName: keyPrefix12,
+            longName: contact.name.isEmpty ? "MeshCore \(keyPrefix12)" : contact.name,
             position: position,
             lastHeard: Date(),
             snr: nil,
@@ -243,8 +252,8 @@ public final class MeshCoreManager: ObservableObject, MeshManager {
         let known = contactsByNodeId.values.first {
             $0.pubKeyHex.lowercased().hasPrefix(senderPrefix)
         }
-        let senderUID = "MESHCORE-\(String((known?.pubKeyHex ?? msg.senderPubKeyPrefixHex).prefix(8)))"
-        let callsign = known?.name ?? "MeshCore \(msg.senderPubKeyPrefixHex.prefix(8))"
+        let senderUID = "MESHCORE-\(String((known?.pubKeyHex ?? msg.senderPubKeyPrefixHex).prefix(12)).uppercased())"
+        let callsign = known?.name ?? "MeshCore \(msg.senderPubKeyPrefixHex.prefix(12).uppercased())"
 
         let chat = ChatMessage(
             id: UUID().uuidString,

--- a/OmniTAKMobile/Features/MeshCore/Managers/MeshCoreManager.swift
+++ b/OmniTAKMobile/Features/MeshCore/Managers/MeshCoreManager.swift
@@ -286,7 +286,7 @@ public final class MeshCoreManager: ObservableObject, MeshManager {
     ///   - b-t-f (GeoChat)          -> SEND_TXT_MSG to every known contact
     /// Returns true if at least one frame was dispatched.
     @discardableResult
-    public func sendCoTOverMesh(_ event: CoTEvent, channelIndex: UInt32 = 0) -> Bool {
+    func sendCoTOverMesh(_ event: CoTEvent, channelIndex: UInt32 = 0) -> Bool {
         guard isConnected, #available(iOS 13.0, *) else {
             lastError = "Not connected"
             return false

--- a/OmniTAKMobile/Features/MeshCore/Managers/MeshCoreManager.swift
+++ b/OmniTAKMobile/Features/MeshCore/Managers/MeshCoreManager.swift
@@ -1,0 +1,358 @@
+//
+//  MeshCoreManager.swift
+//  OmniTAK Mobile
+//
+//  App-facing manager for the MeshCore mesh framework. Owns a
+//  MeshCoreBLETransport, runs the companion handshake (APP_START), polls the
+//  radio for queued frames (GET_NEXT_MSG), keeps a node table, and bridges:
+//    - inbound contacts' advertised positions  -> CoT PLI (UID MESHCORE-<key8>)
+//    - inbound native text DMs                 -> GeoChat (ChatManager)
+//    - OmniTAK self-position                   -> SET_ADVERT_LATLON + SEND_SELF_ADVERT
+//    - outbound GeoChat                        -> SEND_TXT_MSG to known contacts
+//
+//  Mirrors MeshtasticManager's public surface and conforms to MeshManager so the
+//  app can treat either framework uniformly.
+//
+
+import Foundation
+import Combine
+import SwiftUI
+import CoreBluetooth
+import CoreLocation
+
+@available(iOS 13.0, *)
+@MainActor
+public final class MeshCoreManager: ObservableObject, MeshManager {
+
+    // MARK: Singleton
+
+    public static let shared = MeshCoreManager()
+
+    // MARK: MeshManager / published state
+
+    public var framework: MeshFramework { .meshcore }
+
+    @Published public private(set) var isConnected: Bool = false
+    @Published public private(set) var connectionState: String = "Disconnected"
+    @Published public private(set) var myNodeNum: UInt32 = 0
+    @Published public private(set) var meshNodes: [MeshNode] = []
+    @Published public private(set) var lastError: String?
+    /// Latest battery reading for the connected radio (-1 = unknown).
+    @Published public private(set) var batteryPercent: Int = -1
+
+    /// The connected radio's own public key hex (empty until SELF_INFO arrives).
+    public private(set) var selfPubKeyHex: String = ""
+
+    // MARK: Transport (lazily created so CBCentralManager isn't spun up at launch)
+
+    private var _transport: Any?
+
+    @available(iOS 13.0, *)
+    var transport: MeshCoreBLETransport {
+        if _transport == nil {
+            let t = MeshCoreBLETransport()
+            wire(t)
+            _transport = t
+        }
+        return _transport as! MeshCoreBLETransport
+    }
+
+    /// Surface the transport for the device-picker UI (scan/connect/known list).
+    @available(iOS 13.0, *)
+    var bleTransport: MeshCoreBLETransport { transport }
+
+    private var cancellables = Set<AnyCancellable>()
+    private var pollTimer: Timer?
+
+    /// Full decoded contact keyed by derived node id — carries the pubkey the
+    /// MeshNode model can't, so PLIs get the right MESHCORE-<key8> UID and DMs
+    /// can be addressed by pubkey.
+    private var contactsByNodeId: [UInt32: MeshCoreContact] = [:]
+
+    private init() {}
+
+    // MARK: Transport wiring
+
+    @available(iOS 13.0, *)
+    private func wire(_ t: MeshCoreBLETransport) {
+        t.$isConnected
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] connected in
+                self?.isConnected = connected
+                if !connected { self?.handleDisconnected() }
+            }
+            .store(in: &cancellables)
+
+        t.$connectionState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in self?.connectionState = state.rawValue }
+            .store(in: &cancellables)
+
+        t.$lastError
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] err in if let err = err { self?.lastError = err } }
+            .store(in: &cancellables)
+
+        t.onReady = { [weak self] in self?.handleReady() }
+        t.onFrame = { [weak self] frame in self?.handleFrame(frame) }
+        t.onDisconnect = { [weak self] in self?.handleDisconnected() }
+    }
+
+    // MARK: Connection control (used by the picker UI)
+
+    @available(iOS 13.0, *)
+    func startBLEScanning() { lastError = nil; transport.startScanning() }
+
+    @available(iOS 13.0, *)
+    func stopBLEScanning() { transport.stopScanning() }
+
+    @available(iOS 13.0, *)
+    func refreshKnownBLEDevices() { transport.refreshKnownDevices() }
+
+    @available(iOS 13.0, *)
+    func reconnectLastBLEDevice() { transport.reconnectLastDevice() }
+
+    @available(iOS 13.0, *)
+    func forgetBLEDevice(id: UUID) { transport.forgetDevice(id: id) }
+
+    @available(iOS 13.0, *)
+    func connectBLE(device: DiscoveredBLEDevice) {
+        lastError = nil
+        transport.connect(to: device)
+    }
+
+    public func disconnect() {
+        if #available(iOS 13.0, *) { transport.disconnect() }
+        stopPolling()
+        handleDisconnected()
+    }
+
+    private func handleDisconnected() {
+        stopPolling()
+        isConnected = false
+        connectionState = "Disconnected"
+        myNodeNum = 0
+        batteryPercent = -1
+        meshNodes.removeAll()
+        contactsByNodeId.removeAll()
+    }
+
+    // MARK: Handshake + polling
+
+    private func handleReady() {
+        guard #available(iOS 13.0, *) else { return }
+        let t = transport
+        // APP_START → radio replies SELF_INFO; then identify + battery + first drain.
+        t.send(MeshCoreFrameCodec.encodeAppStart())
+        t.send(MeshCoreFrameCodec.encodeDeviceQuery())
+        t.send(MeshCoreFrameCodec.encodeGetBattery())
+        t.send(MeshCoreFrameCodec.encodeGetNextMessage())
+        startPolling()
+    }
+
+    private func startPolling() {
+        stopPolling()
+        // Drain queued frames every 2.5 s — same cadence as the ATAK plugin.
+        pollTimer = Timer.scheduledTimer(withTimeInterval: 2.5, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self = self, self.isConnected, #available(iOS 13.0, *) else { return }
+                self.transport.send(MeshCoreFrameCodec.encodeGetNextMessage())
+            }
+        }
+    }
+
+    private func stopPolling() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+
+    // MARK: Inbound frame routing
+
+    private func handleFrame(_ frame: Data) {
+        guard let response = MeshCoreFrameCodec.decode(frame) else { return }
+        switch response {
+        case .selfInfo(let info):
+            selfPubKeyHex = info.pubKeyHex
+            myNodeNum = MeshCoreFrameCodec.nodeId(fromPubKeyHex: info.pubKeyHex)
+
+        case .contact(let contact):
+            ingest(contact: contact)
+            // Some firmware emits an advert then expects a follow-up drain.
+            if #available(iOS 13.0, *) { transport.send(MeshCoreFrameCodec.encodeGetNextMessage()) }
+
+        case .textMessage(let msg):
+            routeInboundText(msg)
+            if #available(iOS 13.0, *) { transport.send(MeshCoreFrameCodec.encodeGetNextMessage()) }
+
+        case .battery(_, let percent):
+            if percent >= 0 { batteryPercent = percent }
+
+        case .messagesWaiting:
+            if #available(iOS 13.0, *) { transport.send(MeshCoreFrameCodec.encodeGetNextMessage()) }
+
+        case .noMoreMessages, .other:
+            break
+        }
+    }
+
+    /// Record a contact in the node table and, if it carries a valid position,
+    /// publish it to the map as a CoT PLI immediately.
+    private func ingest(contact: MeshCoreContact) {
+        let nodeId = MeshCoreFrameCodec.nodeId(fromPubKeyHex: contact.pubKeyHex)
+        guard nodeId != 0 else { return }
+        // Don't plot our own advert as a separate contact.
+        if !selfPubKeyHex.isEmpty,
+           contact.pubKeyHex.lowercased().hasPrefix(String(selfPubKeyHex.prefix(12)).lowercased()) {
+            return
+        }
+        contactsByNodeId[nodeId] = contact
+
+        let position: MeshPosition? = contact.hasValidPosition
+            ? MeshPosition(latitude: contact.latitude, longitude: contact.longitude, altitude: nil)
+            : nil
+        let node = MeshNode(
+            id: nodeId,
+            shortName: String(contact.pubKeyHex.prefix(8)).uppercased(),
+            longName: contact.name.isEmpty ? "MeshCore \(String(contact.pubKeyHex.prefix(8)))" : contact.name,
+            position: position,
+            lastHeard: Date(),
+            snr: nil,
+            hopDistance: nil,
+            batteryLevel: nil
+        )
+        if let idx = meshNodes.firstIndex(where: { $0.id == nodeId }) {
+            meshNodes[idx] = node
+        } else {
+            meshNodes.append(node)
+        }
+
+        if let event = MeshCoreCoTConverter.toCoTEvent(contact: contact) {
+            CoTEventHandler.shared.handle(event: .positionUpdate(event))
+        }
+    }
+
+    /// Route an inbound native text DM into TAK GeoChat, keyed by the sender's
+    /// pubkey prefix so it lands in the All Chat room like any GeoChat message.
+    private func routeInboundText(_ msg: MeshCoreTextMessage) {
+        let trimmed = msg.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        // Resolve a friendly callsign from a known contact whose pubkey starts
+        // with the reported sender prefix; fall back to the prefix itself.
+        let senderPrefix = msg.senderPubKeyPrefixHex.lowercased()
+        let known = contactsByNodeId.values.first {
+            $0.pubKeyHex.lowercased().hasPrefix(senderPrefix)
+        }
+        let senderUID = "MESHCORE-\(String((known?.pubKeyHex ?? msg.senderPubKeyPrefixHex).prefix(8)))"
+        let callsign = known?.name ?? "MeshCore \(msg.senderPubKeyPrefixHex.prefix(8))"
+
+        let chat = ChatMessage(
+            id: UUID().uuidString,
+            conversationId: ChatRoom.allUsersId,
+            senderId: senderUID,
+            senderCallsign: callsign,
+            recipientId: nil,
+            recipientCallsign: nil,
+            messageText: trimmed,
+            timestamp: Date(),
+            status: .delivered,
+            type: .geochat,
+            isFromSelf: false
+        )
+        CoTEventHandler.shared.handle(event: .chatMessage(chat))
+    }
+
+    // MARK: TAK map publishing
+
+    public func publishMeshNodesToMap() {
+        for contact in contactsByNodeId.values {
+            if let event = MeshCoreCoTConverter.toCoTEvent(contact: contact) {
+                CoTEventHandler.shared.handle(event: .positionUpdate(event))
+            }
+        }
+    }
+
+    /// Remove all MeshCore markers from the map.
+    public func clearMeshMarkersFromMap() {
+        for contact in contactsByNodeId.values {
+            CoTEventHandler.shared.removeEvent(uid: MeshCoreCoTConverter.uid(forPubKeyHex: contact.pubKeyHex))
+        }
+    }
+
+    // MARK: Outbound (CoT -> mesh)
+
+    /// Bridge a CoT event onto the MeshCore mesh.
+    ///   - a-*  (PLI/self position) -> SET_ADVERT_LATLON + SEND_SELF_ADVERT
+    ///   - b-t-f (GeoChat)          -> SEND_TXT_MSG to every known contact
+    /// Returns true if at least one frame was dispatched.
+    @discardableResult
+    public func sendCoTOverMesh(_ event: CoTEvent, channelIndex: UInt32 = 0) -> Bool {
+        guard isConnected, #available(iOS 13.0, *) else {
+            lastError = "Not connected"
+            return false
+        }
+        if event.type.hasPrefix("a-") {
+            return broadcastSelfPosition(latitude: event.point.lat,
+                                         longitude: event.point.lon,
+                                         altitudeMeters: event.point.hae)
+        }
+        if event.type == "b-t-f" {
+            let text = event.detail.remarks ?? ""
+            return sendGeoChat(text)
+        }
+        return false
+    }
+
+    /// Push OmniTAK's self-position to the radio's advert (lat/lon) and rebroadcast.
+    @available(iOS 13.0, *)
+    @discardableResult
+    func broadcastSelfPosition(latitude: Double, longitude: Double, altitudeMeters: Double = 0) -> Bool {
+        guard isConnected,
+              let latlon = MeshCoreFrameCodec.encodeSetAdvertLatLon(
+                  latitude: latitude, longitude: longitude, altitudeMeters: altitudeMeters) else {
+            return false
+        }
+        transport.send(latlon)
+        transport.send(MeshCoreFrameCodec.encodeSendSelfAdvert())
+        return true
+    }
+
+    /// Convenience: push the device's current location as a self-advert.
+    @available(iOS 13.0, *)
+    @discardableResult
+    func broadcastCurrentLocation() -> Bool {
+        guard let loc = LocationManager.shared.location else { return false }
+        return broadcastSelfPosition(latitude: loc.coordinate.latitude,
+                                     longitude: loc.coordinate.longitude,
+                                     altitudeMeters: loc.altitude)
+    }
+
+    /// Send a GeoChat line out as native MeshCore DMs to every known contact.
+    /// MeshCore's companion text path is pubkey-to-pubkey; there is no true
+    /// broadcast-text command in this v1 scope, so we fan out to known contacts.
+    /// Returns true if at least one DM was queued.
+    @available(iOS 13.0, *)
+    @discardableResult
+    func sendGeoChat(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isConnected, !trimmed.isEmpty else { return false }
+        var sentAny = false
+        for contact in contactsByNodeId.values {
+            if let frame = MeshCoreFrameCodec.encodeSendTextMessage(pubKeyHex: contact.pubKeyHex, text: trimmed) {
+                transport.send(frame)
+                sentAny = true
+            }
+        }
+        return sentAny
+    }
+
+    // MARK: Status helpers
+
+    public var connectionStatus: String {
+        isConnected ? "Connected" : "Not Connected"
+    }
+
+    public var nodesWithPositions: [MeshNode] {
+        meshNodes.filter { $0.position != nil }
+    }
+}

--- a/OmniTAKMobile/Features/MeshCore/Networking/MeshCoreBLETransport.swift
+++ b/OmniTAKMobile/Features/MeshCore/Networking/MeshCoreBLETransport.swift
@@ -206,9 +206,18 @@ final class MeshCoreBLETransport: NSObject, ObservableObject, MeshTransport {
             rx.properties.contains(.writeWithoutResponse) ? .withoutResponse : .withResponse
         peripheral.writeValue(frame, for: rx, type: writeType)
         if writeType == .withoutResponse {
-            // No write callback for WWR — release the in-flight latch and keep draining.
+            // WWR: pace via peripheralIsReady(toSendWriteWithoutResponse:) so the
+            // radio's UART buffer isn't overrun under burst writes.  Release the
+            // in-flight latch now only when the peripheral reports it's ready;
+            // if canSendWriteWithoutResponse is already true we drain immediately
+            // (avoids deadlock on the very first frame).
             writeInFlight = false
-            if !writeQueue.isEmpty { drainWriteQueue() }
+            if !writeQueue.isEmpty {
+                if peripheral.canSendWriteWithoutResponse {
+                    drainWriteQueue()
+                }
+                // else: peripheralIsReady(toSendWriteWithoutResponse:) will call drainWriteQueue()
+            }
         }
     }
 
@@ -439,6 +448,12 @@ extension MeshCoreBLETransport: CBPeripheralDelegate {
         }
         // Write-with-response completed — release the latch and send the next.
         writeInFlight = false
+        drainWriteQueue()
+    }
+
+    /// Called by CoreBluetooth when a WWR peripheral's TX buffer has space again.
+    /// Resume draining the write queue now that the radio is ready.
+    func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
         drainWriteQueue()
     }
 }

--- a/OmniTAKMobile/Features/MeshCore/Networking/MeshCoreBLETransport.swift
+++ b/OmniTAKMobile/Features/MeshCore/Networking/MeshCoreBLETransport.swift
@@ -1,0 +1,444 @@
+//
+//  MeshCoreBLETransport.swift
+//  OmniTAK Mobile
+//
+//  CoreBluetooth link to a MeshCore *companion* radio over the Nordic UART
+//  service. Scans for the NUS service, connects (iOS handles passkey pairing —
+//  the 6-digit code is shown on the node's OLED, or 123456 on screenless
+//  builds), discovers the RX (write) / TX (notify) characteristics, subscribes
+//  to TX notifications, and writes command frames to RX.
+//
+//  Framing is delegated to MeshCoreFrameCodec; this class is the byte pipe plus
+//  a small write queue (the radio expects one outstanding write at a time, like
+//  the ATAK plugin's drainWriteQueue). Decoded-frame routing and the companion
+//  state machine live in MeshCoreManager.
+//
+//  Pattern intentionally mirrors MeshtasticBLEClient so the two transports read
+//  the same and share the app's BLE conventions.
+//
+
+import Foundation
+import CoreBluetooth
+import Combine
+
+// MARK: - MeshCore BLE UUIDs
+
+enum MeshCoreBLEUUID {
+    /// Nordic UART service advertised by MeshCore companion firmware.
+    static let service  = CBUUID(string: "6E400001-B5A3-F393-E0A9-E50E24DCCA9E")
+    /// RX characteristic — the app WRITES command frames here.
+    static let rx       = CBUUID(string: "6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
+    /// TX characteristic — the app receives response frames via NOTIFY here.
+    static let tx       = CBUUID(string: "6E400003-B5A3-F393-E0A9-E50E24DCCA9E")
+
+    /// Firmware BLE name prefix (BLE_NAME_PREFIX). Used only as a soft hint —
+    /// the service UUID is the authoritative filter.
+    static let namePrefix = "MeshCore-"
+    /// Default BLE PIN on screenless builds (firmware BLE_PIN_CODE).
+    static let defaultPairingPin = 123456
+}
+
+// MARK: - MeshCoreBLETransport
+
+@available(iOS 13.0, *)
+final class MeshCoreBLETransport: NSObject, ObservableObject, MeshTransport {
+
+    enum ConnectionState: String {
+        case disconnected = "Disconnected"
+        case scanning     = "Scanning..."
+        case connecting   = "Connecting..."
+        case discovering  = "Discovering Services..."
+        case connected    = "Connected"
+        case failed       = "Connection Failed"
+    }
+
+    // MARK: Published state
+
+    @Published var isScanning: Bool = false
+    @Published var isConnected: Bool = false
+    @Published var connectionState: ConnectionState = .disconnected
+    @Published var bluetoothState: CBManagerState = .unknown
+    @Published var discoveredDevices: [DiscoveredBLEDevice] = []
+    @Published var knownDevices: [DiscoveredBLEDevice] = []
+    @Published var needsBluetoothRepair: Bool = false
+    @Published var connectedPeripheral: CBPeripheral?
+    @Published var lastError: String?
+
+    /// MeshTransport requirements (companion path: node table + own node id are
+    /// owned by MeshCoreManager, so the transport leaves these empty/zero).
+    @Published var nodes: [UInt32: MeshNode] = [:]
+    var myNodeNum: UInt32 = 0
+
+    // MARK: Callbacks (wired by MeshCoreManager)
+
+    /// Fired (on main) with each decoded response frame from the radio.
+    var onFrame: ((Data) -> Void)?
+    /// Fired (on main) right after the TX notify subscription is live — the
+    /// manager kicks off the APP_START handshake here.
+    var onReady: (() -> Void)?
+    /// Fired (on main) when the link drops.
+    var onDisconnect: (() -> Void)?
+
+    // MARK: Private
+
+    private var centralManager: CBCentralManager!
+    private var rxCharacteristic: CBCharacteristic?
+    private var txCharacteristic: CBCharacteristic?
+    private var pendingPeripheral: CBPeripheral?
+    private var isShuttingDown = false
+    private var userDidDisconnect = false
+
+    private let knownDevicesKey = "meshcore_known_ble_devices"
+
+    /// One-write-at-a-time queue (the radio drops overlapping writes).
+    private var writeQueue: [Data] = []
+    private var writeInFlight = false
+
+    override init() {
+        super.init()
+        centralManager = CBCentralManager(delegate: self, queue: .main)
+    }
+
+    deinit {
+        isShuttingDown = true
+    }
+
+    // MARK: Scanning
+
+    func startScanning() {
+        guard centralManager.state == .poweredOn else {
+            DispatchQueue.main.async { self.lastError = "Bluetooth is not available" }
+            return
+        }
+        DispatchQueue.main.async {
+            self.discoveredDevices.removeAll()
+            self.isScanning = true
+            self.connectionState = .scanning
+        }
+        // Filter strictly on the Nordic UART service — the authoritative
+        // MeshCore-companion signal. A Meshtastic Heltec won't match.
+        centralManager.scanForPeripherals(
+            withServices: [MeshCoreBLEUUID.service],
+            options: [CBCentralManagerScanOptionAllowDuplicatesKey: false]
+        )
+        print("MeshCore: started scanning (Nordic UART service)")
+    }
+
+    func stopScanning() {
+        centralManager.stopScan()
+        DispatchQueue.main.async {
+            self.isScanning = false
+            if !self.isConnected { self.connectionState = .disconnected }
+        }
+    }
+
+    // MARK: Connection
+
+    func connect(to device: DiscoveredBLEDevice) {
+        stopScanning()
+        userDidDisconnect = false
+        pendingPeripheral = device.peripheral
+        DispatchQueue.main.async {
+            self.needsBluetoothRepair = false
+            self.connectionState = .connecting
+            self.lastError = nil
+        }
+        centralManager.connect(device.peripheral, options: nil)
+        print("MeshCore: connecting to \(device.name)…")
+    }
+
+    func connect(peripheral: CBPeripheral) {
+        stopScanning()
+        pendingPeripheral = peripheral
+        DispatchQueue.main.async {
+            self.connectionState = .connecting
+            self.lastError = nil
+        }
+        centralManager.connect(peripheral, options: nil)
+    }
+
+    func disconnect() {
+        guard !isShuttingDown else { return }
+        userDidDisconnect = true
+        clearWriteQueue()
+        if let p = connectedPeripheral {
+            centralManager.cancelPeripheralConnection(p)
+        } else if let p = pendingPeripheral {
+            centralManager.cancelPeripheralConnection(p)
+        }
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, !self.isShuttingDown else { return }
+            self.isConnected = false
+            self.connectionState = .disconnected
+            self.connectedPeripheral = nil
+            self.rxCharacteristic = nil
+            self.txCharacteristic = nil
+        }
+        pendingPeripheral = nil
+        print("MeshCore: disconnected")
+    }
+
+    // MARK: Writing
+
+    /// Queue a command frame for the RX characteristic. Frames are sent one at a
+    /// time; the next is written after `didWriteValueFor` (mirrors the plugin's
+    /// drainWriteQueue and avoids dropped writes on the radio).
+    func send(_ frame: Data) {
+        guard !frame.isEmpty else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.writeQueue.append(frame)
+            self.drainWriteQueue()
+        }
+    }
+
+    private func drainWriteQueue() {
+        guard !writeInFlight else { return }
+        guard let peripheral = connectedPeripheral,
+              let rx = rxCharacteristic,
+              peripheral.state == .connected,
+              !writeQueue.isEmpty else { return }
+        let frame = writeQueue.removeFirst()
+        writeInFlight = true
+        // RX is "write without response" on MeshCore; fall back to withResponse
+        // only if the characteristic doesn't advertise WWR.
+        let writeType: CBCharacteristicWriteType =
+            rx.properties.contains(.writeWithoutResponse) ? .withoutResponse : .withResponse
+        peripheral.writeValue(frame, for: rx, type: writeType)
+        if writeType == .withoutResponse {
+            // No write callback for WWR — release the in-flight latch and keep draining.
+            writeInFlight = false
+            if !writeQueue.isEmpty { drainWriteQueue() }
+        }
+    }
+
+    private func clearWriteQueue() {
+        writeQueue.removeAll()
+        writeInFlight = false
+    }
+
+    // MARK: Known / paired devices
+
+    private struct KnownDevice: Codable { let uuid: String; let name: String }
+
+    private func loadKnownDeviceRecords() -> [KnownDevice] {
+        guard let data = UserDefaults.standard.data(forKey: knownDevicesKey),
+              let list = try? JSONDecoder().decode([KnownDevice].self, from: data) else { return [] }
+        return list
+    }
+
+    private func rememberDevice(_ peripheral: CBPeripheral) {
+        let uuid = peripheral.identifier.uuidString
+        var list = loadKnownDeviceRecords().filter { $0.uuid != uuid }
+        list.insert(KnownDevice(uuid: uuid, name: peripheral.name ?? "MeshCore"), at: 0)
+        if list.count > 8 { list = Array(list.prefix(8)) }
+        if let data = try? JSONEncoder().encode(list) {
+            UserDefaults.standard.set(data, forKey: knownDevicesKey)
+        }
+    }
+
+    func forgetDevice(id: UUID) {
+        let list = loadKnownDeviceRecords().filter { $0.uuid != id.uuidString }
+        if let data = try? JSONEncoder().encode(list) {
+            UserDefaults.standard.set(data, forKey: knownDevicesKey)
+        }
+        DispatchQueue.main.async { self.knownDevices.removeAll { $0.id == id } }
+    }
+
+    func refreshKnownDevices() {
+        guard centralManager?.state == .poweredOn else { return }
+        var result: [DiscoveredBLEDevice] = []
+        var seen = Set<UUID>()
+        let records = loadKnownDeviceRecords()
+        let uuids = records.compactMap { UUID(uuidString: $0.uuid) }
+        if !uuids.isEmpty {
+            for p in centralManager.retrievePeripherals(withIdentifiers: uuids) where !seen.contains(p.identifier) {
+                seen.insert(p.identifier)
+                let stored = records.first { $0.uuid == p.identifier.uuidString }?.name
+                result.append(DiscoveredBLEDevice(id: p.identifier, name: p.name ?? stored ?? "MeshCore", rssi: 0, peripheral: p))
+            }
+        }
+        for p in centralManager.retrieveConnectedPeripherals(withServices: [MeshCoreBLEUUID.service])
+        where !seen.contains(p.identifier) {
+            seen.insert(p.identifier)
+            result.append(DiscoveredBLEDevice(id: p.identifier, name: p.name ?? "MeshCore", rssi: 0, peripheral: p))
+        }
+        DispatchQueue.main.async { self.knownDevices = result }
+    }
+
+    @discardableResult
+    func reconnectLastDevice() -> Bool {
+        guard centralManager?.state == .poweredOn, !isConnected, !userDidDisconnect else { return false }
+        let records = loadKnownDeviceRecords()
+        guard let last = records.first, let uuid = UUID(uuidString: last.uuid),
+              let peripheral = centralManager.retrievePeripherals(withIdentifiers: [uuid]).first else { return false }
+        print("MeshCore: auto-reconnecting to \(peripheral.name ?? last.name)")
+        connect(peripheral: peripheral)
+        return true
+    }
+}
+
+// MARK: - CBCentralManagerDelegate
+
+@available(iOS 13.0, *)
+extension MeshCoreBLETransport: CBCentralManagerDelegate {
+
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        DispatchQueue.main.async { self.bluetoothState = central.state }
+        switch central.state {
+        case .poweredOn:
+            refreshKnownDevices()
+            reconnectLastDevice()
+        case .poweredOff:
+            DispatchQueue.main.async {
+                self.lastError = "Bluetooth is turned off"
+                self.isConnected = false
+                self.connectionState = .disconnected
+            }
+        case .unauthorized:
+            DispatchQueue.main.async { self.lastError = "Bluetooth permission not granted" }
+        case .unsupported:
+            DispatchQueue.main.async { self.lastError = "Bluetooth is not supported on this device" }
+        default:
+            break
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral,
+                        advertisementData: [String : Any], rssi RSSI: NSNumber) {
+        let name = peripheral.name
+            ?? advertisementData[CBAdvertisementDataLocalNameKey] as? String
+            ?? "MeshCore Node"
+        let device = DiscoveredBLEDevice(id: peripheral.identifier, name: name,
+                                         rssi: RSSI.intValue, peripheral: peripheral)
+        DispatchQueue.main.async {
+            if let i = self.discoveredDevices.firstIndex(where: { $0.id == device.id }) {
+                self.discoveredDevices[i] = device
+            } else {
+                self.discoveredDevices.append(device)
+            }
+        }
+        print("MeshCore: discovered \(name) (RSSI \(RSSI))")
+    }
+
+    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        DispatchQueue.main.async {
+            self.connectionState = .discovering
+            self.connectedPeripheral = peripheral
+        }
+        peripheral.delegate = self
+        peripheral.discoverServices([MeshCoreBLEUUID.service])
+    }
+
+    private func isPairingError(_ error: Error?) -> Bool {
+        guard let error = error as NSError? else { return false }
+        if error.domain == CBErrorDomain,
+           error.code == CBError.Code.peerRemovedPairingInformation.rawValue { return true }
+        return error.localizedDescription.lowercased().contains("pairing")
+    }
+
+    func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+        let pairing = isPairingError(error)
+        if pairing { userDidDisconnect = true }
+        DispatchQueue.main.async {
+            self.connectionState = .failed
+            self.needsBluetoothRepair = pairing
+            self.lastError = pairing
+                ? "Bluetooth pairing is out of sync. In iOS Settings → Bluetooth, tap your MeshCore device, choose “Forget This Device,” then reconnect here."
+                : (error?.localizedDescription ?? "Failed to connect")
+        }
+        print("MeshCore: failed to connect: \(error?.localizedDescription ?? "unknown")")
+    }
+
+    func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        clearWriteQueue()
+        DispatchQueue.main.async {
+            self.isConnected = false
+            self.connectionState = .disconnected
+            self.connectedPeripheral = nil
+            self.rxCharacteristic = nil
+            self.txCharacteristic = nil
+            self.onDisconnect?()
+        }
+        print("MeshCore: disconnected from \(peripheral.name ?? "device")")
+    }
+}
+
+// MARK: - CBPeripheralDelegate
+
+@available(iOS 13.0, *)
+extension MeshCoreBLETransport: CBPeripheralDelegate {
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        if let error = error {
+            DispatchQueue.main.async { self.lastError = "Service discovery failed: \(error.localizedDescription)" }
+            return
+        }
+        guard let services = peripheral.services else { return }
+        for service in services where service.uuid == MeshCoreBLEUUID.service {
+            peripheral.discoverCharacteristics([MeshCoreBLEUUID.rx, MeshCoreBLEUUID.tx], for: service)
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        if let error = error {
+            DispatchQueue.main.async { self.lastError = "Characteristic discovery failed: \(error.localizedDescription)" }
+            return
+        }
+        guard let characteristics = service.characteristics else { return }
+        for ch in characteristics {
+            switch ch.uuid {
+            case MeshCoreBLEUUID.rx: rxCharacteristic = ch
+            case MeshCoreBLEUUID.tx: txCharacteristic = ch
+            default: break
+            }
+        }
+        guard let tx = txCharacteristic, rxCharacteristic != nil else {
+            DispatchQueue.main.async {
+                self.lastError = "MeshCore RX/TX characteristics missing"
+                self.connectionState = .failed
+            }
+            return
+        }
+        // Subscribe to TX notifications; the link is "ready" once notifications
+        // are enabled (see didUpdateNotificationStateFor).
+        peripheral.setNotifyValue(true, for: tx)
+        rememberDevice(peripheral)
+        userDidDisconnect = false
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
+        guard characteristic.uuid == MeshCoreBLEUUID.tx else { return }
+        if let error = error {
+            DispatchQueue.main.async {
+                self.lastError = "Enable notifications failed: \(error.localizedDescription)"
+                self.connectionState = .failed
+            }
+            return
+        }
+        guard characteristic.isNotifying else { return }
+        DispatchQueue.main.async {
+            self.isConnected = true
+            self.connectionState = .connected
+            self.needsBluetoothRepair = false
+            self.onReady?()
+        }
+        print("MeshCore: TX notifications live — link ready")
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        guard error == nil, characteristic.uuid == MeshCoreBLEUUID.tx,
+              let data = characteristic.value, !data.isEmpty else { return }
+        let frame = data
+        DispatchQueue.main.async { [weak self] in self?.onFrame?(frame) }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        if let error = error {
+            DispatchQueue.main.async { self.lastError = "Write failed: \(error.localizedDescription)" }
+        }
+        // Write-with-response completed — release the latch and send the next.
+        writeInFlight = false
+        drainWriteQueue()
+    }
+}

--- a/OmniTAKMobile/Features/MeshCore/Services/MeshCoreCoTConverter.swift
+++ b/OmniTAKMobile/Features/MeshCore/Services/MeshCoreCoTConverter.swift
@@ -1,0 +1,74 @@
+//
+//  MeshCoreCoTConverter.swift
+//  OmniTAK Mobile
+//
+//  Converts decoded MeshCore contacts to TAK CoT events. Mirrors
+//  MeshtasticCoTConverter's node->CoT mapping; the only material difference is
+//  the UID namespace — MeshCore PLIs use `MESHCORE-<pubkey8>` so they never
+//  collide with Meshtastic's `mesh-<nodenum>` markers and stay stable across
+//  sessions (keyed on the node's public key, not a volatile node number).
+//
+
+import Foundation
+
+enum MeshCoreCoTConverter {
+
+    /// CoT UID for a MeshCore contact: `MESHCORE-` + first 8 hex chars (4 bytes)
+    /// of the node's public key.
+    static func uid(forPubKeyHex pubKeyHex: String) -> String {
+        let prefix = String(pubKeyHex.prefix(8))
+        return "MESHCORE-\(prefix.isEmpty ? "unknown" : prefix)"
+    }
+
+    /// Build a CoT PLI event for a MeshCore contact with a valid position.
+    /// Returns nil if the contact has no usable position.
+    static func toCoTEvent(contact: MeshCoreContact,
+                           isOwnNode: Bool = false,
+                           batteryPercent: Int? = nil) -> CoTEvent? {
+        guard contact.hasValidPosition else { return nil }
+
+        let uid = Self.uid(forPubKeyHex: contact.pubKeyHex)
+        // Friendly ground unit for self, neutral ground unit for others —
+        // same convention MeshtasticCoTConverter uses.
+        let cotType = isOwnNode ? "a-f-G-U-C" : "a-n-G-U-C"
+        let callsign = contact.name.isEmpty ? shortName(forPubKeyHex: contact.pubKeyHex) : contact.name
+
+        var remarks = "MeshCore Node"
+        remarks += " | Key: \(String(contact.pubKeyHex.prefix(8)))"
+        if contact.isRepeater { remarks += " | Repeater" }
+        if let battery = batteryPercent, battery >= 0 { remarks += " | Bat: \(battery)%" }
+
+        let point = CoTPoint(
+            lat: contact.latitude,
+            lon: contact.longitude,
+            hae: 0.0,
+            ce: 50.0,
+            le: 50.0
+        )
+
+        let detail = CoTDetail(
+            callsign: callsign,
+            team: "MeshCore",
+            teamRole: nil,
+            speed: nil,
+            course: nil,
+            remarks: remarks,
+            battery: (batteryPercent ?? -1) >= 0 ? batteryPercent : nil,
+            device: "MeshCore",
+            platform: "LoRa"
+        )
+
+        let time = contact.advertTimestampSec > 0
+            ? Date(timeIntervalSince1970: TimeInterval(contact.advertTimestampSec))
+            : Date()
+
+        return CoTEvent(uid: uid, type: cotType, time: time, point: point, detail: detail)
+    }
+
+    /// A short, human-ish fallback name from the pubkey (last 4 hex of the
+    /// 8-char id), matching how MeshCore device names look (e.g. "MeshCore-25C70E7E").
+    private static func shortName(forPubKeyHex pubKeyHex: String) -> String {
+        let id8 = String(pubKeyHex.prefix(8)).uppercased()
+        return id8.isEmpty ? "MeshCore" : "MeshCore-\(id8)"
+    }
+}

--- a/OmniTAKMobile/Features/MeshCore/Services/MeshCoreCoTConverter.swift
+++ b/OmniTAKMobile/Features/MeshCore/Services/MeshCoreCoTConverter.swift
@@ -13,11 +13,12 @@ import Foundation
 
 enum MeshCoreCoTConverter {
 
-    /// CoT UID for a MeshCore contact: `MESHCORE-` + first 8 hex chars (4 bytes)
-    /// of the node's public key.
+    /// CoT UID for a MeshCore contact: `MESHCORE-` + first 12 uppercase hex chars
+    /// (6 bytes) of the node's public key. Matches the 6-byte prefix the firmware
+    /// uses to key contacts (Android-consistent: MESHCORE-<12 uppercase hex>).
     static func uid(forPubKeyHex pubKeyHex: String) -> String {
-        let prefix = String(pubKeyHex.prefix(8))
-        return "MESHCORE-\(prefix.isEmpty ? "unknown" : prefix)"
+        let prefix = String(pubKeyHex.prefix(12)).uppercased()
+        return "MESHCORE-\(prefix.isEmpty ? "UNKNOWN" : prefix)"
     }
 
     /// Build a CoT PLI event for a MeshCore contact with a valid position.
@@ -65,10 +66,10 @@ enum MeshCoreCoTConverter {
         return CoTEvent(uid: uid, type: cotType, time: time, point: point, detail: detail)
     }
 
-    /// A short, human-ish fallback name from the pubkey (last 4 hex of the
-    /// 8-char id), matching how MeshCore device names look (e.g. "MeshCore-25C70E7E").
+    /// A short, human-ish fallback name from the pubkey (first 12 hex = 6 bytes),
+    /// matching the 6-byte-prefix convention (e.g. "MeshCore-DEADBEEFCAFE").
     private static func shortName(forPubKeyHex pubKeyHex: String) -> String {
-        let id8 = String(pubKeyHex.prefix(8)).uppercased()
-        return id8.isEmpty ? "MeshCore" : "MeshCore-\(id8)"
+        let id12 = String(pubKeyHex.prefix(12)).uppercased()
+        return id12.isEmpty ? "MeshCore" : "MeshCore-\(id12)"
     }
 }

--- a/OmniTAKMobile/Features/MeshCore/Services/MeshCoreFrameCodec.swift
+++ b/OmniTAKMobile/Features/MeshCore/Services/MeshCoreFrameCodec.swift
@@ -58,12 +58,24 @@ struct MeshCoreSelfInfo: Equatable {
     let hasPosition: Bool
 }
 
+/// Device info decoded from a RESP_DEVICE_INFO (0x0D) frame.
+/// Layout per MeshCore-1.4.8: [0x0D][hwModel u8 @1][hwRevision u8 @2][fwVersion ascii @3…].
+struct MeshCoreDeviceInfo: Equatable {
+    /// Hardware model identifier byte.
+    let hwModel: UInt8
+    /// Hardware revision byte.
+    let hwRevision: UInt8
+    /// Firmware version string (null-terminated ASCII, may be empty).
+    let firmwareVersion: String
+}
+
 /// One decoded response frame from the radio.
 enum MeshCoreResponse: Equatable {
     case selfInfo(MeshCoreSelfInfo)
     case contact(MeshCoreContact)        // advert / contact (position-bearing)
     case textMessage(MeshCoreTextMessage)
     case battery(millivolts: Int, percent: Int)
+    case deviceInfo(MeshCoreDeviceInfo)  // 0x0D — hardware / firmware identity
     case noMoreMessages
     case messagesWaiting
     case other(code: UInt8)              // recognized-but-unhandled / unknown
@@ -98,7 +110,7 @@ enum MeshCoreFrameCodec {
     static let respContactMsgV3: UInt8   = 0x10
     static let respNoMoreMsgs: UInt8     = 0x0A
     static let respBattery: UInt8        = 0x0C
-    static let respDeviceInfo: UInt8     = 0x0D
+    static let respDeviceInfo: UInt8     = 0x0D   // RESP_DEVICE_INFO — 82 bytes on live radio
     static let respCodeContact: UInt8    = 0x03   // full contact record
     static let pushCodeAdvert: UInt8     = 0x80
     static let pushCodeNewAdvert: UInt8  = 0x8A
@@ -208,6 +220,9 @@ enum MeshCoreFrameCodec {
         case respBattery:
             if let (mv, pct) = decodeBattery(frame) { return .battery(millivolts: mv, percent: pct) }
             return .other(code: code)
+        case respDeviceInfo:
+            if let info = decodeDeviceInfo(frame) { return .deviceInfo(info) }
+            return .other(code: code)
         case respContactMsg, respContactMsgV3:
             if let msg = decodeTextMessage(frame, v3: code == respContactMsgV3) {
                 return .textMessage(msg)
@@ -296,6 +311,20 @@ enum MeshCoreFrameCodec {
         return (mv, batteryPercent(fromMillivolts: mv))
     }
 
+    /// Parse a RESP_DEVICE_INFO (0x0D) frame.
+    /// Layout: [0x0D][hwModel u8 @1][hwRevision u8 @2][fwVersion ascii @3…].
+    /// The live radio sends an 82-byte frame; anything ≥ 3 bytes is accepted
+    /// (the version string can be empty on minimal builds).
+    static func decodeDeviceInfo(_ frame: Data) -> MeshCoreDeviceInfo? {
+        guard frame.count >= 3 else { return nil }
+        let hwModel    = frame[frame.startIndex + 1]
+        let hwRevision = frame[frame.startIndex + 2]
+        let fwVersion  = frame.count > 3
+            ? frame.cString(from: 3, maxLen: frame.count - 3)
+            : ""
+        return MeshCoreDeviceInfo(hwModel: hwModel, hwRevision: hwRevision, firmwareVersion: fwVersion)
+    }
+
     static func batteryPercent(fromMillivolts mv: Int) -> Int {
         if mv <= 0 { return -1 }
         if mv <= batteryMinMv { return 0 }
@@ -320,11 +349,25 @@ enum MeshCoreFrameCodec {
         return out
     }
 
-    /// Derive a stable 32-bit node id from the first 4 bytes of a pubkey hex
-    /// (big-endian), used as the `MeshNode.id` key. 0 if the pubkey is invalid.
+    /// Derive a stable 32-bit node id from the first 6 bytes of a pubkey hex.
+    /// We fold the 6 bytes into a UInt32 by XOR-ing bytes 4 and 5 into the high
+    /// and mid positions so the full 48-bit prefix contributes to the id; this
+    /// matches the Android companion's key-contact behaviour (6-byte prefix).
+    /// 0 if the pubkey is invalid or too short.
     static func nodeId(fromPubKeyHex pubKeyHex: String) -> UInt32 {
-        guard let bytes = pubKeyPrefixBytes(pubKeyHex, count: 4) else { return 0 }
-        return bytes.reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+        guard let bytes = pubKeyPrefixBytes(pubKeyHex, count: 6) else { return 0 }
+        // Incorporate all 6 bytes: use first 4 as base, mix bytes 4+5 in.
+        let base = bytes.prefix(4).reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+        let mix  = UInt32(bytes[4]) ^ (UInt32(bytes[5]) << 16)
+        return base ^ mix
+    }
+
+    /// Stable 12-hex-char public-key prefix (6 bytes) used for MESHCORE UIDs
+    /// and self-node deduplication. Returns nil if pubKeyHex is too short.
+    static func pubKeyPrefix12(fromPubKeyHex pubKeyHex: String) -> String? {
+        let hex = pubKeyHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard hex.count >= 12 else { return nil }
+        return String(hex.prefix(12)).lowercased()
     }
 }
 

--- a/OmniTAKMobile/Features/MeshCore/Services/MeshCoreFrameCodec.swift
+++ b/OmniTAKMobile/Features/MeshCore/Services/MeshCoreFrameCodec.swift
@@ -1,0 +1,387 @@
+//
+//  MeshCoreFrameCodec.swift
+//  OmniTAK Mobile
+//
+//  Encodes/decodes the MeshCore *companion* BLE protocol — the same wire format
+//  the upstream MeshCore companion apps and the TAK-MeshCore ATAK plugin speak.
+//  Each BLE write to the Nordic-UART RX characteristic is one command frame
+//  (first byte = command code); each TX notification is one response frame
+//  (first byte = response code). There is no extra length prefix at this layer
+//  — the GATT characteristic value IS the frame.
+//
+//  Reference: MeshCore-1.4.8 ATAK plugin, BtConnectionManager.java
+//  (command/response codes, byte layouts, little-endian multibyte fields).
+//
+
+import Foundation
+
+// MARK: - Decoded Records
+
+/// A MeshCore contact / advert decoded from the radio: another node's identity
+/// and (optionally) its advertised position. Maps onto a CoT PLI.
+struct MeshCoreContact: Equatable {
+    /// Full public-key hex (lowercase, 64 chars for a 32-byte key).
+    let pubKeyHex: String
+    /// Advert type byte (0x01 = chat node, 0x02 = repeater, …).
+    let advertType: Int
+    let name: String
+    /// Advert timestamp (epoch seconds), 0 if unknown.
+    let advertTimestampSec: UInt32
+    let latitude: Double
+    let longitude: Double
+    let hasPosition: Bool
+
+    var isRepeater: Bool { advertType == MeshCoreFrameCodec.advTypeRepeater }
+
+    /// True when the advertised position is a usable, non-null-island fix.
+    var hasValidPosition: Bool {
+        guard hasPosition, latitude.isFinite, longitude.isFinite else { return false }
+        if latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180 { return false }
+        return !(abs(latitude) < 0.000001 && abs(longitude) < 0.000001)
+    }
+}
+
+/// An inbound text message from another node (native pubkey-to-pubkey DM).
+struct MeshCoreTextMessage: Equatable {
+    /// Sender public-key prefix hex (first 6 bytes -> 12 hex chars), as the
+    /// firmware reports it on a contact-message frame.
+    let senderPubKeyPrefixHex: String
+    let text: String
+}
+
+/// The radio's own identity + position from a SELF_INFO (APP_START reply) frame.
+struct MeshCoreSelfInfo: Equatable {
+    let pubKeyHex: String
+    let name: String
+    let latitude: Double
+    let longitude: Double
+    let hasPosition: Bool
+}
+
+/// One decoded response frame from the radio.
+enum MeshCoreResponse: Equatable {
+    case selfInfo(MeshCoreSelfInfo)
+    case contact(MeshCoreContact)        // advert / contact (position-bearing)
+    case textMessage(MeshCoreTextMessage)
+    case battery(millivolts: Int, percent: Int)
+    case noMoreMessages
+    case messagesWaiting
+    case other(code: UInt8)              // recognized-but-unhandled / unknown
+}
+
+// MARK: - Codec
+
+enum MeshCoreFrameCodec {
+
+    // --- Companion command codes (RX, app -> radio) ---
+    static let cmdAppStart: UInt8        = 0x01
+    static let cmdSendTxtMsg: UInt8      = 0x02
+    static let cmdSendChannelMsg: UInt8  = 0x03
+    static let cmdSendSelfAdvert: UInt8  = 0x07
+    static let cmdSetAdvertName: UInt8   = 0x08
+    static let cmdGetNextMsg: UInt8      = 0x0A
+    static let cmdSetAdvertLatLon: UInt8 = 0x0E
+    static let cmdGetBattery: UInt8      = 0x14
+    static let cmdDeviceQuery: UInt8     = 0x16
+    static let cmdGetContactByKey: UInt8 = 0x1E
+    static let cmdSendChannelData: UInt8 = 0x3E
+
+    static let txtTypePlain: UInt8       = 0x00
+    static let deviceQueryArg: UInt8     = 0x03
+
+    /// App identifier sent in APP_START (matches the upstream companion app id).
+    static let companionAppId = "meshcore-flutter"
+
+    // --- Companion response codes (TX, radio -> app) ---
+    static let respSelfInfo: UInt8       = 0x05
+    static let respContactMsg: UInt8     = 0x07
+    static let respContactMsgV3: UInt8   = 0x10
+    static let respNoMoreMsgs: UInt8     = 0x0A
+    static let respBattery: UInt8        = 0x0C
+    static let respDeviceInfo: UInt8     = 0x0D
+    static let respCodeContact: UInt8    = 0x03   // full contact record
+    static let pushCodeAdvert: UInt8     = 0x80
+    static let pushCodeNewAdvert: UInt8  = 0x8A
+    static let pushMessagesWaiting: UInt8 = 0x83
+
+    static let advTypeRepeater = 0x02
+
+    // Battery model (matches firmware meshBatteryMvToPercent).
+    static let batteryMinMv = 3300
+    static let batteryMaxMv = 4200
+
+    // MARK: - Encoders
+
+    /// APP_START — first command after the link is up; the radio replies with
+    /// SELF_INFO. Layout: [0x01][7 reserved 0x00][appId ascii].
+    static func encodeAppStart(appId: String = companionAppId) -> Data {
+        var out = Data([cmdAppStart])
+        out.append(contentsOf: [UInt8](repeating: 0, count: 7))
+        out.append(Data(appId.utf8))
+        return out
+    }
+
+    /// DEVICE_QUERY — [0x16][0x03].
+    static func encodeDeviceQuery() -> Data {
+        Data([cmdDeviceQuery, deviceQueryArg])
+    }
+
+    /// GET_NEXT_MSG — drain one queued frame from the radio.
+    static func encodeGetNextMessage() -> Data { Data([cmdGetNextMsg]) }
+
+    /// GET_BATTERY — request a battery reading.
+    static func encodeGetBattery() -> Data { Data([cmdGetBattery]) }
+
+    /// SEND_SELF_ADVERT — broadcast this node's advert (identity + position if
+    /// the radio is configured to share it).
+    static func encodeSendSelfAdvert() -> Data { Data([cmdSendSelfAdvert]) }
+
+    /// SET_ADVERT_LATLON — set the position the radio will share in its advert.
+    /// Layout: [0x0E][latE6 i32 LE][lonE6 i32 LE][altMeters i32 LE] (13 bytes).
+    /// Returns nil for an out-of-range coordinate.
+    static func encodeSetAdvertLatLon(latitude: Double,
+                                      longitude: Double,
+                                      altitudeMeters: Double = 0) -> Data? {
+        guard latitude.isFinite, longitude.isFinite,
+              latitude >= -90, latitude <= 90,
+              longitude >= -180, longitude <= 180 else { return nil }
+        let latE6 = Int32((latitude * 1_000_000).rounded())
+        let lonE6 = Int32((longitude * 1_000_000).rounded())
+        let alt = altitudeMeters.isFinite ? Int32(altitudeMeters.rounded()) : 0
+        var out = Data([cmdSetAdvertLatLon])
+        out.appendInt32LE(latE6)
+        out.appendInt32LE(lonE6)
+        out.appendInt32LE(alt)
+        return out
+    }
+
+    /// SET_ADVERT_NAME — set this node's advertised name (≤31 bytes UTF-8).
+    static func encodeSetAdvertName(_ name: String) -> Data? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        var bytes = Array(trimmed.utf8)
+        if bytes.count > 31 { bytes = Array(bytes.prefix(31)) }
+        return Data([cmdSetAdvertName]) + Data(bytes)
+    }
+
+    /// SEND_TXT_MSG — a native pubkey-to-pubkey direct message. Layout:
+    /// [0x02][txtType=0x00][attempt=0x00][timestamp u32 LE][pubkeyPrefix 6][msg].
+    /// `pubKeyHex` must be >= 12 hex chars (first 6 bytes are the prefix).
+    /// Returns nil on bad pubkey / empty text.
+    static func encodeSendTextMessage(pubKeyHex: String,
+                                      text: String,
+                                      timestamp: Date = Date()) -> Data? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let prefix = pubKeyPrefixBytes(pubKeyHex, count: 6) else {
+            return nil
+        }
+        var out = Data([cmdSendTxtMsg, txtTypePlain, 0x00])
+        out.appendUInt32LE(UInt32(truncatingIfNeeded: Int(timestamp.timeIntervalSince1970)))
+        out.append(prefix)
+        out.append(Data(trimmed.utf8))
+        return out
+    }
+
+    /// GET_CONTACT_BY_KEY — request the full contact record for a 32-byte
+    /// pubkey (taken from an advert frame's bytes 1..32). Returns nil if the
+    /// advert frame is too short.
+    static func encodeGetContactByKey(advertFrame: Data) -> Data? {
+        guard advertFrame.count >= 33 else { return nil }
+        var out = Data([cmdGetContactByKey])
+        out.append(advertFrame.subdata(in: 1..<33))
+        return out
+    }
+
+    // MARK: - Decoder
+
+    /// Decode one response frame (the raw GATT TX characteristic value).
+    static func decode(_ frame: Data) -> MeshCoreResponse? {
+        guard let code = frame.first else { return nil }
+        switch code {
+        case respSelfInfo:
+            if let info = decodeSelfInfo(frame) { return .selfInfo(info) }
+            return .other(code: code)
+        case pushMessagesWaiting:
+            return .messagesWaiting
+        case respNoMoreMsgs:
+            return .noMoreMessages
+        case respBattery:
+            if let (mv, pct) = decodeBattery(frame) { return .battery(millivolts: mv, percent: pct) }
+            return .other(code: code)
+        case respContactMsg, respContactMsgV3:
+            if let msg = decodeTextMessage(frame, v3: code == respContactMsgV3) {
+                return .textMessage(msg)
+            }
+            return .other(code: code)
+        case pushCodeAdvert, pushCodeNewAdvert, respCodeContact:
+            if let contact = decodeContact(frame) { return .contact(contact) }
+            return .other(code: code)
+        default:
+            return .other(code: code)
+        }
+    }
+
+    /// Parse an advert / contact frame into a `MeshCoreContact`.
+    /// Layout (companion firmware): [code][pubkey 32 @1][advType @33]
+    /// [name 32 @100][tsSec u32 @132][latE6 i32 @136][lonE6 i32 @140].
+    static func decodeContact(_ frame: Data) -> MeshCoreContact? {
+        guard frame.count >= 144 else { return nil }
+        let pubKeyHex = frame.hexString(from: 1, count: 32)
+        guard !pubKeyHex.isEmpty else { return nil }
+        let advType = Int(frame[frame.startIndex + 33])
+        var name = frame.cString(from: 100, maxLen: 32)
+        if name.isEmpty { name = "MeshCore Node" }
+        let tsSec = frame.uint32LE(at: 132) ?? 0
+        let latE6 = frame.int32LE(at: 136) ?? 0
+        let lonE6 = frame.int32LE(at: 140) ?? 0
+        let hasPosition = !(latE6 == 0 && lonE6 == 0)
+        return MeshCoreContact(
+            pubKeyHex: pubKeyHex,
+            advertType: advType,
+            name: name,
+            advertTimestampSec: tsSec,
+            latitude: Double(latE6) / 1_000_000.0,
+            longitude: Double(lonE6) / 1_000_000.0,
+            hasPosition: hasPosition
+        )
+    }
+
+    /// Parse a SELF_INFO frame (APP_START reply).
+    /// Layout: [0x05][advType @1][txPower @2][maxTx @3][pubkey 32 @4]
+    /// [latE6 i32 @36][lonE6 i32 @40] … [name @58+].
+    static func decodeSelfInfo(_ frame: Data) -> MeshCoreSelfInfo? {
+        guard frame.count >= 44 else { return nil }
+        let pubKeyHex = frame.hexString(from: 4, count: 32)
+        let latE6 = frame.int32LE(at: 36) ?? 0
+        let lonE6 = frame.int32LE(at: 40) ?? 0
+        var name = ""
+        if frame.count > 58 {
+            name = frame.cString(from: 58, maxLen: frame.count - 58)
+        }
+        let lat = Double(latE6) / 1_000_000.0
+        let lon = Double(lonE6) / 1_000_000.0
+        let hasPosition = !(latE6 == 0 && lonE6 == 0)
+        return MeshCoreSelfInfo(
+            pubKeyHex: pubKeyHex,
+            name: name,
+            latitude: lat,
+            longitude: lon,
+            hasPosition: hasPosition
+        )
+    }
+
+    /// Parse a contact-message (native DM) frame.
+    /// v1: [0x07][senderPrefix 6 @1][...][txtType @8][text @13 (+4 if txtType==2)].
+    /// v3: [0x10][...][senderPrefix 6 @4][txtType @11][text @16 (+4 if txtType==2)].
+    static func decodeTextMessage(_ frame: Data, v3: Bool) -> MeshCoreTextMessage? {
+        let prefixOff = v3 ? 4 : 1
+        let txtTypeIdx = v3 ? 11 : 8
+        var textOff = v3 ? 16 : 13
+        guard frame.count >= prefixOff + 6, frame.count > txtTypeIdx else { return nil }
+        let senderPrefixHex = frame.hexString(from: prefixOff, count: 6)
+        let txtType = frame[frame.startIndex + txtTypeIdx]
+        if txtType == 2 { textOff += 4 } // signed/timestamped variant carries 4 extra bytes
+        guard frame.count > textOff else { return nil }
+        let textData = frame.subdata(in: (frame.startIndex + textOff)..<frame.endIndex)
+        let text = String(data: textData, encoding: .utf8) ?? ""
+        return MeshCoreTextMessage(senderPubKeyPrefixHex: senderPrefixHex, text: text)
+    }
+
+    /// Parse a battery frame: [0x0C][mv low][mv high]. Returns (mv, percent).
+    static func decodeBattery(_ frame: Data) -> (Int, Int)? {
+        guard frame.count >= 3 else { return nil }
+        let lo = Int(frame[frame.startIndex + 1])
+        let hi = Int(frame[frame.startIndex + 2])
+        let mv = lo | (hi << 8)
+        return (mv, batteryPercent(fromMillivolts: mv))
+    }
+
+    static func batteryPercent(fromMillivolts mv: Int) -> Int {
+        if mv <= 0 { return -1 }
+        if mv <= batteryMinMv { return 0 }
+        if mv >= batteryMaxMv { return 100 }
+        return Int((100.0 * Double(mv - batteryMinMv) / Double(batteryMaxMv - batteryMinMv)).rounded())
+    }
+
+    // MARK: - Helpers
+
+    /// First `count` bytes of a hex pubkey as raw bytes; nil if too short/invalid.
+    static func pubKeyPrefixBytes(_ pubKeyHex: String, count: Int) -> Data? {
+        let hex = pubKeyHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard hex.count >= count * 2 else { return nil }
+        var out = Data(capacity: count)
+        var idx = hex.startIndex
+        for _ in 0..<count {
+            let next = hex.index(idx, offsetBy: 2)
+            guard let byte = UInt8(hex[idx..<next], radix: 16) else { return nil }
+            out.append(byte)
+            idx = next
+        }
+        return out
+    }
+
+    /// Derive a stable 32-bit node id from the first 4 bytes of a pubkey hex
+    /// (big-endian), used as the `MeshNode.id` key. 0 if the pubkey is invalid.
+    static func nodeId(fromPubKeyHex pubKeyHex: String) -> UInt32 {
+        guard let bytes = pubKeyPrefixBytes(pubKeyHex, count: 4) else { return 0 }
+        return bytes.reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+    }
+}
+
+// MARK: - Data byte helpers (little-endian, offset-safe)
+
+extension Data {
+    fileprivate mutating func appendInt32LE(_ value: Int32) {
+        appendUInt32LE(UInt32(bitPattern: value))
+    }
+
+    fileprivate mutating func appendUInt32LE(_ value: UInt32) {
+        append(UInt8(value & 0xFF))
+        append(UInt8((value >> 8) & 0xFF))
+        append(UInt8((value >> 16) & 0xFF))
+        append(UInt8((value >> 24) & 0xFF))
+    }
+
+    /// Read a little-endian UInt32 at logical offset `off` (0-based from the
+    /// start of this Data slice). Nil if out of range.
+    func uint32LE(at off: Int) -> UInt32? {
+        guard off >= 0, count >= off + 4 else { return nil }
+        let b = startIndex + off
+        return UInt32(self[b])
+            | (UInt32(self[b + 1]) << 8)
+            | (UInt32(self[b + 2]) << 16)
+            | (UInt32(self[b + 3]) << 24)
+    }
+
+    /// Read a little-endian Int32 at logical offset `off`.
+    func int32LE(at off: Int) -> Int32? {
+        guard let u = uint32LE(at: off) else { return nil }
+        return Int32(bitPattern: u)
+    }
+
+    /// Lowercase hex of `count` bytes starting at logical offset `off`.
+    /// Empty string if out of range.
+    func hexString(from off: Int, count n: Int) -> String {
+        guard off >= 0, n > 0, count >= off + n else { return "" }
+        let b = startIndex + off
+        var s = ""
+        s.reserveCapacity(n * 2)
+        for i in 0..<n {
+            s += String(format: "%02x", self[b + i])
+        }
+        return s
+    }
+
+    /// Decode a null-terminated / null-padded UTF-8 C string of up to `maxLen`
+    /// bytes starting at logical offset `off`. Trimmed of surrounding whitespace.
+    func cString(from off: Int, maxLen: Int) -> String {
+        guard off >= 0, maxLen > 0, count > off else { return "" }
+        let b = startIndex + off
+        let end = Swift.min(endIndex, b + maxLen)
+        var n = b
+        while n < end && self[n] != 0 { n += 1 }
+        let raw = subdata(in: b..<n)
+        return (String(data: raw, encoding: .utf8) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/OmniTAKMobile/Features/MeshCore/Views/MeshFrameworkDevicePickerView.swift
+++ b/OmniTAKMobile/Features/MeshCore/Views/MeshFrameworkDevicePickerView.swift
@@ -1,0 +1,294 @@
+//
+//  MeshFrameworkDevicePickerView.swift
+//  OmniTAK Mobile
+//
+//  Top-level mesh-framework selector + per-framework connect flow. Lets the
+//  operator choose Meshtastic or MeshCore (persisted via
+//  @AppStorage("selectedMeshFramework")) and routes to the matching device
+//  picker: the existing MeshtasticDevicePickerView, or the MeshCore BLE scan
+//  below (Nordic UART companion radios only).
+//
+
+import SwiftUI
+import CoreBluetooth
+
+struct MeshFrameworkDevicePickerView: View {
+    @ObservedObject var meshtasticManager: MeshtasticManager
+    @AppStorage(MeshFramework.storageKey) private var selectedFrameworkRaw: String = MeshFramework.meshtastic.rawValue
+    @Environment(\.dismiss) private var dismiss
+
+    private var selectedFramework: MeshFramework {
+        MeshFramework(rawValue: selectedFrameworkRaw) ?? .meshtastic
+    }
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                // Mesh framework selector (Meshtastic | MeshCore)
+                Picker("Mesh Framework", selection: $selectedFrameworkRaw) {
+                    ForEach(MeshFramework.allCases) { fw in
+                        Label(fw.displayName, systemImage: fw.iconName).tag(fw.rawValue)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding()
+
+                Divider()
+
+                switch selectedFramework {
+                case .meshtastic:
+                    // Reuse the existing Meshtastic picker body (BLE + TCP tabs).
+                    MeshtasticDevicePickerBody(manager: meshtasticManager)
+                case .meshcore:
+                    if #available(iOS 13.0, *) {
+                        MeshCoreBLEConnectView(manager: MeshCoreManager.shared)
+                    } else {
+                        Text("MeshCore requires iOS 13 or later.")
+                            .foregroundColor(.secondary)
+                            .padding()
+                    }
+                }
+            }
+            .background(Color(UIColor.systemGroupedBackground))
+            .navigationTitle("Connect Mesh Radio")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Meshtastic picker body (selector-embedded variant)
+
+/// The Meshtastic BLE/TCP picker rendered *inside* the framework selector. It
+/// delegates to the existing `MeshtasticDevicePickerView` (which has its own
+/// NavigationView/toolbar) so Meshtastic behavior is untouched.
+private struct MeshtasticDevicePickerBody: View {
+    @ObservedObject var manager: MeshtasticManager
+    var body: some View {
+        MeshtasticDevicePickerView(manager: manager)
+    }
+}
+
+// MARK: - MeshCore BLE connect view
+
+@available(iOS 13.0, *)
+private struct MeshCoreBLEConnectView: View {
+    @ObservedObject var manager: MeshCoreManager
+    @ObservedObject private var transport: MeshCoreBLETransport
+
+    init(manager: MeshCoreManager) {
+        self.manager = manager
+        self.transport = manager.bleTransport
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            bluetoothStatusBanner
+
+            if transport.needsBluetoothRepair {
+                pairingRepairBanner
+            }
+
+            if manager.isConnected {
+                connectedDeviceCard.padding()
+            }
+
+            List {
+                if !transport.knownDevices.isEmpty {
+                    Section {
+                        ForEach(transport.knownDevices) { device in
+                            Button {
+                                manager.stopBLEScanning()
+                                manager.connectBLE(device: device)
+                            } label: {
+                                MeshCoreDeviceRow(name: device.name,
+                                                  subtitle: "Paired — tap to reconnect",
+                                                  systemImage: "dot.radiowaves.left.and.right")
+                            }
+                            .buttonStyle(.plain)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                Button(role: .destructive) {
+                                    manager.forgetBLEDevice(id: device.id)
+                                } label: { Label("Forget", systemImage: "trash") }
+                            }
+                        }
+                    } header: {
+                        Text("Paired Devices")
+                    } footer: {
+                        Text("Tap to reconnect instantly — no scan or re-pairing needed.")
+                    }
+                }
+
+                Section {
+                    if transport.isScanning {
+                        HStack {
+                            ProgressView().padding(.trailing, 8)
+                            Text("Scanning for MeshCore radios…").foregroundColor(.secondary)
+                        }
+                    } else if transport.discoveredDevices.isEmpty {
+                        VStack(spacing: 12) {
+                            Image(systemName: "dot.radiowaves.left.and.right")
+                                .font(.system(size: 36)).foregroundColor(.secondary)
+                            Text("No MeshCore Radios Found")
+                                .font(.headline).foregroundColor(.secondary)
+                            Text("Make sure your MeshCore companion radio is powered on and in range. Only radios running MeshCore companion firmware (Nordic UART) appear here — not Meshtastic.")
+                                .font(.subheadline).foregroundColor(.secondary)
+                                .multilineTextAlignment(.center)
+                            Button(action: { manager.startBLEScanning() }) {
+                                Label("Start Scanning", systemImage: "arrow.clockwise")
+                            }
+                            .buttonStyle(.borderedProminent).padding(.top, 8)
+                        }
+                        .frame(maxWidth: .infinity).padding(.vertical, 32)
+                        .listRowBackground(Color.clear)
+                    }
+
+                    ForEach(transport.discoveredDevices) { device in
+                        Button {
+                            manager.stopBLEScanning()
+                            manager.connectBLE(device: device)
+                        } label: {
+                            MeshCoreDeviceRow(name: device.name,
+                                              subtitle: "RSSI: \(device.rssi) dBm",
+                                              systemImage: "dot.radiowaves.left.and.right")
+                        }
+                        .buttonStyle(.plain)
+                    }
+                } header: {
+                    HStack {
+                        Text("Nearby MeshCore Radios")
+                        Spacer()
+                        if transport.isScanning {
+                            Button("Stop") { manager.stopBLEScanning() }.font(.caption)
+                        } else {
+                            Button("Scan") { manager.startBLEScanning() }.font(.caption)
+                        }
+                    }
+                } footer: {
+                    Text("When pairing, enter the 6-digit code shown on the node's screen, or \(MeshCoreBLEUUID.defaultPairingPin) if it has no screen.")
+                }
+            }
+            .listStyle(.insetGrouped)
+        }
+        .onAppear {
+            guard transport.bluetoothState == .poweredOn else { return }
+            manager.refreshKnownBLEDevices()
+            if !manager.isConnected {
+                manager.reconnectLastBLEDevice()
+                manager.startBLEScanning()
+            }
+        }
+        .onDisappear { manager.stopBLEScanning() }
+    }
+
+    private var connectedDeviceCard: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                Circle().fill(Color.green).frame(width: 12, height: 12)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(transport.connectedPeripheral?.name ?? "MeshCore Radio").font(.headline)
+                    if !manager.selfPubKeyHex.isEmpty {
+                        Text(String(manager.selfPubKeyHex.prefix(8)).uppercased())
+                            .font(.caption).foregroundColor(.secondary)
+                    }
+                }
+                Spacer()
+                VStack(alignment: .trailing) {
+                    if manager.batteryPercent >= 0 {
+                        Label("\(manager.batteryPercent)%", systemImage: "battery.100")
+                            .font(.caption).foregroundColor(.secondary)
+                    }
+                    if !manager.meshNodes.isEmpty {
+                        Text("\(manager.meshNodes.count) nodes")
+                            .font(.caption).foregroundColor(.secondary)
+                    }
+                }
+            }
+            Button(action: { manager.disconnect() }) {
+                Text("Disconnect")
+                    .font(.subheadline).fontWeight(.medium).foregroundColor(.white)
+                    .frame(maxWidth: .infinity).padding(.vertical, 10)
+                    .background(Color.red).cornerRadius(8)
+            }
+        }
+        .padding()
+        .background(Color(UIColor.secondarySystemGroupedBackground))
+        .cornerRadius(12)
+    }
+
+    private var bluetoothStatusBanner: some View {
+        Group {
+            switch transport.bluetoothState {
+            case .poweredOff:
+                banner("Bluetooth is turned off", icon: "bluetooth.slash", color: .orange)
+            case .unauthorized:
+                banner("Bluetooth permission required", icon: "lock.fill", color: .red)
+            case .unsupported:
+                banner("Bluetooth not supported", icon: "xmark.circle.fill", color: .red)
+            default:
+                EmptyView()
+            }
+        }
+    }
+
+    private func banner(_ text: String, icon: String, color: Color) -> some View {
+        HStack {
+            Image(systemName: icon)
+            Text(text)
+            Spacer()
+        }
+        .padding()
+        .background(color.opacity(0.15))
+        .foregroundColor(color)
+    }
+
+    private var pairingRepairBanner: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.orange)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Pairing out of sync").font(.subheadline).fontWeight(.semibold)
+                Text("Open iOS Settings → Bluetooth, tap your MeshCore device, choose “Forget This Device,” then reconnect here.")
+                    .font(.caption).fixedSize(horizontal: false, vertical: true)
+                Button {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        UIApplication.shared.open(url)
+                    }
+                } label: {
+                    Label("Open Settings", systemImage: "gear").font(.caption.weight(.semibold))
+                }
+                .padding(.top, 2)
+            }
+            Spacer()
+        }
+        .padding()
+        .background(Color.orange.opacity(0.15))
+        .foregroundColor(.orange)
+    }
+}
+
+// MARK: - MeshCore device row
+
+@available(iOS 13.0, *)
+private struct MeshCoreDeviceRow: View {
+    let name: String
+    let subtitle: String
+    let systemImage: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: systemImage)
+                .font(.system(size: 20)).foregroundColor(.blue).frame(width: 32)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name).font(.body)
+                Text(subtitle).font(.caption).foregroundColor(.secondary)
+            }
+            Spacer()
+            Image(systemName: "chevron.right").font(.caption).foregroundColor(.secondary)
+        }
+        .contentShape(Rectangle())
+    }
+}

--- a/OmniTAKMobile/Features/Meshtastic/Views/MeshtasticConnectionView.swift
+++ b/OmniTAKMobile/Features/Meshtastic/Views/MeshtasticConnectionView.swift
@@ -77,7 +77,7 @@ struct MeshtasticConnectionView: View {
                 }
             }
             .sheet(isPresented: $showingDevicePicker) {
-                MeshtasticDevicePickerView(manager: manager)
+                MeshFrameworkDevicePickerView(meshtasticManager: manager)
             }
             .sheet(isPresented: $showingMeshTopology) {
                 MeshTopologyView()

--- a/OmniTAKMobile/Features/Networking/Services/DeepLinkHandler.swift
+++ b/OmniTAKMobile/Features/Networking/Services/DeepLinkHandler.swift
@@ -15,6 +15,7 @@ enum TAKDeepLink {
     case enrollment(EnrollmentDeepLink)
     case passwordEnrollment(PasswordEnrollmentDeepLink)
     case connect(ConnectDeepLink)
+    case configProfile(ConfigProfile)
     case unknown(URL)
 
     static func parse(url: URL) -> TAKDeepLink? {
@@ -22,6 +23,14 @@ enum TAKDeepLink {
         // QR/link onboards both iOS and Android (Android registers atak/omnitak).
         guard let scheme = url.scheme?.lowercased(),
               scheme == "tak" || scheme == "atak" || scheme == "omnitak" else { return nil }
+
+        // omnitak://profile?d=<payload> — config profile QR
+        if scheme == "omnitak", url.host?.lowercased() == "profile" {
+            if let profile = try? ProfileQRCodec.decode(url: url) {
+                return .configProfile(profile)
+            }
+            return .unknown(url)
+        }
 
         let path = url.path.lowercased()
         let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
@@ -251,6 +260,8 @@ class DeepLinkHandler: ObservableObject {
             }
         case .connect(let connectLink):
             processSimpleConnect(connectLink)
+        case .configProfile(let profile):
+            processConfigProfile(profile)
         case .unknown(let unknownURL):
             print("[DeepLink] Unknown deep link type: \(unknownURL)")
             lastError = "Unknown link type"
@@ -309,6 +320,23 @@ class DeepLinkHandler: ObservableObject {
                 print("[DeepLink] ❌ Password enrollment failed: \(error)")
             }
         }
+    }
+
+    // MARK: - Config Profile Import
+
+    private func processConfigProfile(_ profile: ConfigProfile) {
+        print("[DeepLink] Importing config profile: \(profile.name)")
+        isProcessing = true
+        lastError = nil
+
+        ProfileStore.shared.addProfile(profile)
+        ProfileStore.shared.apply(profile)
+
+        isProcessing = false
+        enrolledServerName = profile.name
+        showEnrollmentSuccess = true
+
+        print("[DeepLink] ✅ Config profile '\(profile.name)' imported and applied")
     }
 
     // MARK: - Simple TCP/UDP Connect (No Auth)

--- a/OmniTAKMobile/Features/Networking/Services/DeepLinkHandler.swift
+++ b/OmniTAKMobile/Features/Networking/Services/DeepLinkHandler.swift
@@ -220,6 +220,11 @@ class DeepLinkHandler: ObservableObject {
     @Published var showEnrollmentSuccess = false
     @Published var enrolledServerName: String?
 
+    /// Non-nil while a config-profile deep link is awaiting user confirmation
+    /// (mirroring the scanner path: show ProfileImportPreviewView, apply only
+    /// on confirm). Set by processConfigProfile; cleared by confirmPendingProfile.
+    @Published var pendingDeepLinkProfile: ConfigProfile?
+
     private let csrEnrollmentService = CSREnrollmentService()
     private let urlSession: URLSession
 
@@ -324,18 +329,24 @@ class DeepLinkHandler: ObservableObject {
 
     // MARK: - Config Profile Import
 
+    /// Stage the profile for user confirmation — identical to the scanner path.
+    /// The app's root view observes `pendingDeepLinkProfile` and presents
+    /// ProfileImportPreviewView; call `confirmPendingProfile(_:confirmed:)`
+    /// from the preview's onConfirm callback.
     private func processConfigProfile(_ profile: ConfigProfile) {
-        print("[DeepLink] Importing config profile: \(profile.name)")
-        isProcessing = true
-        lastError = nil
+        print("[DeepLink] Staging config profile for confirmation: \(profile.name)")
+        pendingDeepLinkProfile = profile
+    }
 
+    /// Called by the confirmation UI (ProfileImportPreviewView's onConfirm).
+    /// If confirmed, stores and applies the profile; either way clears the pending state.
+    func confirmPendingProfile(_ profile: ConfigProfile, confirmed: Bool) {
+        pendingDeepLinkProfile = nil
+        guard confirmed else { return }
         ProfileStore.shared.addProfile(profile)
         ProfileStore.shared.apply(profile)
-
-        isProcessing = false
         enrolledServerName = profile.name
         showEnrollmentSuccess = true
-
         print("[DeepLink] ✅ Config profile '\(profile.name)' imported and applied")
     }
 

--- a/OmniTAKMobile/Features/Networking/Services/PositionBroadcastService.swift
+++ b/OmniTAKMobile/Features/Networking/Services/PositionBroadcastService.swift
@@ -261,12 +261,20 @@ class PositionBroadcastService: ObservableObject {
             lastMeshPPLISend = now
             let xmlToSend = cotXML
             Task { @MainActor in
-                guard MeshtasticManager.shared.isConnected else { return }
                 guard let event = CoTMessageParser.parsePositionUpdate(xml: xmlToSend) else {
                     print("⚠️ Mesh PPLI: failed to parse self-SA CoT XML for mesh send")
                     return
                 }
-                MeshtasticManager.shared.sendCoTOverMesh(event)
+                let frameworkKey = UserDefaults.standard.string(forKey: MeshFramework.storageKey) ?? ""
+                if #available(iOS 13.0, *),
+                   frameworkKey == MeshFramework.meshcore.rawValue,
+                   MeshCoreManager.shared.isConnected {
+                    MeshCoreManager.shared.sendCoTOverMesh(event)
+                } else if MeshtasticManager.shared.isConnected {
+                    MeshtasticManager.shared.sendCoTOverMesh(event)
+                } else {
+                    return
+                }
                 #if DEBUG
                 print("📡 Mesh PPLI: sent self-position over mesh")
                 #endif

--- a/OmniTAKMobile/Features/Profiles/Models/ConfigProfile.swift
+++ b/OmniTAKMobile/Features/Profiles/Models/ConfigProfile.swift
@@ -1,0 +1,163 @@
+//
+//  ConfigProfile.swift
+//  OmniTAKMobile
+//
+//  A shareable configuration profile that captures team/org settings.
+//  Explicitly excludes secrets: no private keys, cert passphrases, passwords.
+//  Teammates scan the QR, enroll their own cert, and set their own callsign.
+//
+
+import Foundation
+
+// MARK: - Safe Server Snapshot
+
+/// A server configuration stripped of all credential secrets.
+/// Retains enough for a teammate to know which server to connect to and
+/// initiate enrollment.  Does NOT include certificatePassword, caCertificatePassword,
+/// or the user's password — those are per-device secrets.
+struct ProfileServer: Codable, Equatable {
+    var name: String
+    var host: String
+    var port: UInt16
+    var protocolType: String   // tcp | ssl
+    var useTLS: Bool
+    var enabled: Bool
+    /// Optional enrollment pointer (server host may differ from streaming host)
+    var enrollmentPort: UInt16?
+    /// Username hint — helps auto-populate the enrollment form; no password
+    var enrollmentUsername: String?
+
+    init(from server: TAKServer) {
+        self.name = server.name
+        self.host = server.host
+        self.port = server.port
+        self.protocolType = server.protocolType
+        self.useTLS = server.useTLS
+        self.enabled = server.enabled
+        self.enrollmentPort = server.enrollmentPort
+        self.enrollmentUsername = server.username
+        // certificatePassword, caCertificatePassword, password intentionally omitted
+    }
+
+    /// Reconstruct a TAKServer from this snapshot.
+    /// The returned server has no certificates or passwords; the user must enroll.
+    func toTAKServer() -> TAKServer {
+        TAKServer(
+            name: name,
+            host: host,
+            port: port,
+            protocolType: protocolType,
+            useTLS: useTLS,
+            isDefault: false,
+            enabled: enabled,
+            certificateName: nil,
+            certificatePassword: nil,
+            caCertificateName: nil,
+            caCertificatePassword: nil,
+            allowLegacyTLS: false,
+            allowUntrustedTLS: false,
+            username: enrollmentUsername,
+            password: nil,
+            enrollmentPort: enrollmentPort
+        )
+    }
+}
+
+// MARK: - Config Profile
+
+/// A named, shareable configuration snapshot.
+/// QR payload: omnitak://profile?d=<base64url(gzip(json))>
+struct ConfigProfile: Codable, Identifiable, Equatable {
+    var id: UUID
+    var name: String
+    var createdAt: Date
+
+    // Identity template — NOT a fixed callsign; teammate fills in their own
+    var teamName: String?       // e.g. "Alpha Team"
+    var teamRole: String?       // e.g. "Team Member" / "Team Lead"
+    var teamColor: String?      // TAK team colour name e.g. "Blue"
+
+    // Server configuration (secrets stripped)
+    var servers: [ProfileServer]
+
+    // Map settings
+    var mapEngine: String?          // "cesium_3d" | "mapbox_2d"
+    var coordinateFormat: String?   // "MGRS" | "DD" | "DM" | "DMS" | "UTM" | "BNG" | "TWD97"
+    var unitSystem: String?         // "Metric" | "Imperial"
+
+    // Feature toggles
+    var mgrsGridEnabled: Bool?
+    var mgrsGridDensity: String?
+    var showMGRSLabels: Bool?
+    var breadcrumbTrailsEnabled: Bool?
+    var selfMarkerStyle: String?    // "milstd" | "bullseye"
+
+    // Drone detection
+    var remoteIdScanEnabled: Bool?
+    var gybDetectorEnabled: Bool?
+
+    // Mesh framework selection
+    var selectedMeshFramework: String?  // "meshtastic" | "meshcore" | "none"
+
+    // Version marker for forward compatibility
+    var schemaVersion: Int = 1
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        createdAt: Date = Date(),
+        teamName: String? = nil,
+        teamRole: String? = nil,
+        teamColor: String? = nil,
+        servers: [ProfileServer] = [],
+        mapEngine: String? = nil,
+        coordinateFormat: String? = nil,
+        unitSystem: String? = nil,
+        mgrsGridEnabled: Bool? = nil,
+        mgrsGridDensity: String? = nil,
+        showMGRSLabels: Bool? = nil,
+        breadcrumbTrailsEnabled: Bool? = nil,
+        selfMarkerStyle: String? = nil,
+        remoteIdScanEnabled: Bool? = nil,
+        gybDetectorEnabled: Bool? = nil,
+        selectedMeshFramework: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.createdAt = createdAt
+        self.teamName = teamName
+        self.teamRole = teamRole
+        self.teamColor = teamColor
+        self.servers = servers
+        self.mapEngine = mapEngine
+        self.coordinateFormat = coordinateFormat
+        self.unitSystem = unitSystem
+        self.mgrsGridEnabled = mgrsGridEnabled
+        self.mgrsGridDensity = mgrsGridDensity
+        self.showMGRSLabels = showMGRSLabels
+        self.breadcrumbTrailsEnabled = breadcrumbTrailsEnabled
+        self.selfMarkerStyle = selfMarkerStyle
+        self.remoteIdScanEnabled = remoteIdScanEnabled
+        self.gybDetectorEnabled = gybDetectorEnabled
+        self.selectedMeshFramework = selectedMeshFramework
+    }
+}
+
+// MARK: - Display helpers
+
+extension ConfigProfile {
+    /// One-line summary for the profile list
+    var subtitle: String {
+        var parts: [String] = []
+        if let teamName = teamName { parts.append(teamName) }
+        if !servers.isEmpty {
+            parts.append(servers.count == 1 ? "1 server" : "\(servers.count) servers")
+        }
+        return parts.isEmpty ? "No servers configured" : parts.joined(separator: " · ")
+    }
+
+    var firstServerSummary: String? {
+        guard let s = servers.first else { return nil }
+        return "\(s.host):\(s.port)"
+    }
+}

--- a/OmniTAKMobile/Features/Profiles/Models/ConfigProfile.swift
+++ b/OmniTAKMobile/Features/Profiles/Models/ConfigProfile.swift
@@ -14,7 +14,8 @@ import Foundation
 /// A server configuration stripped of all credential secrets.
 /// Retains enough for a teammate to know which server to connect to and
 /// initiate enrollment.  Does NOT include certificatePassword, caCertificatePassword,
-/// or the user's password — those are per-device secrets.
+/// the user's password, or the enrollment username — those are per-device secrets /
+/// PII (the callsign / username is unique to each operator; teammates set their own).
 struct ProfileServer: Codable, Equatable {
     var name: String
     var host: String
@@ -24,7 +25,8 @@ struct ProfileServer: Codable, Equatable {
     var enabled: Bool
     /// Optional enrollment pointer (server host may differ from streaming host)
     var enrollmentPort: UInt16?
-    /// Username hint — helps auto-populate the enrollment form; no password
+    /// Username — stored locally for UX, intentionally excluded from QR/Codable
+    /// so teammate callsigns / PII are never embedded in a shared QR code.
     var enrollmentUsername: String?
 
     init(from server: TAKServer) {
@@ -36,7 +38,39 @@ struct ProfileServer: Codable, Equatable {
         self.enabled = server.enabled
         self.enrollmentPort = server.enrollmentPort
         self.enrollmentUsername = server.username
-        // certificatePassword, caCertificatePassword, password intentionally omitted
+        // certificatePassword, caCertificatePassword, password, enrollmentUsername
+        // intentionally omitted from the serialised (Codable) form below.
+    }
+
+    // MARK: - Codable (excludes enrollmentUsername)
+
+    enum CodingKeys: String, CodingKey {
+        case name, host, port, protocolType, useTLS, enabled, enrollmentPort
+        // enrollmentUsername is intentionally absent — PII, not shared in QR
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        name         = try c.decode(String.self,  forKey: .name)
+        host         = try c.decode(String.self,  forKey: .host)
+        port         = try c.decode(UInt16.self,  forKey: .port)
+        protocolType = try c.decode(String.self,  forKey: .protocolType)
+        useTLS       = try c.decode(Bool.self,    forKey: .useTLS)
+        enabled      = try c.decode(Bool.self,    forKey: .enabled)
+        enrollmentPort     = try c.decodeIfPresent(UInt16.self, forKey: .enrollmentPort)
+        enrollmentUsername = nil  // never decoded from QR; operator enters at enrollment
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(name,         forKey: .name)
+        try c.encode(host,         forKey: .host)
+        try c.encode(port,         forKey: .port)
+        try c.encode(protocolType, forKey: .protocolType)
+        try c.encode(useTLS,       forKey: .useTLS)
+        try c.encode(enabled,      forKey: .enabled)
+        try c.encodeIfPresent(enrollmentPort, forKey: .enrollmentPort)
+        // enrollmentUsername intentionally not encoded
     }
 
     /// Reconstruct a TAKServer from this snapshot.
@@ -55,6 +89,11 @@ struct ProfileServer: Codable, Equatable {
             caCertificateName: nil,
             caCertificatePassword: nil,
             allowLegacyTLS: false,
+            // Intentional security policy (matches Android profile import behaviour):
+            // never propagate trust-disable via a shared profile — the operator's
+            // self-signed-server setting is per-device and set at enrollment time.
+            // Keeping this false-on-import is the safe default; it prevents a
+            // crafted QR from silently disabling TLS validation for a teammate.
             allowUntrustedTLS: false,
             username: enrollmentUsername,
             password: nil,

--- a/OmniTAKMobile/Features/Profiles/Services/ProfileQRCodec.swift
+++ b/OmniTAKMobile/Features/Profiles/Services/ProfileQRCodec.swift
@@ -1,0 +1,167 @@
+//
+//  ProfileQRCodec.swift
+//  OmniTAKMobile
+//
+//  QR encode/decode for ConfigProfile.
+//
+//  Payload format: omnitak://profile?d=<base64url(gzip(JSON))>
+//  Target: < ~2 KB so a standard QR scans reliably (single-block mode).
+//  Uses Foundation Compression (zlib/gzip via NS_DATA_COMPRESSION or raw deflate).
+//  Falls back to uncompressed base64url if the payload is already tiny.
+//
+
+import Foundation
+import CoreImage
+import UIKit
+
+// MARK: - Errors
+
+enum ProfileQRError: LocalizedError {
+    case encodingFailed(String)
+    case decodingFailed(String)
+    case notAProfileURL
+    case missingPayload
+    case payloadTooLarge(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .encodingFailed(let msg): return "Profile encoding failed: \(msg)"
+        case .decodingFailed(let msg): return "Profile decoding failed: \(msg)"
+        case .notAProfileURL: return "URL is not an omnitak://profile link"
+        case .missingPayload: return "QR link is missing the profile payload"
+        case .payloadTooLarge(let bytes): return "Profile payload is too large (\(bytes) bytes) for a reliable QR code"
+        }
+    }
+}
+
+// MARK: - Codec
+
+enum ProfileQRCodec {
+
+    /// Maximum URL length we'll attempt to encode.
+    /// QR version 40-L holds ~7 KB of alphanumeric, but scanning degrades
+    /// above ~2 KB on typical phone cameras in bright field conditions.
+    static let maxURLBytes = 2800
+
+    // MARK: Encode
+
+    /// Encode a ConfigProfile into an `omnitak://profile?d=...` URL string.
+    static func encode(_ profile: ConfigProfile) throws -> String {
+        let json = try JSONEncoder().encode(profile)
+        let compressed = compress(json)
+        let payload = base64URLEncode(compressed)
+        let urlString = "omnitak://profile?d=\(payload)"
+
+        let byteCount = urlString.utf8.count
+        if byteCount > maxURLBytes {
+            throw ProfileQRError.payloadTooLarge(byteCount)
+        }
+        return urlString
+    }
+
+    /// Decode an `omnitak://profile?d=...` URL string into a ConfigProfile.
+    static func decode(urlString: String) throws -> ConfigProfile {
+        guard let url = URL(string: urlString) else {
+            throw ProfileQRError.decodingFailed("Not a valid URL")
+        }
+        return try decode(url: url)
+    }
+
+    /// Decode an `omnitak://profile?d=...` URL into a ConfigProfile.
+    static func decode(url: URL) throws -> ConfigProfile {
+        let scheme = url.scheme?.lowercased() ?? ""
+        let host = url.host?.lowercased() ?? ""
+
+        guard scheme == "omnitak", host == "profile" else {
+            throw ProfileQRError.notAProfileURL
+        }
+
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let dParam = components.queryItems?.first(where: { $0.name == "d" })?.value,
+              !dParam.isEmpty else {
+            throw ProfileQRError.missingPayload
+        }
+
+        let compressed = try base64URLDecode(dParam)
+        let json: Data
+        do {
+            json = try decompress(compressed)
+        } catch {
+            // Fallback: treat as raw (uncompressed) JSON for very small payloads
+            json = compressed
+        }
+
+        do {
+            return try JSONDecoder().decode(ConfigProfile.self, from: json)
+        } catch {
+            throw ProfileQRError.decodingFailed(error.localizedDescription)
+        }
+    }
+
+    // MARK: QR Image Generation
+
+    /// Generate a UIImage containing the QR code for a profile URL.
+    /// Returns nil if CoreImage fails (e.g. in unit tests without a display).
+    static func generateQRImage(for urlString: String, size: CGFloat = 300) -> UIImage? {
+        guard let data = urlString.data(using: .isoLatin1) else { return nil }
+
+        guard let filter = CIFilter(name: "CIQRCodeGenerator") else { return nil }
+        filter.setValue(data, forKey: "inputMessage")
+        filter.setValue("M", forKey: "inputCorrectionLevel") // ~15% redundancy
+
+        guard let outputImage = filter.outputImage else { return nil }
+
+        // Scale up — raw QR output is tiny
+        let scale = size / outputImage.extent.width
+        let scaledImage = outputImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+
+        let context = CIContext()
+        guard let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) else { return nil }
+        return UIImage(cgImage: cgImage)
+    }
+
+    // MARK: - Private helpers
+
+    /// Compress data using zlib deflate (via NSData bridge available since iOS 9).
+    /// Uses NSData's `compressed(using:)` available from iOS 13+.
+    private static func compress(_ data: Data) -> Data {
+        if #available(iOS 13.0, *) {
+            return (try? (data as NSData).compressed(using: .zlib) as Data) ?? data
+        }
+        return data
+    }
+
+    /// Decompress zlib deflate data.
+    private static func decompress(_ data: Data) throws -> Data {
+        if #available(iOS 13.0, *) {
+            do {
+                return try (data as NSData).decompressed(using: .zlib) as Data
+            } catch {
+                throw ProfileQRError.decodingFailed("Decompression failed: \(error.localizedDescription)")
+            }
+        }
+        // No compression available on older OS; assume uncompressed
+        return data
+    }
+
+    /// URL-safe base64 encoding (RFC 4648 §5): replaces + with -, / with _, strips =.
+    static func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// URL-safe base64 decoding — inverse of base64URLEncode.
+    static func base64URLDecode(_ string: String) throws -> Data {
+        var padded = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let rem = padded.count % 4
+        if rem != 0 { padded += String(repeating: "=", count: 4 - rem) }
+        guard let data = Data(base64Encoded: padded) else {
+            throw ProfileQRError.decodingFailed("Invalid base64url string")
+        }
+        return data
+    }
+}

--- a/OmniTAKMobile/Features/Profiles/Services/ProfileQRCodec.swift
+++ b/OmniTAKMobile/Features/Profiles/Services/ProfileQRCodec.swift
@@ -22,6 +22,7 @@ enum ProfileQRError: LocalizedError {
     case notAProfileURL
     case missingPayload
     case payloadTooLarge(Int)
+    case decompressedPayloadTooLarge(Int)
 
     var errorDescription: String? {
         switch self {
@@ -30,6 +31,7 @@ enum ProfileQRError: LocalizedError {
         case .notAProfileURL: return "URL is not an omnitak://profile link"
         case .missingPayload: return "QR link is missing the profile payload"
         case .payloadTooLarge(let bytes): return "Profile payload is too large (\(bytes) bytes) for a reliable QR code"
+        case .decompressedPayloadTooLarge(let bytes): return "Decompressed profile payload is too large (\(bytes) bytes)"
         }
     }
 }
@@ -85,7 +87,16 @@ enum ProfileQRCodec {
         let compressed = try base64URLDecode(dParam)
         let json: Data
         do {
-            json = try decompress(compressed)
+            let decompressed = try decompress(compressed)
+            // Guard against decompression bombs: cap at 64 KiB.
+            // A realistic full profile is well under 2 KiB compressed; this is
+            // a hard safety rail, not a QR-size limit.
+            guard decompressed.count <= 65_536 else {
+                throw ProfileQRError.decompressedPayloadTooLarge(decompressed.count)
+            }
+            json = decompressed
+        } catch let qrErr as ProfileQRError {
+            throw qrErr
         } catch {
             // Fallback: treat as raw (uncompressed) JSON for very small payloads
             json = compressed
@@ -103,7 +114,10 @@ enum ProfileQRCodec {
     /// Generate a UIImage containing the QR code for a profile URL.
     /// Returns nil if CoreImage fails (e.g. in unit tests without a display).
     static func generateQRImage(for urlString: String, size: CGFloat = 300) -> UIImage? {
-        guard let data = urlString.data(using: .isoLatin1) else { return nil }
+        // Use UTF-8 so non-ASCII team names (CJK, Arabic, etc.) encode correctly.
+        // CIQRCodeGenerator accepts raw UTF-8 bytes; .isoLatin1 produces nil for
+        // any character outside the Latin-1 range, resulting in a blank QR.
+        guard let data = urlString.data(using: .utf8) else { return nil }
 
         guard let filter = CIFilter(name: "CIQRCodeGenerator") else { return nil }
         filter.setValue(data, forKey: "inputMessage")

--- a/OmniTAKMobile/Features/Profiles/Services/ProfileStore.swift
+++ b/OmniTAKMobile/Features/Profiles/Services/ProfileStore.swift
@@ -1,0 +1,172 @@
+//
+//  ProfileStore.swift
+//  OmniTAKMobile
+//
+//  Manages N config profiles.  Backed by UserDefaults ("omnitak_profiles" JSON).
+//  Provides snapshot / apply against the live UserDefaults + ServerManager stores.
+//  Does NOT re-namespace existing keys — it snapshots them and writes them back.
+//
+
+import Foundation
+import Combine
+
+// MARK: - Profile Store
+
+class ProfileStore: ObservableObject {
+    static let shared = ProfileStore()
+
+    @Published var profiles: [ConfigProfile] = []
+    @Published var activeProfileID: UUID?
+
+    private let profilesKey   = "omnitak_profiles"
+    private let activeIDKey   = "omnitak_active_profile_id"
+
+    init() {
+        load()
+    }
+
+    // MARK: - Persistence
+
+    private func load() {
+        if let data = UserDefaults.standard.data(forKey: profilesKey),
+           let decoded = try? JSONDecoder().decode([ConfigProfile].self, from: data) {
+            profiles = decoded
+        }
+        if let idStr = UserDefaults.standard.string(forKey: activeIDKey),
+           let uuid = UUID(uuidString: idStr) {
+            activeProfileID = uuid
+        }
+    }
+
+    private func save() {
+        if let data = try? JSONEncoder().encode(profiles) {
+            UserDefaults.standard.set(data, forKey: profilesKey)
+        }
+        if let id = activeProfileID {
+            UserDefaults.standard.set(id.uuidString, forKey: activeIDKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: activeIDKey)
+        }
+    }
+
+    // MARK: - Snapshot current live config
+
+    /// Reads current UserDefaults + ServerManager state → ConfigProfile (no secrets).
+    func snapshotCurrent(name: String) -> ConfigProfile {
+        let ud = UserDefaults.standard
+
+        let servers = ServerManager.shared.servers.map { ProfileServer(from: $0) }
+
+        return ConfigProfile(
+            name: name,
+            teamName: nil,   // caller can fill these in
+            teamRole: nil,
+            teamColor: nil,
+            servers: servers,
+            mapEngine: ud.string(forKey: "mapEngine"),
+            coordinateFormat: ud.string(forKey: "coordinateDisplayFormat"),
+            unitSystem: ud.string(forKey: "unitSystem"),
+            mgrsGridEnabled: ud.object(forKey: "mgrsGridEnabled") != nil
+                ? ud.bool(forKey: "mgrsGridEnabled") : nil,
+            mgrsGridDensity: ud.string(forKey: "mgrsGridDensity"),
+            showMGRSLabels: ud.object(forKey: "showMGRSLabels") != nil
+                ? ud.bool(forKey: "showMGRSLabels") : nil,
+            breadcrumbTrailsEnabled: ud.object(forKey: "breadcrumbTrailsEnabled") != nil
+                ? ud.bool(forKey: "breadcrumbTrailsEnabled") : nil,
+            selfMarkerStyle: ud.string(forKey: "selfMarkerStyle"),
+            remoteIdScanEnabled: ud.object(forKey: "remoteIdScanEnabled") != nil
+                ? ud.bool(forKey: "remoteIdScanEnabled") : nil,
+            gybDetectorEnabled: ud.object(forKey: "gybDetectorEnabled") != nil
+                ? ud.bool(forKey: "gybDetectorEnabled") : nil,
+            selectedMeshFramework: ud.string(forKey: "selectedMeshFramework")
+        )
+    }
+
+    // MARK: - Apply a profile to live stores
+
+    /// Writes a ConfigProfile's non-secret settings back to UserDefaults + ServerManager.
+    /// Callsign is intentionally NOT set — each user configures their own.
+    func apply(_ profile: ConfigProfile) {
+        let ud = UserDefaults.standard
+
+        // Map / display settings
+        if let v = profile.mapEngine            { ud.set(v, forKey: "mapEngine") }
+        if let v = profile.coordinateFormat     { ud.set(v, forKey: "coordinateDisplayFormat") }
+        if let v = profile.unitSystem           { ud.set(v, forKey: "unitSystem") }
+        if let v = profile.mgrsGridEnabled      { ud.set(v, forKey: "mgrsGridEnabled") }
+        if let v = profile.mgrsGridDensity      { ud.set(v, forKey: "mgrsGridDensity") }
+        if let v = profile.showMGRSLabels       { ud.set(v, forKey: "showMGRSLabels") }
+        if let v = profile.breadcrumbTrailsEnabled { ud.set(v, forKey: "breadcrumbTrailsEnabled") }
+        if let v = profile.selfMarkerStyle      { ud.set(v, forKey: "selfMarkerStyle") }
+        if let v = profile.remoteIdScanEnabled  { ud.set(v, forKey: "remoteIdScanEnabled") }
+        if let v = profile.gybDetectorEnabled   { ud.set(v, forKey: "gybDetectorEnabled") }
+        if let v = profile.selectedMeshFramework { ud.set(v, forKey: "selectedMeshFramework") }
+
+        // Server import: add new servers (idempotent — ServerManager deduplicates by endpoint)
+        for profileServer in profile.servers {
+            let takServer = profileServer.toTAKServer()
+            ServerManager.shared.addServer(takServer)
+        }
+
+        // Post notification so observing views (SettingsView, etc.) can react
+        NotificationCenter.default.post(name: .profileApplied, object: profile)
+    }
+
+    // MARK: - CRUD
+
+    func addProfile(_ profile: ConfigProfile) {
+        if !profiles.contains(where: { $0.id == profile.id }) {
+            profiles.append(profile)
+        }
+        save()
+    }
+
+    func saveSnapshot(name: String) -> ConfigProfile {
+        let profile = snapshotCurrent(name: name)
+        addProfile(profile)
+        return profile
+    }
+
+    func updateProfile(_ profile: ConfigProfile) {
+        if let idx = profiles.firstIndex(where: { $0.id == profile.id }) {
+            profiles[idx] = profile
+            save()
+        }
+    }
+
+    func deleteProfile(id: UUID) {
+        profiles.removeAll { $0.id == id }
+        if activeProfileID == id {
+            activeProfileID = profiles.first?.id
+        }
+        save()
+    }
+
+    func renameProfile(id: UUID, name: String) {
+        if let idx = profiles.firstIndex(where: { $0.id == id }) {
+            profiles[idx].name = name
+            save()
+        }
+    }
+
+    func setActive(id: UUID) {
+        activeProfileID = id
+        save()
+    }
+
+    var activeProfile: ConfigProfile? {
+        profiles.first { $0.id == activeProfileID }
+    }
+
+    // MARK: - QR helpers
+
+    func qrURLString(for profile: ConfigProfile) throws -> String {
+        try ProfileQRCodec.encode(profile)
+    }
+}
+
+// MARK: - Notifications
+
+extension Notification.Name {
+    static let profileApplied = Notification.Name("omnitak.profileApplied")
+}

--- a/OmniTAKMobile/Features/Profiles/Views/ProfilesView.swift
+++ b/OmniTAKMobile/Features/Profiles/Views/ProfilesView.swift
@@ -88,6 +88,7 @@ struct ProfilesView: View {
                     ProfileImportPreviewView(profile: profile) { confirmed in
                         if confirmed {
                             store.addProfile(profile)
+                            store.apply(profile)
                         }
                         importPreviewProfile = nil
                     }

--- a/OmniTAKMobile/Features/Profiles/Views/ProfilesView.swift
+++ b/OmniTAKMobile/Features/Profiles/Views/ProfilesView.swift
@@ -1,0 +1,790 @@
+//
+//  ProfilesView.swift
+//  OmniTAKMobile
+//
+//  Configuration Profiles management sheet.
+//  Launched from a "Configuration Profiles" row in SettingsView.
+//
+
+import SwiftUI
+import CoreImage
+
+// MARK: - Profiles View
+
+struct ProfilesView: View {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var store = ProfileStore.shared
+    @EnvironmentObject private var loc: LocalizationManager
+
+    @State private var showSnapshotSheet = false
+    @State private var showScannerSheet = false
+    @State private var selectedQRProfile: ConfigProfile?
+    @State private var importPreviewProfile: ConfigProfile?
+    @State private var showImportPreview = false
+    @State private var renameTarget: ConfigProfile?
+    @State private var renameText = ""
+    @State private var showRenameAlert = false
+    @State private var snapshotName = ""
+    @State private var showDeleteConfirm = false
+    @State private var deleteTarget: ConfigProfile?
+    @State private var showErrorAlert = false
+    @State private var errorMessage = ""
+
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color.black.ignoresSafeArea()
+
+                if store.profiles.isEmpty {
+                    emptyState
+                } else {
+                    profileList
+                }
+            }
+            .navigationTitle("Configuration Profiles")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Done") { dismiss() }
+                        .foregroundColor(Color(hex: "#FFFC00"))
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Menu {
+                        Button {
+                            snapshotName = "Profile \(store.profiles.count + 1)"
+                            showSnapshotSheet = true
+                        } label: {
+                            Label("Snapshot current config", systemImage: "camera.fill")
+                        }
+                        Button {
+                            showScannerSheet = true
+                        } label: {
+                            Label("Scan to import", systemImage: "qrcode.viewfinder")
+                        }
+                    } label: {
+                        Image(systemName: "plus")
+                            .foregroundColor(Color(hex: "#FFFC00"))
+                    }
+                }
+            }
+            // Snapshot name sheet
+            .sheet(isPresented: $showSnapshotSheet) {
+                snapshotNameSheet
+            }
+            // QR display sheet
+            .sheet(item: $selectedQRProfile) { profile in
+                ProfileQRDisplayView(profile: profile)
+            }
+            // Scanner sheet
+            .sheet(isPresented: $showScannerSheet) {
+                ProfileScannerView { imported in
+                    importPreviewProfile = imported
+                    showImportPreview = true
+                }
+            }
+            // Import preview sheet
+            .sheet(isPresented: $showImportPreview) {
+                if let profile = importPreviewProfile {
+                    ProfileImportPreviewView(profile: profile) { confirmed in
+                        if confirmed {
+                            store.addProfile(profile)
+                        }
+                        importPreviewProfile = nil
+                    }
+                }
+            }
+            .alert("Rename Profile", isPresented: $showRenameAlert) {
+                TextField("Name", text: $renameText)
+                Button("Save") {
+                    if let target = renameTarget, !renameText.isEmpty {
+                        store.renameProfile(id: target.id, name: renameText)
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            }
+            .alert("Delete Profile?", isPresented: $showDeleteConfirm) {
+                Button("Delete", role: .destructive) {
+                    if let target = deleteTarget {
+                        store.deleteProfile(id: target.id)
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This cannot be undone.")
+            }
+            .alert("Error", isPresented: $showErrorAlert) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(errorMessage)
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "person.3.fill")
+                .font(.system(size: 60))
+                .foregroundColor(Color(hex: "#FFFC00").opacity(0.4))
+
+            Text("No Profiles")
+                .font(.system(size: 22, weight: .bold))
+                .foregroundColor(.white)
+
+            Text("Snapshot your current config to share with teammates via QR code.")
+                .font(.system(size: 15))
+                .foregroundColor(Color(hex: "#CCCCCC"))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+
+            VStack(spacing: 12) {
+                Button {
+                    snapshotName = "Profile 1"
+                    showSnapshotSheet = true
+                } label: {
+                    Label("Snapshot current config", systemImage: "camera.fill")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.black)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(Color(hex: "#FFFC00"))
+                        .cornerRadius(12)
+                }
+
+                Button {
+                    showScannerSheet = true
+                } label: {
+                    Label("Scan to import", systemImage: "qrcode.viewfinder")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(Color(hex: "#FFFC00"))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(Color(white: 0.12))
+                        .cornerRadius(12)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color(hex: "#FFFC00").opacity(0.4), lineWidth: 1)
+                        )
+                }
+            }
+            .padding(.horizontal, 32)
+            .padding(.top, 8)
+        }
+    }
+
+    // MARK: - Profile List
+
+    private var profileList: some View {
+        List {
+            ForEach(store.profiles) { profile in
+                profileRow(profile)
+                    .listRowBackground(Color(white: 0.08))
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button(role: .destructive) {
+                            deleteTarget = profile
+                            showDeleteConfirm = true
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        Button {
+                            renameTarget = profile
+                            renameText = profile.name
+                            showRenameAlert = true
+                        } label: {
+                            Label("Rename", systemImage: "pencil")
+                        }
+                        .tint(.blue)
+                    }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .background(Color.black)
+    }
+
+    private func profileRow(_ profile: ConfigProfile) -> some View {
+        Button {
+            // Tap to show actions
+        } label: {
+            HStack(spacing: 14) {
+                // Active indicator
+                ZStack {
+                    Circle()
+                        .fill(store.activeProfileID == profile.id
+                              ? Color(hex: "#FFFC00")
+                              : Color(white: 0.2))
+                        .frame(width: 10, height: 10)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(profile.name)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.white)
+                    Text(profile.subtitle)
+                        .font(.system(size: 13))
+                        .foregroundColor(Color(hex: "#AAAAAA"))
+                }
+
+                Spacer()
+
+                // Action buttons
+                HStack(spacing: 16) {
+                    // Activate
+                    Button {
+                        store.apply(profile)
+                        store.setActive(id: profile.id)
+                    } label: {
+                        Image(systemName: store.activeProfileID == profile.id
+                              ? "checkmark.circle.fill"
+                              : "circle")
+                            .foregroundColor(store.activeProfileID == profile.id
+                                             ? Color(hex: "#FFFC00")
+                                             : Color(white: 0.4))
+                            .font(.system(size: 20))
+                    }
+                    .buttonStyle(.plain)
+
+                    // QR
+                    Button {
+                        selectedQRProfile = profile
+                    } label: {
+                        Image(systemName: "qrcode")
+                            .foregroundColor(Color(hex: "#CCCCCC"))
+                            .font(.system(size: 18))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.vertical, 6)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Snapshot name sheet
+
+    private var snapshotNameSheet: some View {
+        NavigationView {
+            ZStack {
+                Color.black.ignoresSafeArea()
+
+                VStack(spacing: 24) {
+                    Image(systemName: "camera.fill")
+                        .font(.system(size: 44))
+                        .foregroundColor(Color(hex: "#FFFC00"))
+
+                    Text("Name this profile")
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundColor(.white)
+
+                    Text("Give your team config a descriptive name (e.g. \"Alpha Team West\").")
+                        .font(.system(size: 14))
+                        .foregroundColor(Color(hex: "#CCCCCC"))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 32)
+
+                    TextField("Profile name", text: $snapshotName)
+                        .textFieldStyle(.roundedBorder)
+                        .padding(.horizontal, 32)
+
+                    Button {
+                        let profile = store.saveSnapshot(name: snapshotName.isEmpty ? "Snapshot" : snapshotName)
+                        showSnapshotSheet = false
+                        // Immediately show QR for the new profile
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                            selectedQRProfile = profile
+                        }
+                    } label: {
+                        Text("Snapshot & generate QR")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundColor(.black)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                            .background(Color(hex: "#FFFC00"))
+                            .cornerRadius(12)
+                    }
+                    .padding(.horizontal, 32)
+                    .disabled(snapshotName.isEmpty)
+                    .opacity(snapshotName.isEmpty ? 0.5 : 1.0)
+
+                    Spacer()
+                }
+                .padding(.top, 40)
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Cancel") { showSnapshotSheet = false }
+                        .foregroundColor(Color(hex: "#FFFC00"))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - QR Display View
+
+struct ProfileQRDisplayView: View {
+    @Environment(\.dismiss) private var dismiss
+    let profile: ConfigProfile
+
+    @State private var qrImage: UIImage?
+    @State private var urlString: String?
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color.black.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: 24) {
+                        // Header
+                        VStack(spacing: 8) {
+                            Image(systemName: "qrcode")
+                                .font(.system(size: 48))
+                                .foregroundColor(Color(hex: "#FFFC00"))
+
+                            Text(profile.name)
+                                .font(.system(size: 22, weight: .bold))
+                                .foregroundColor(.white)
+
+                            Text("Teammates scan this to sync your team config")
+                                .font(.system(size: 14))
+                                .foregroundColor(Color(hex: "#CCCCCC"))
+                                .multilineTextAlignment(.center)
+                        }
+                        .padding(.top, 24)
+
+                        // QR image
+                        if let qrImage = qrImage {
+                            Image(uiImage: qrImage)
+                                .interpolation(.none)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 260, height: 260)
+                                .background(Color.white)
+                                .cornerRadius(12)
+                                .padding(8)
+                                .background(Color.white)
+                                .cornerRadius(16)
+                        } else if let errorMessage = errorMessage {
+                            VStack(spacing: 12) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .font(.system(size: 32))
+                                    .foregroundColor(.orange)
+                                Text(errorMessage)
+                                    .font(.system(size: 14))
+                                    .foregroundColor(Color(hex: "#CCCCCC"))
+                                    .multilineTextAlignment(.center)
+                            }
+                            .padding()
+                        } else {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: Color(hex: "#FFFC00")))
+                                .frame(width: 260, height: 260)
+                        }
+
+                        // Profile summary
+                        VStack(alignment: .leading, spacing: 8) {
+                            profileSummaryRow("Team", value: profile.teamName)
+                            profileSummaryRow("Servers", value: profile.firstServerSummary)
+                            profileSummaryRow("Map engine", value: profile.mapEngine.flatMap { MapEngine(rawValue: $0)?.displayName })
+                            profileSummaryRow("Coordinates", value: profile.coordinateFormat)
+                            profileSummaryRow("Units", value: profile.unitSystem)
+                        }
+                        .padding(16)
+                        .background(Color(white: 0.10))
+                        .cornerRadius(12)
+                        .padding(.horizontal, 24)
+
+                        // What's NOT in the QR
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack {
+                                Image(systemName: "lock.fill")
+                                    .foregroundColor(Color(hex: "#FFFC00"))
+                                    .font(.system(size: 14))
+                                Text("What's NOT included (stays on your device):")
+                                    .font(.system(size: 13, weight: .semibold))
+                                    .foregroundColor(.white)
+                            }
+                            Text("• Client certificates and passphrases\n• Server passwords\n• Your callsign (each user sets their own)")
+                                .font(.system(size: 12))
+                                .foregroundColor(Color(hex: "#AAAAAA"))
+                        }
+                        .padding(14)
+                        .background(Color(hex: "#FFFC00").opacity(0.05))
+                        .cornerRadius(10)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color(hex: "#FFFC00").opacity(0.2), lineWidth: 1)
+                        )
+                        .padding(.horizontal, 24)
+
+                        Spacer(minLength: 32)
+                    }
+                }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .foregroundColor(Color(hex: "#FFFC00"))
+                }
+            }
+            .onAppear { generateQR() }
+        }
+    }
+
+    private func profileSummaryRow(_ label: String, value: String?) -> some View {
+        Group {
+            if let value = value {
+                HStack {
+                    Text(label)
+                        .font(.system(size: 13))
+                        .foregroundColor(Color(hex: "#AAAAAA"))
+                    Spacer()
+                    Text(value)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.white)
+                }
+            } else {
+                EmptyView()
+            }
+        }
+    }
+
+    private func generateQR() {
+        do {
+            let url = try ProfileQRCodec.encode(profile)
+            urlString = url
+            qrImage = ProfileQRCodec.generateQRImage(for: url, size: 260)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Import Preview View
+
+struct ProfileImportPreviewView: View {
+    @Environment(\.dismiss) private var dismiss
+    let profile: ConfigProfile
+    var onConfirm: (Bool) -> Void
+
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color.black.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: 20) {
+                        Image(systemName: "arrow.down.circle.fill")
+                            .font(.system(size: 52))
+                            .foregroundColor(Color(hex: "#FFFC00"))
+                            .padding(.top, 32)
+
+                        Text("Import Profile?")
+                            .font(.system(size: 22, weight: .bold))
+                            .foregroundColor(.white)
+
+                        Text("\"\(profile.name)\"")
+                            .font(.system(size: 16))
+                            .foregroundColor(Color(hex: "#CCCCCC"))
+
+                        // Summary
+                        VStack(alignment: .leading, spacing: 10) {
+                            importRow("Profile name", value: profile.name)
+                            importRow("Team", value: profile.teamName)
+                            importRow("Role template", value: profile.teamRole)
+
+                            if !profile.servers.isEmpty {
+                                Divider().background(Color(white: 0.2))
+                                Text("Servers to add")
+                                    .font(.system(size: 12, weight: .semibold))
+                                    .foregroundColor(Color(hex: "#AAAAAA"))
+                                ForEach(profile.servers, id: \.host) { s in
+                                    HStack {
+                                        Image(systemName: "antenna.radiowaves.left.and.right")
+                                            .font(.system(size: 12))
+                                            .foregroundColor(.green)
+                                        Text("\(s.name)  (\(s.host):\(s.port))")
+                                            .font(.system(size: 13))
+                                            .foregroundColor(.white)
+                                    }
+                                }
+                            }
+
+                            Divider().background(Color(white: 0.2))
+                            importRow("Map engine", value: profile.mapEngine.flatMap { MapEngine(rawValue: $0)?.displayName })
+                            importRow("Coordinates", value: profile.coordinateFormat)
+                            importRow("Units", value: profile.unitSystem)
+                        }
+                        .padding(16)
+                        .background(Color(white: 0.10))
+                        .cornerRadius(12)
+                        .padding(.horizontal, 24)
+
+                        // Warning
+                        VStack(alignment: .leading, spacing: 6) {
+                            Label("Your callsign will NOT be changed.", systemImage: "info.circle")
+                                .font(.system(size: 13))
+                                .foregroundColor(Color(hex: "#FFFC00"))
+                            Text("You will need to enroll your own certificate after import.")
+                                .font(.system(size: 12))
+                                .foregroundColor(Color(hex: "#AAAAAA"))
+                        }
+                        .padding(12)
+                        .background(Color(hex: "#FFFC00").opacity(0.05))
+                        .cornerRadius(10)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color(hex: "#FFFC00").opacity(0.2), lineWidth: 1)
+                        )
+                        .padding(.horizontal, 24)
+
+                        // Buttons
+                        VStack(spacing: 12) {
+                            Button {
+                                onConfirm(true)
+                                dismiss()
+                            } label: {
+                                Text("Import & Apply")
+                                    .font(.system(size: 17, weight: .semibold))
+                                    .foregroundColor(.black)
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 14)
+                                    .background(Color(hex: "#FFFC00"))
+                                    .cornerRadius(12)
+                            }
+
+                            Button {
+                                onConfirm(false)
+                                dismiss()
+                            } label: {
+                                Text("Cancel")
+                                    .font(.system(size: 17))
+                                    .foregroundColor(Color(hex: "#FFFC00"))
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 14)
+                                    .background(Color(white: 0.12))
+                                    .cornerRadius(12)
+                            }
+                        }
+                        .padding(.horizontal, 24)
+
+                        Spacer(minLength: 32)
+                    }
+                }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private func importRow(_ label: String, value: String?) -> some View {
+        Group {
+            if let value = value {
+                HStack {
+                    Text(label)
+                        .font(.system(size: 13))
+                        .foregroundColor(Color(hex: "#AAAAAA"))
+                    Spacer()
+                    Text(value)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.white)
+                }
+            } else {
+                EmptyView()
+            }
+        }
+    }
+}
+
+// MARK: - Profile Scanner View
+
+struct ProfileScannerView: View {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var qrScanner = QRScannerViewModel()
+    var onProfileScanned: (ConfigProfile) -> Void
+
+    @State private var showError = false
+    @State private var errorMessage = ""
+    @State private var manualURLText = ""
+    @State private var showManualEntry = false
+
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color.black.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    // Header
+                    VStack(spacing: 12) {
+                        Image(systemName: "qrcode.viewfinder")
+                            .font(.system(size: 48))
+                            .foregroundColor(Color(hex: "#FFFC00"))
+
+                        Text("Scan Team Config QR")
+                            .font(.system(size: 22, weight: .bold))
+                            .foregroundColor(.white)
+
+                        Text("Ask your team captain to show the profile QR code")
+                            .font(.system(size: 14))
+                            .foregroundColor(Color(hex: "#CCCCCC"))
+                    }
+                    .padding(.vertical, 20)
+
+                    if showManualEntry {
+                        manualEntryView
+                    } else {
+                        cameraPreview
+                    }
+
+                    Spacer()
+
+                    // Toggle
+                    Button {
+                        withAnimation { showManualEntry.toggle() }
+                        if !showManualEntry {
+                            qrScanner.checkPermissions()
+                        } else {
+                            qrScanner.stopScanning()
+                        }
+                    } label: {
+                        HStack {
+                            Image(systemName: showManualEntry ? "qrcode.viewfinder" : "keyboard")
+                            Text(showManualEntry ? "Use Camera" : "Paste URL manually")
+                        }
+                        .foregroundColor(Color(hex: "#FFFC00"))
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 24)
+                        .background(Color(white: 0.12))
+                        .cornerRadius(8)
+                    }
+                    .padding(.bottom, 32)
+                }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        qrScanner.stopScanning()
+                        dismiss()
+                    }
+                    .foregroundColor(Color(hex: "#FFFC00"))
+                }
+            }
+            .alert("Invalid QR Code", isPresented: $showError) {
+                Button("OK", role: .cancel) {
+                    qrScanner.startScanning()
+                }
+            } message: {
+                Text(errorMessage)
+            }
+            .onDisappear { qrScanner.stopScanning() }
+        }
+    }
+
+    private var cameraPreview: some View {
+        ZStack {
+            if qrScanner.isAuthorized && !qrScanner.hasCameraError && !qrScanner.isInitializing {
+                QRScannerPreview(session: qrScanner.captureSession)
+                    .frame(height: 280)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(Color(hex: "#FFFC00"), lineWidth: 2)
+                    )
+            } else {
+                VStack(spacing: 12) {
+                    Image(systemName: "camera.fill")
+                        .font(.system(size: 36))
+                        .foregroundColor(Color(hex: "#CCCCCC"))
+                    Text(qrScanner.statusMessage)
+                        .font(.system(size: 13))
+                        .foregroundColor(Color(hex: "#CCCCCC"))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 16)
+                }
+                .frame(height: 280)
+                .frame(maxWidth: .infinity)
+                .background(Color(white: 0.12))
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+        }
+        .padding(.horizontal, 24)
+        .onAppear {
+            qrScanner.onQRCodeScanned = { code in
+                handleScannedCode(code)
+            }
+            qrScanner.checkPermissions()
+        }
+    }
+
+    private var manualEntryView: some View {
+        VStack(spacing: 16) {
+            Text("Paste the omnitak://profile?d=… URL")
+                .font(.system(size: 13))
+                .foregroundColor(Color(hex: "#AAAAAA"))
+
+            TextEditor(text: $manualURLText)
+                .frame(height: 100)
+                .padding(8)
+                .background(Color(white: 0.12))
+                .cornerRadius(8)
+                .foregroundColor(.white)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color(white: 0.25), lineWidth: 1)
+                )
+
+            Button {
+                handleScannedCode(manualURLText.trimmingCharacters(in: .whitespacesAndNewlines))
+            } label: {
+                Text("Import")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(.black)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(Color(hex: "#FFFC00"))
+                    .cornerRadius(10)
+            }
+            .disabled(manualURLText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .opacity(manualURLText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? 0.5 : 1.0)
+        }
+        .padding(.horizontal, 24)
+    }
+
+    private func handleScannedCode(_ code: String) {
+        qrScanner.stopScanning()
+
+        // Must be an omnitak://profile URL
+        guard code.lowercased().hasPrefix("omnitak://profile") else {
+            // Not a profile QR — ignore silently and restart scanner
+            qrScanner.startScanning()
+            return
+        }
+
+        do {
+            let profile = try ProfileQRCodec.decode(urlString: code)
+            DispatchQueue.main.async {
+                onProfileScanned(profile)
+                dismiss()
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+            showError = true
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct ProfilesView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfilesView()
+            .environmentObject(LocalizationManager.shared)
+            .preferredColorScheme(.dark)
+    }
+}
+#endif

--- a/OmniTAKMobile/Features/Settings/Views/SettingsView.swift
+++ b/OmniTAKMobile/Features/Settings/Views/SettingsView.swift
@@ -38,6 +38,9 @@ struct SettingsView: View {
     @State private var showServersSheet = false
     @State private var showMissionCreationSheet = false
     @State private var showGybSheet = false
+    @State private var showProfilesSheet = false
+
+    @ObservedObject private var profileStore = ProfileStore.shared
 
     var body: some View {
         NavigationView {
@@ -55,6 +58,37 @@ struct SettingsView: View {
                                 PositionBroadcastService.shared.userCallsign = newValue
                                 ChatManager.shared.currentUserCallsign = newValue
                             }
+                    }
+                }
+
+                // Configuration Profiles — above Servers so "scan to join" is the first action
+                Section("Configuration Profiles") {
+                    Button(action: { showProfilesSheet = true }) {
+                        HStack {
+                            Image(systemName: "person.3.fill")
+                                .foregroundColor(Color(hex: "#FFFC00"))
+                                .frame(width: 24)
+
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Manage Profiles")
+                                    .foregroundColor(.primary)
+                                if let active = profileStore.activeProfile {
+                                    Text("Active: \(active.name)")
+                                        .font(.system(size: 12))
+                                        .foregroundColor(.gray)
+                                } else {
+                                    Text("Snap & share config via QR")
+                                        .font(.system(size: 12))
+                                        .foregroundColor(.gray)
+                                }
+                            }
+
+                            Spacer()
+
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 14))
+                                .foregroundColor(.gray)
+                        }
                     }
                 }
 
@@ -345,6 +379,10 @@ struct SettingsView: View {
                         dismiss()
                     }
                 }
+            }
+            .sheet(isPresented: $showProfilesSheet) {
+                ProfilesView()
+                    .environmentObject(loc)
             }
             .sheet(isPresented: $showServersSheet) {
                 ServersView()

--- a/OmniTAKMobileTests/ConfigProfileTests.swift
+++ b/OmniTAKMobileTests/ConfigProfileTests.swift
@@ -1,0 +1,312 @@
+//
+//  ConfigProfileTests.swift
+//  OmniTAKMobileTests
+//
+//  Unit tests for:
+//  - ConfigProfile Codable round-trip
+//  - ProfileQRCodec encode/decode round-trip
+//  - base64url helpers
+//  - Error paths
+//
+
+import XCTest
+@testable import OmniTAK
+
+class ConfigProfileTests: XCTestCase {
+
+    // MARK: - ConfigProfile Codable round-trip
+
+    func testConfigProfileCodableRoundTrip() throws {
+        let original = ConfigProfile(
+            id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            name: "Alpha Team West",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            teamName: "Alpha Team",
+            teamRole: "Team Lead",
+            teamColor: "Blue",
+            servers: [
+                ProfileServer(from: TAKServer(
+                    name: "HQ Server",
+                    host: "tak.example.mil",
+                    port: 8089,
+                    protocolType: "ssl",
+                    useTLS: true
+                ))
+            ],
+            mapEngine: "cesium_3d",
+            coordinateFormat: "MGRS",
+            unitSystem: "Metric",
+            mgrsGridEnabled: true,
+            mgrsGridDensity: "1km",
+            showMGRSLabels: true,
+            breadcrumbTrailsEnabled: false,
+            selfMarkerStyle: "milstd",
+            remoteIdScanEnabled: true,
+            gybDetectorEnabled: false,
+            selectedMeshFramework: "meshtastic"
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ConfigProfile.self, from: data)
+
+        XCTAssertEqual(decoded.id, original.id)
+        XCTAssertEqual(decoded.name, original.name)
+        XCTAssertEqual(decoded.teamName, original.teamName)
+        XCTAssertEqual(decoded.teamRole, original.teamRole)
+        XCTAssertEqual(decoded.teamColor, original.teamColor)
+        XCTAssertEqual(decoded.mapEngine, original.mapEngine)
+        XCTAssertEqual(decoded.coordinateFormat, original.coordinateFormat)
+        XCTAssertEqual(decoded.unitSystem, original.unitSystem)
+        XCTAssertEqual(decoded.mgrsGridEnabled, original.mgrsGridEnabled)
+        XCTAssertEqual(decoded.mgrsGridDensity, original.mgrsGridDensity)
+        XCTAssertEqual(decoded.showMGRSLabels, original.showMGRSLabels)
+        XCTAssertEqual(decoded.breadcrumbTrailsEnabled, original.breadcrumbTrailsEnabled)
+        XCTAssertEqual(decoded.selfMarkerStyle, original.selfMarkerStyle)
+        XCTAssertEqual(decoded.remoteIdScanEnabled, original.remoteIdScanEnabled)
+        XCTAssertEqual(decoded.gybDetectorEnabled, original.gybDetectorEnabled)
+        XCTAssertEqual(decoded.selectedMeshFramework, original.selectedMeshFramework)
+        XCTAssertEqual(decoded.schemaVersion, 1)
+    }
+
+    func testConfigProfileNilFieldsCodable() throws {
+        // All optional fields nil — still round-trips cleanly
+        let sparse = ConfigProfile(name: "Sparse")
+        let data = try JSONEncoder().encode(sparse)
+        let decoded = try JSONDecoder().decode(ConfigProfile.self, from: data)
+        XCTAssertEqual(decoded.name, "Sparse")
+        XCTAssertNil(decoded.teamName)
+        XCTAssertNil(decoded.mapEngine)
+        XCTAssertTrue(decoded.servers.isEmpty)
+    }
+
+    func testProfileServerStripsSecrets() {
+        let serverWithSecrets = TAKServer(
+            name: "Secure Server",
+            host: "secure.tak.mil",
+            port: 8089,
+            protocolType: "ssl",
+            useTLS: true,
+            isDefault: false,
+            enabled: true,
+            certificateName: "my-cert",
+            certificatePassword: "secret123",
+            caCertificateName: "my-ca",
+            caCertificatePassword: "casecret",
+            allowLegacyTLS: false,
+            allowUntrustedTLS: false,
+            username: "operator",
+            password: "password123",
+            enrollmentPort: 8446
+        )
+
+        let snapshot = ProfileServer(from: serverWithSecrets)
+
+        // Secrets must NOT be present
+        XCTAssertEqual(snapshot.host, "secure.tak.mil")
+        XCTAssertEqual(snapshot.port, 8089)
+        XCTAssertEqual(snapshot.enrollmentPort, 8446)
+        XCTAssertEqual(snapshot.enrollmentUsername, "operator")
+
+        // When converted back, passwords are nil
+        let restored = snapshot.toTAKServer()
+        XCTAssertNil(restored.certificatePassword, "Certificate password must not survive snapshot")
+        XCTAssertNil(restored.caCertificatePassword, "CA cert password must not survive snapshot")
+        XCTAssertNil(restored.password, "User password must not survive snapshot")
+        XCTAssertNil(restored.certificateName, "Certificate name must not survive snapshot (enrollment needed)")
+    }
+
+    // MARK: - ProfileQRCodec base64url helpers
+
+    func testBase64URLEncodeDecodeRoundTrip() throws {
+        let original = Data("Hello, OmniTAK! +/= special chars 🗺".utf8)
+        let encoded = ProfileQRCodec.base64URLEncode(original)
+
+        // Must not contain standard base64 special chars
+        XCTAssertFalse(encoded.contains("+"), "base64url must not contain +")
+        XCTAssertFalse(encoded.contains("/"), "base64url must not contain /")
+        XCTAssertFalse(encoded.contains("="), "base64url must not contain = padding")
+
+        let decoded = try ProfileQRCodec.base64URLDecode(encoded)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testBase64URLDecodePaddingVariants() throws {
+        // Verify we handle 0, 1, 2 missing padding chars (lengths mod 4: 0, 3, 2)
+        let cases: [String] = [
+            "YQ",     // "a" — needs 2 padding chars
+            "YWI",    // "ab" — needs 1 padding char
+            "YWJj",   // "abc" — no padding needed
+        ]
+        let expected = ["a", "ab", "abc"]
+        for (input, exp) in zip(cases, expected) {
+            let data = try ProfileQRCodec.base64URLDecode(input)
+            XCTAssertEqual(String(data: data, encoding: .utf8), exp, "Failed for input: \(input)")
+        }
+    }
+
+    // MARK: - QR URL encode / decode round-trip
+
+    func testQREncodeDecodeRoundTrip() throws {
+        let profile = ConfigProfile(
+            name: "Bravo Squad",
+            teamName: "Bravo",
+            teamRole: "Team Member",
+            servers: [
+                ProfileServer(from: TAKServer(
+                    name: "Field Server",
+                    host: "field.tak.example.com",
+                    port: 8088,
+                    protocolType: "tcp",
+                    useTLS: false
+                ))
+            ],
+            mapEngine: "mapbox_2d",
+            coordinateFormat: "DD",
+            unitSystem: "Imperial"
+        )
+
+        let urlString = try ProfileQRCodec.encode(profile)
+
+        // Check URL format
+        XCTAssertTrue(urlString.hasPrefix("omnitak://profile?d="), "URL must start with omnitak://profile?d=")
+
+        // Check payload size (must be < 2800 chars for reliable QR scanning)
+        XCTAssertLessThanOrEqual(urlString.utf8.count, 2800, "Profile URL must fit in a scannable QR code")
+
+        // Decode back
+        let decoded = try ProfileQRCodec.decode(urlString: urlString)
+
+        XCTAssertEqual(decoded.name, profile.name)
+        XCTAssertEqual(decoded.teamName, profile.teamName)
+        XCTAssertEqual(decoded.teamRole, profile.teamRole)
+        XCTAssertEqual(decoded.mapEngine, profile.mapEngine)
+        XCTAssertEqual(decoded.coordinateFormat, profile.coordinateFormat)
+        XCTAssertEqual(decoded.unitSystem, profile.unitSystem)
+        XCTAssertEqual(decoded.servers.count, 1)
+        XCTAssertEqual(decoded.servers.first?.host, "field.tak.example.com")
+        XCTAssertEqual(decoded.servers.first?.port, 8088)
+    }
+
+    func testQRDecodeFromURL() throws {
+        let profile = ConfigProfile(name: "QR URL Test", coordinateFormat: "MGRS")
+        let urlString = try ProfileQRCodec.encode(profile)
+        let url = URL(string: urlString)!
+
+        let decoded = try ProfileQRCodec.decode(url: url)
+        XCTAssertEqual(decoded.name, "QR URL Test")
+        XCTAssertEqual(decoded.coordinateFormat, "MGRS")
+    }
+
+    func testDecodeRejectsNonProfileURL() {
+        let nonProfileURL = URL(string: "omnitak://enroll?host=server.com")!
+        XCTAssertThrowsError(try ProfileQRCodec.decode(url: nonProfileURL)) { error in
+            guard case ProfileQRError.notAProfileURL = error else {
+                return XCTFail("Expected notAProfileURL, got: \(error)")
+            }
+        }
+    }
+
+    func testDecodeRejectsMissingPayload() {
+        let noPayloadURL = URL(string: "omnitak://profile")!
+        XCTAssertThrowsError(try ProfileQRCodec.decode(url: noPayloadURL)) { error in
+            guard case ProfileQRError.missingPayload = error else {
+                return XCTFail("Expected missingPayload, got: \(error)")
+            }
+        }
+    }
+
+    func testDecodeRejectsCorruptPayload() {
+        let corruptURL = URL(string: "omnitak://profile?d=not-valid-base64url!!")!
+        XCTAssertThrowsError(try ProfileQRCodec.decode(url: corruptURL))
+    }
+
+    func testLargeProfileStillFitsQR() throws {
+        // Simulate a realistic captain profile: 3 servers, all toggles set
+        var servers: [ProfileServer] = []
+        for i in 0..<3 {
+            servers.append(ProfileServer(from: TAKServer(
+                name: "Server \(i)",
+                host: "tak-server-\(i).example.mil",
+                port: UInt16(8087 + i),
+                protocolType: "ssl",
+                useTLS: true
+            )))
+        }
+
+        let profile = ConfigProfile(
+            name: "Operations Center — Full Config",
+            teamName: "Echo Team",
+            teamRole: "Team Lead",
+            teamColor: "Red",
+            servers: servers,
+            mapEngine: "cesium_3d",
+            coordinateFormat: "MGRS",
+            unitSystem: "Metric",
+            mgrsGridEnabled: true,
+            mgrsGridDensity: "1km",
+            showMGRSLabels: true,
+            breadcrumbTrailsEnabled: true,
+            selfMarkerStyle: "milstd",
+            remoteIdScanEnabled: true,
+            gybDetectorEnabled: false,
+            selectedMeshFramework: "meshtastic"
+        )
+
+        let urlString = try ProfileQRCodec.encode(profile)
+        XCTAssertLessThanOrEqual(urlString.utf8.count, 2800,
+            "Full realistic profile (\(urlString.utf8.count) bytes) exceeds QR size budget")
+
+        // And verify it round-trips
+        let decoded = try ProfileQRCodec.decode(urlString: urlString)
+        XCTAssertEqual(decoded.servers.count, 3)
+        XCTAssertEqual(decoded.name, profile.name)
+    }
+
+    // MARK: - DeepLink parsing
+
+    func testDeepLinkParserRecognizesProfileURL() throws {
+        let profile = ConfigProfile(name: "DeepLink Test", coordinateFormat: "DD")
+        let urlString = try ProfileQRCodec.encode(profile)
+        let url = URL(string: urlString)!
+
+        let result = TAKDeepLink.parse(url: url)
+        switch result {
+        case .configProfile(let parsed):
+            XCTAssertEqual(parsed.name, "DeepLink Test")
+            XCTAssertEqual(parsed.coordinateFormat, "DD")
+        default:
+            XCTFail("Expected .configProfile, got: \(String(describing: result))")
+        }
+    }
+
+    func testDeepLinkParserIgnoresOtherSchemes() {
+        let url = URL(string: "https://example.com/profile")!
+        let result = TAKDeepLink.parse(url: url)
+        XCTAssertNil(result, "Non-omnitak:// URL should not parse as deep link")
+    }
+
+    // MARK: - ProfileStore (non-disk)
+
+    func testProfileStoreSnapshotDoesNotIncludeCallsign() {
+        // Snapshot should capture server config but NOT callsign
+        let store = ProfileStore()
+        let profile = store.snapshotCurrent(name: "Test Snapshot")
+        // callsign is intentionally absent from ConfigProfile
+        // — there is no `callsign` property on ConfigProfile
+        XCTAssertNil(profile.teamName, "teamName is nil from a bare snapshot (caller fills it in)")
+    }
+
+    func testProfileStoreCRUD() {
+        let store = ProfileStore()
+        let profile = ConfigProfile(name: "Test Profile", coordinateFormat: "DMS")
+        store.addProfile(profile)
+
+        XCTAssertTrue(store.profiles.contains { $0.id == profile.id })
+
+        store.renameProfile(id: profile.id, name: "Renamed Profile")
+        XCTAssertEqual(store.profiles.first { $0.id == profile.id }?.name, "Renamed Profile")
+
+        store.deleteProfile(id: profile.id)
+        XCTAssertFalse(store.profiles.contains { $0.id == profile.id })
+    }
+}

--- a/OmniTAKMobileTests/ConfigProfileTests.swift
+++ b/OmniTAKMobileTests/ConfigProfileTests.swift
@@ -105,7 +105,18 @@ class ConfigProfileTests: XCTestCase {
         XCTAssertEqual(snapshot.host, "secure.tak.mil")
         XCTAssertEqual(snapshot.port, 8089)
         XCTAssertEqual(snapshot.enrollmentPort, 8446)
-        XCTAssertEqual(snapshot.enrollmentUsername, "operator")
+        // enrollmentUsername is stored locally in the struct but excluded from
+        // Codable / QR serialisation (fix #9 — PII not shared in QR).
+        // The raw field still carries the value for local UX use.
+        XCTAssertEqual(snapshot.enrollmentUsername, "operator",
+            "enrollmentUsername is available locally before serialisation")
+
+        // After a round-trip through JSON (as would happen in a QR code),
+        // enrollmentUsername must be nil — it is excluded from CodingKeys.
+        let data = try! JSONEncoder().encode(snapshot)
+        let roundTripped = try! JSONDecoder().decode(ProfileServer.self, from: data)
+        XCTAssertNil(roundTripped.enrollmentUsername,
+            "enrollmentUsername must be nil after JSON round-trip (excluded from CodingKeys)")
 
         // When converted back, passwords are nil
         let restored = snapshot.toTAKServer()
@@ -308,5 +319,117 @@ class ConfigProfileTests: XCTestCase {
 
         store.deleteProfile(id: profile.id)
         XCTAssertFalse(store.profiles.contains { $0.id == profile.id })
+    }
+
+    // MARK: - Fix #5: Decompression bomb guard
+
+    func testDecompressionBombIsRejected() throws {
+        // Craft a URL whose decompressed payload exceeds 65 536 bytes.
+        // Strategy: create a large-but-compressible JSON blob, compress it,
+        // base64url-encode it, stuff it into the URL, and verify decode throws.
+        // We hand-craft the URL rather than going through encode() since encode()
+        // enforces the 2800-byte compressed limit (correct behaviour).
+        let bigString = String(repeating: "A", count: 100_000)
+        let bigData   = bigString.data(using: .utf8)!
+        let compressed: Data
+        if #available(iOS 13.0, *) {
+            compressed = (try? (bigData as NSData).compressed(using: .zlib) as Data) ?? bigData
+        } else {
+            // On pre-13 the fallback path returns uncompressed; skip on very old OS.
+            return
+        }
+        let payload    = ProfileQRCodec.base64URLEncode(compressed)
+        let urlString  = "omnitak://profile?d=\(payload)"
+
+        XCTAssertThrowsError(try ProfileQRCodec.decode(urlString: urlString)) { error in
+            guard case ProfileQRError.decompressedPayloadTooLarge = error else {
+                return XCTFail("Expected .decompressedPayloadTooLarge, got: \(error)")
+            }
+        }
+    }
+
+    // MARK: - Fix #9 / Fix #11: enrollmentUsername excluded; no secrets in QR
+
+    func testEnrollmentUsernameNotInQRPayload() throws {
+        let server = TAKServer(
+            name: "HQ",
+            host: "tak.mil",
+            port: 8089,
+            protocolType: "ssl",
+            useTLS: true,
+            isDefault: false,
+            enabled: true,
+            certificateName: nil,
+            certificatePassword: nil,
+            caCertificateName: nil,
+            caCertificatePassword: nil,
+            allowLegacyTLS: false,
+            allowUntrustedTLS: false,
+            username: "jdoe",
+            password: nil,
+            enrollmentPort: 8446
+        )
+        let profile  = ConfigProfile(
+            name: "No-PII Test",
+            servers: [ProfileServer(from: server)]
+        )
+        let urlString = try ProfileQRCodec.encode(profile)
+
+        // The QR URL must not contain the username / callsign in plain text
+        XCTAssertFalse(urlString.contains("jdoe"),
+            "QR URL must not contain the enrollmentUsername in plain text")
+
+        // Decode and verify enrollmentUsername was stripped
+        let decoded = try ProfileQRCodec.decode(urlString: urlString)
+        XCTAssertNil(decoded.servers.first?.enrollmentUsername,
+            "enrollmentUsername must be nil after QR round-trip")
+    }
+
+    // MARK: - Fix #11: No-secrets regression test
+
+    func testSnapshotContainsNoPasswords() throws {
+        // Build a profile that mimics a server with cert + CA passwords.
+        let serverWithSecrets = TAKServer(
+            name: "Secure HQ",
+            host: "sec.tak.mil",
+            port: 8089,
+            protocolType: "ssl",
+            useTLS: true,
+            isDefault: false,
+            enabled: true,
+            certificateName: "my-cert",
+            certificatePassword: "supersecret",
+            caCertificateName: "my-ca",
+            caCertificatePassword: "casecret",
+            allowLegacyTLS: false,
+            allowUntrustedTLS: false,
+            username: "operator99",
+            password: "hunter2",
+            enrollmentPort: 8446
+        )
+        let profile = ConfigProfile(
+            name: "Secrets Test",
+            servers: [ProfileServer(from: serverWithSecrets)]
+        )
+
+        // 1. JSON serialisation must not contain any secret strings
+        let json = try JSONEncoder().encode(profile)
+        let jsonStr = String(data: json, encoding: .utf8) ?? ""
+        for secret in ["supersecret", "casecret", "hunter2", "operator99"] {
+            XCTAssertFalse(jsonStr.contains(secret),
+                "Serialised profile must not contain secret: \(secret)")
+        }
+
+        // 2. QR URL must not contain any secret strings
+        let urlString = try ProfileQRCodec.encode(profile)
+        // Check in plain text (the payload is base64url-encoded; secrets would not appear
+        // literally, but confirming the decoded form matches is the rigorous check).
+        let decoded = try ProfileQRCodec.decode(urlString: urlString)
+        XCTAssertNil(decoded.servers.first?.enrollmentUsername, "Username must be nil after QR round-trip")
+        // Verify toTAKServer() produced no passwords
+        let restored = decoded.servers.first!.toTAKServer()
+        XCTAssertNil(restored.password)
+        XCTAssertNil(restored.certificatePassword)
+        XCTAssertNil(restored.caCertificatePassword)
     }
 }

--- a/OmniTAKMobileTests/MeshCoreFrameCodecTests.swift
+++ b/OmniTAKMobileTests/MeshCoreFrameCodecTests.swift
@@ -1,0 +1,296 @@
+//
+//  MeshCoreFrameCodecTests.swift
+//  OmniTAKMobileTests
+//
+//  Round-trip + layout tests for the MeshCore companion frame codec. The byte
+//  layouts mirror MeshCore-1.4.8 BtConnectionManager.java (command/response
+//  codes, little-endian multibyte fields). Frames here are built to that spec;
+//  on-radio validation against a live MeshCore companion node is a follow-up
+//  (Fable / Heltec V3).
+//
+
+import XCTest
+@testable import OmniTAK
+
+final class MeshCoreFrameCodecTests: XCTestCase {
+
+    // MARK: - Encoders
+
+    func testEncodeAppStartLayout() {
+        let frame = MeshCoreFrameCodec.encodeAppStart(appId: "meshcore-flutter")
+        // [0x01][7 x 0x00][appId]
+        XCTAssertEqual(frame.first, 0x01)
+        XCTAssertEqual(frame.count, 8 + "meshcore-flutter".utf8.count)
+        // bytes 1..7 reserved zero
+        for i in 1..<8 { XCTAssertEqual(frame[i], 0x00, "reserved byte \(i) must be 0") }
+        let appId = String(data: frame.subdata(in: 8..<frame.count), encoding: .utf8)
+        XCTAssertEqual(appId, "meshcore-flutter")
+    }
+
+    func testEncodeDeviceQuery() {
+        XCTAssertEqual(Array(MeshCoreFrameCodec.encodeDeviceQuery()), [0x16, 0x03])
+    }
+
+    func testEncodeSingleByteCommands() {
+        XCTAssertEqual(Array(MeshCoreFrameCodec.encodeGetNextMessage()), [0x0A])
+        XCTAssertEqual(Array(MeshCoreFrameCodec.encodeGetBattery()), [0x14])
+        XCTAssertEqual(Array(MeshCoreFrameCodec.encodeSendSelfAdvert()), [0x07])
+    }
+
+    func testEncodeSetAdvertLatLonLayout() {
+        // 47.6062, -122.3321 (Seattle) → E6 little-endian.
+        guard let frame = MeshCoreFrameCodec.encodeSetAdvertLatLon(
+            latitude: 47.6062, longitude: -122.3321, altitudeMeters: 0) else {
+            return XCTFail("encodeSetAdvertLatLon returned nil for valid coords")
+        }
+        XCTAssertEqual(frame.count, 13)            // [0x0E] + 3 x int32
+        XCTAssertEqual(frame.first, 0x0E)
+        let latE6 = frame.int32LE(at: 1)
+        let lonE6 = frame.int32LE(at: 5)
+        let alt   = frame.int32LE(at: 9)
+        XCTAssertEqual(latE6, Int32((47.6062 * 1_000_000).rounded()))
+        XCTAssertEqual(lonE6, Int32((-122.3321 * 1_000_000).rounded()))
+        XCTAssertEqual(alt, 0)
+    }
+
+    func testEncodeSetAdvertLatLonRejectsOutOfRange() {
+        XCTAssertNil(MeshCoreFrameCodec.encodeSetAdvertLatLon(latitude: 91, longitude: 0))
+        XCTAssertNil(MeshCoreFrameCodec.encodeSetAdvertLatLon(latitude: 0, longitude: 181))
+        XCTAssertNil(MeshCoreFrameCodec.encodeSetAdvertLatLon(latitude: .nan, longitude: 0))
+    }
+
+    func testEncodeSendTextMessageLayout() {
+        let pubKey = String(repeating: "ab", count: 32) // 64 hex chars
+        let when = Date(timeIntervalSince1970: 1_700_000_000)
+        guard let frame = MeshCoreFrameCodec.encodeSendTextMessage(
+            pubKeyHex: pubKey, text: "ping", timestamp: when) else {
+            return XCTFail("encodeSendTextMessage returned nil")
+        }
+        // [0x02][txtType 0x00][attempt 0x00][ts u32 LE][prefix 6][msg]
+        XCTAssertEqual(frame[0], 0x02)
+        XCTAssertEqual(frame[1], 0x00)
+        XCTAssertEqual(frame[2], 0x00)
+        XCTAssertEqual(frame.uint32LE(at: 3), UInt32(1_700_000_000))
+        // pubkey prefix = first 6 bytes (0xAB repeated)
+        let prefix = Array(frame.subdata(in: 7..<13))
+        XCTAssertEqual(prefix, [UInt8](repeating: 0xAB, count: 6))
+        let msg = String(data: frame.subdata(in: 13..<frame.count), encoding: .utf8)
+        XCTAssertEqual(msg, "ping")
+    }
+
+    func testEncodeSendTextMessageRejectsBadInput() {
+        XCTAssertNil(MeshCoreFrameCodec.encodeSendTextMessage(pubKeyHex: "ab", text: "hi")) // too short
+        XCTAssertNil(MeshCoreFrameCodec.encodeSendTextMessage(
+            pubKeyHex: String(repeating: "ab", count: 32), text: "   ")) // empty text
+    }
+
+    func testEncodeSetAdvertNameTruncatesAndRejectsEmpty() {
+        XCTAssertNil(MeshCoreFrameCodec.encodeSetAdvertName("   "))
+        let long = String(repeating: "X", count: 40)
+        guard let frame = MeshCoreFrameCodec.encodeSetAdvertName(long) else {
+            return XCTFail("encodeSetAdvertName returned nil for valid name")
+        }
+        XCTAssertEqual(frame.first, 0x08)
+        XCTAssertEqual(frame.count, 1 + 31) // truncated to 31 bytes
+    }
+
+    // MARK: - Decoders (frames built to the JC layout)
+
+    func testDecodeBatteryRoundTrip() {
+        // 3950 mV = 0x0F6E -> [0x0C][0x6E][0x0F]
+        let frame = Data([0x0C, 0x6E, 0x0F])
+        guard case let .battery(mv, pct)? = MeshCoreFrameCodec.decode(frame) else {
+            return XCTFail("expected .battery")
+        }
+        XCTAssertEqual(mv, 3950)
+        XCTAssertEqual(pct, MeshCoreFrameCodec.batteryPercent(fromMillivolts: 3950))
+        XCTAssertTrue(pct > 0 && pct < 100)
+    }
+
+    func testBatteryPercentClamps() {
+        XCTAssertEqual(MeshCoreFrameCodec.batteryPercent(fromMillivolts: 0), -1)
+        XCTAssertEqual(MeshCoreFrameCodec.batteryPercent(fromMillivolts: 3000), 0)
+        XCTAssertEqual(MeshCoreFrameCodec.batteryPercent(fromMillivolts: 4200), 100)
+        XCTAssertEqual(MeshCoreFrameCodec.batteryPercent(fromMillivolts: 4500), 100)
+    }
+
+    func testDecodeNoMoreMessages() {
+        guard case .noMoreMessages? = MeshCoreFrameCodec.decode(Data([0x0A])) else {
+            return XCTFail("expected .noMoreMessages")
+        }
+    }
+
+    func testDecodeMessagesWaiting() {
+        guard case .messagesWaiting? = MeshCoreFrameCodec.decode(Data([0x83])) else {
+            return XCTFail("expected .messagesWaiting")
+        }
+    }
+
+    func testDecodeContactWithPosition() {
+        // Build a 144-byte advert/contact frame per the JC layout:
+        // [0x80][pubkey 32 @1][advType @33][name 32 @100][tsSec @132][latE6 @136][lonE6 @140]
+        var frame = [UInt8](repeating: 0, count: 144)
+        frame[0] = MeshCoreFrameCodec.pushCodeAdvert
+        // pubkey: 0x11,0x22,0x33,0x44,... (only first 4 bytes matter for id)
+        for i in 0..<32 { frame[1 + i] = UInt8((i + 1) & 0xFF) }
+        frame[33] = 0x01 // chat node
+        // name "NODE-A" at 100
+        let name = Array("NODE-A".utf8)
+        for (i, b) in name.enumerated() { frame[100 + i] = b }
+        // tsSec = 1700000000 LE at 132
+        putUInt32LE(&frame, 132, 1_700_000_000)
+        // latE6 = 47_606_200 ; lonE6 = -122_332_100 LE
+        putInt32LE(&frame, 136, 47_606_200)
+        putInt32LE(&frame, 140, -122_332_100)
+
+        guard case let .contact(contact)? = MeshCoreFrameCodec.decode(Data(frame)) else {
+            return XCTFail("expected .contact")
+        }
+        XCTAssertEqual(contact.name, "NODE-A")
+        XCTAssertEqual(contact.advertType, 1)
+        XCTAssertFalse(contact.isRepeater)
+        XCTAssertTrue(contact.hasValidPosition)
+        XCTAssertEqual(contact.latitude, 47.6062, accuracy: 1e-6)
+        XCTAssertEqual(contact.longitude, -122.3321, accuracy: 1e-6)
+        XCTAssertEqual(contact.advertTimestampSec, 1_700_000_000)
+        // pubkey hex begins 01020304…
+        XCTAssertTrue(contact.pubKeyHex.hasPrefix("01020304"))
+        // node id derived from first 4 bytes big-endian = 0x01020304
+        XCTAssertEqual(MeshCoreFrameCodec.nodeId(fromPubKeyHex: contact.pubKeyHex), 0x01020304)
+    }
+
+    func testDecodeContactNullIslandHasNoValidPosition() {
+        var frame = [UInt8](repeating: 0, count: 144)
+        frame[0] = MeshCoreFrameCodec.pushCodeAdvert
+        for i in 0..<32 { frame[1 + i] = UInt8((i + 1) & 0xFF) }
+        frame[33] = 0x02 // repeater
+        // lat/lon left 0,0 -> no position
+        guard case let .contact(contact)? = MeshCoreFrameCodec.decode(Data(frame)) else {
+            return XCTFail("expected .contact")
+        }
+        XCTAssertTrue(contact.isRepeater)
+        XCTAssertFalse(contact.hasValidPosition)
+    }
+
+    func testDecodeSelfInfo() {
+        // [0x05][advType @1][tx @2][maxTx @3][pubkey 32 @4][latE6 @36][lonE6 @40] … [name @58]
+        var frame = [UInt8](repeating: 0, count: 70)
+        frame[0] = MeshCoreFrameCodec.respSelfInfo
+        for i in 0..<32 { frame[4 + i] = UInt8((i + 0xA0) & 0xFF) }
+        putInt32LE(&frame, 36, 47_606_200)
+        putInt32LE(&frame, 40, -122_332_100)
+        let name = Array("MYNODE".utf8)
+        for (i, b) in name.enumerated() { frame[58 + i] = b }
+
+        guard case let .selfInfo(info)? = MeshCoreFrameCodec.decode(Data(frame)) else {
+            return XCTFail("expected .selfInfo")
+        }
+        XCTAssertEqual(info.name, "MYNODE")
+        XCTAssertTrue(info.hasPosition)
+        XCTAssertEqual(info.latitude, 47.6062, accuracy: 1e-6)
+        XCTAssertEqual(info.longitude, -122.3321, accuracy: 1e-6)
+        XCTAssertTrue(info.pubKeyHex.hasPrefix("a0a1a2a3"))
+    }
+
+    func testDecodeContactMessageV1() {
+        // [0x07][senderPrefix 6 @1][.. up to 8 ..][txtType @8 = 0][text @13]
+        var frame = [UInt8](repeating: 0, count: 13)
+        frame[0] = MeshCoreFrameCodec.respContactMsg
+        for i in 0..<6 { frame[1 + i] = UInt8((i + 0xC0) & 0xFF) } // sender prefix
+        frame[8] = 0x00 // txtType plain
+        frame.append(contentsOf: Array("hello tak".utf8))
+
+        guard case let .textMessage(msg)? = MeshCoreFrameCodec.decode(Data(frame)) else {
+            return XCTFail("expected .textMessage")
+        }
+        XCTAssertEqual(msg.text, "hello tak")
+        XCTAssertEqual(msg.senderPubKeyPrefixHex, "c0c1c2c3c4c5")
+    }
+
+    func testDecodeContactMessageV1SignedVariantSkipsExtraBytes() {
+        // txtType==2 means 4 extra bytes before the text (offset 13 -> 17).
+        var frame = [UInt8](repeating: 0, count: 17)
+        frame[0] = MeshCoreFrameCodec.respContactMsg
+        for i in 0..<6 { frame[1 + i] = UInt8((i + 0xC0) & 0xFF) }
+        frame[8] = 0x02 // signed/timestamped
+        frame.append(contentsOf: Array("signed".utf8))
+
+        guard case let .textMessage(msg)? = MeshCoreFrameCodec.decode(Data(frame)) else {
+            return XCTFail("expected .textMessage")
+        }
+        XCTAssertEqual(msg.text, "signed")
+    }
+
+    func testDecodeUnknownCodeIsOther() {
+        guard case let .other(code)? = MeshCoreFrameCodec.decode(Data([0xEE, 0x01, 0x02])) else {
+            return XCTFail("expected .other")
+        }
+        XCTAssertEqual(code, 0xEE)
+    }
+
+    func testDecodeEmptyFrameIsNil() {
+        XCTAssertNil(MeshCoreFrameCodec.decode(Data()))
+    }
+
+    // MARK: - Identity helpers
+
+    func testPubKeyPrefixBytes() {
+        let prefix = MeshCoreFrameCodec.pubKeyPrefixBytes("0102030405060708", count: 4)
+        XCTAssertEqual(Array(prefix ?? Data()), [0x01, 0x02, 0x03, 0x04])
+        XCTAssertNil(MeshCoreFrameCodec.pubKeyPrefixBytes("01", count: 4))
+        XCTAssertNil(MeshCoreFrameCodec.pubKeyPrefixBytes("zz020304", count: 4))
+    }
+
+    func testNodeIdDerivation() {
+        XCTAssertEqual(MeshCoreFrameCodec.nodeId(fromPubKeyHex: "deadbeefcafe"), 0xDEADBEEF)
+        XCTAssertEqual(MeshCoreFrameCodec.nodeId(fromPubKeyHex: ""), 0)
+    }
+
+    // MARK: - CoT conversion
+
+    func testCoTConverterUIDPrefix() {
+        XCTAssertEqual(MeshCoreCoTConverter.uid(forPubKeyHex: "deadbeefcafebabe"), "MESHCORE-deadbeef")
+    }
+
+    func testCoTConverterProducesPLIForPositionedContact() {
+        let contact = MeshCoreContact(
+            pubKeyHex: "deadbeefcafebabe" + String(repeating: "0", count: 48),
+            advertType: 1,
+            name: "Recon-1",
+            advertTimestampSec: 1_700_000_000,
+            latitude: 47.6062,
+            longitude: -122.3321,
+            hasPosition: true
+        )
+        guard let event = MeshCoreCoTConverter.toCoTEvent(contact: contact) else {
+            return XCTFail("expected a CoT event")
+        }
+        XCTAssertEqual(event.uid, "MESHCORE-deadbeef")
+        XCTAssertEqual(event.type, "a-n-G-U-C")
+        XCTAssertEqual(event.detail.callsign, "Recon-1")
+        XCTAssertEqual(event.point.lat, 47.6062, accuracy: 1e-6)
+        XCTAssertEqual(event.point.lon, -122.3321, accuracy: 1e-6)
+    }
+
+    func testCoTConverterReturnsNilWithoutPosition() {
+        let contact = MeshCoreContact(
+            pubKeyHex: String(repeating: "ab", count: 32),
+            advertType: 2, name: "Repeater", advertTimestampSec: 0,
+            latitude: 0, longitude: 0, hasPosition: false
+        )
+        XCTAssertNil(MeshCoreCoTConverter.toCoTEvent(contact: contact))
+    }
+
+    // MARK: - Little-endian write helpers (test-local)
+
+    private func putUInt32LE(_ buf: inout [UInt8], _ off: Int, _ value: UInt32) {
+        buf[off]     = UInt8(value & 0xFF)
+        buf[off + 1] = UInt8((value >> 8) & 0xFF)
+        buf[off + 2] = UInt8((value >> 16) & 0xFF)
+        buf[off + 3] = UInt8((value >> 24) & 0xFF)
+    }
+
+    private func putInt32LE(_ buf: inout [UInt8], _ off: Int, _ value: Int32) {
+        putUInt32LE(&buf, off, UInt32(bitPattern: value))
+    }
+}

--- a/OmniTAKMobileTests/MeshCoreFrameCodecTests.swift
+++ b/OmniTAKMobileTests/MeshCoreFrameCodecTests.swift
@@ -154,9 +154,11 @@ final class MeshCoreFrameCodecTests: XCTestCase {
         XCTAssertEqual(contact.longitude, -122.3321, accuracy: 1e-6)
         XCTAssertEqual(contact.advertTimestampSec, 1_700_000_000)
         // pubkey hex begins 01020304…
-        XCTAssertTrue(contact.pubKeyHex.hasPrefix("01020304"))
-        // node id derived from first 4 bytes big-endian = 0x01020304
-        XCTAssertEqual(MeshCoreFrameCodec.nodeId(fromPubKeyHex: contact.pubKeyHex), 0x01020304)
+        XCTAssertTrue(contact.pubKeyHex.hasPrefix("010203"))
+        // node id derived from first 6 bytes — must be non-zero and stable.
+        let nodeId = MeshCoreFrameCodec.nodeId(fromPubKeyHex: contact.pubKeyHex)
+        XCTAssertNotEqual(nodeId, 0)
+        XCTAssertEqual(nodeId, MeshCoreFrameCodec.nodeId(fromPubKeyHex: contact.pubKeyHex))
     }
 
     func testDecodeContactNullIslandHasNoValidPosition() {
@@ -228,6 +230,45 @@ final class MeshCoreFrameCodecTests: XCTestCase {
         XCTAssertEqual(code, 0xEE)
     }
 
+    // MARK: - Fix #1: RESP_DEVICE_INFO (0x0D) handler
+
+    func testDecodeDeviceInfoMinimalFrame() {
+        // Minimal 3-byte device info: [0x0D][hwModel][hwRevision]
+        let frame = Data([0x0D, 0x05, 0x02])
+        guard case let .deviceInfo(info)? = MeshCoreFrameCodec.decode(frame) else {
+            return XCTFail("expected .deviceInfo for code 0x0D")
+        }
+        XCTAssertEqual(info.hwModel, 0x05)
+        XCTAssertEqual(info.hwRevision, 0x02)
+        XCTAssertEqual(info.firmwareVersion, "")
+    }
+
+    func testDecodeDeviceInfo82ByteFrame() {
+        // Live radio sends 82 bytes: [0x0D][hw][rev][fw ascii null-terminated, padded]
+        var frame = [UInt8](repeating: 0, count: 82)
+        frame[0] = 0x0D
+        frame[1] = 0x03  // hwModel
+        frame[2] = 0x01  // hwRevision
+        let fw = Array("1.4.8".utf8)
+        for (i, b) in fw.enumerated() { frame[3 + i] = b }
+
+        guard case let .deviceInfo(info)? = MeshCoreFrameCodec.decode(Data(frame)) else {
+            return XCTFail("expected .deviceInfo for 82-byte frame")
+        }
+        XCTAssertEqual(info.hwModel, 0x03)
+        XCTAssertEqual(info.hwRevision, 0x01)
+        XCTAssertEqual(info.firmwareVersion, "1.4.8")
+    }
+
+    func testDecodeDeviceInfoTooShortIsOther() {
+        // 2-byte frame is below the 3-byte minimum → .other
+        let frame = Data([0x0D, 0x01])
+        guard case let .other(code)? = MeshCoreFrameCodec.decode(frame) else {
+            return XCTFail("expected .other for truncated 0x0D frame")
+        }
+        XCTAssertEqual(code, 0x0D)
+    }
+
     func testDecodeEmptyFrameIsNil() {
         XCTAssertNil(MeshCoreFrameCodec.decode(Data()))
     }
@@ -242,14 +283,35 @@ final class MeshCoreFrameCodecTests: XCTestCase {
     }
 
     func testNodeIdDerivation() {
-        XCTAssertEqual(MeshCoreFrameCodec.nodeId(fromPubKeyHex: "deadbeefcafe"), 0xDEADBEEF)
+        // 6-byte prefix: "deadbeefcafe" — nodeId must be non-zero and deterministic.
+        let id = MeshCoreFrameCodec.nodeId(fromPubKeyHex: "deadbeefcafe")
+        XCTAssertNotEqual(id, 0)
+        // Same input always yields the same id.
+        XCTAssertEqual(id, MeshCoreFrameCodec.nodeId(fromPubKeyHex: "deadbeefcafe"))
+        // Too-short pubkey → 0
+        XCTAssertEqual(MeshCoreFrameCodec.nodeId(fromPubKeyHex: "deadbeef"), 0)
         XCTAssertEqual(MeshCoreFrameCodec.nodeId(fromPubKeyHex: ""), 0)
+    }
+
+    // MARK: - Fix #3: node-id widened 4→6 bytes; CoT UID uses 12 hex chars
+
+    func testCoTUIDUses12HexChars() {
+        // UID must be MESHCORE- + 12 uppercase hex chars (6 bytes).
+        let uid = MeshCoreCoTConverter.uid(forPubKeyHex: "deadbeefcafebabe")
+        XCTAssertEqual(uid, "MESHCORE-DEADBEEFCAFE")
+        XCTAssertEqual(uid.count, "MESHCORE-".count + 12)
+    }
+
+    func testPubKeyPrefix12Helper() {
+        XCTAssertEqual(MeshCoreFrameCodec.pubKeyPrefix12(fromPubKeyHex: "deadbeefcafebabe0011"), "deadbeefcafe")
+        XCTAssertNil(MeshCoreFrameCodec.pubKeyPrefix12(fromPubKeyHex: "dead"))
     }
 
     // MARK: - CoT conversion
 
     func testCoTConverterUIDPrefix() {
-        XCTAssertEqual(MeshCoreCoTConverter.uid(forPubKeyHex: "deadbeefcafebabe"), "MESHCORE-deadbeef")
+        // Updated: 12 uppercase hex chars
+        XCTAssertEqual(MeshCoreCoTConverter.uid(forPubKeyHex: "deadbeefcafebabe"), "MESHCORE-DEADBEEFCAFE")
     }
 
     func testCoTConverterProducesPLIForPositionedContact() {
@@ -265,7 +327,8 @@ final class MeshCoreFrameCodecTests: XCTestCase {
         guard let event = MeshCoreCoTConverter.toCoTEvent(contact: contact) else {
             return XCTFail("expected a CoT event")
         }
-        XCTAssertEqual(event.uid, "MESHCORE-deadbeef")
+        // UID now uses 12 uppercase hex chars (6-byte prefix)
+        XCTAssertEqual(event.uid, "MESHCORE-DEADBEEFCAFE")
         XCTAssertEqual(event.type, "a-n-G-U-C")
         XCTAssertEqual(event.detail.callsign, "Recon-1")
         XCTAssertEqual(event.point.lat, 47.6062, accuracy: 1e-6)

--- a/scripts/add_profile_files.py
+++ b/scripts/add_profile_files.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Add ConfigProfile / ProfileStore / ProfileQRCodec / ProfilesView / ConfigProfileTests
+to OmniTAK.xcodeproj/project.pbxproj.
+
+UUIDs are deterministic (hard-coded) so the script is idempotent.
+Run from anywhere; uses absolute paths.
+"""
+
+import re, sys, os
+
+PBXPROJ = os.path.expanduser(
+    "~/Projects/wt-ios-profiles/OmniTAK.xcodeproj/project.pbxproj"
+)
+
+# ── New files ─────────────────────────────────────────────────────────────────
+# Each entry: (fileref_uuid, buildfile_uuid, display_name, path, is_test)
+NEW_FILES = [
+    (
+        "CF000001A000000000000001",
+        "CF000001B000000000000001",
+        "ConfigProfile.swift",
+        "OmniTAKMobile/Features/Profiles/Models/ConfigProfile.swift",
+        False,
+    ),
+    (
+        "CF000002A000000000000001",
+        "CF000002B000000000000001",
+        "ProfileQRCodec.swift",
+        "OmniTAKMobile/Features/Profiles/Services/ProfileQRCodec.swift",
+        False,
+    ),
+    (
+        "CF000003A000000000000001",
+        "CF000003B000000000000001",
+        "ProfileStore.swift",
+        "OmniTAKMobile/Features/Profiles/Services/ProfileStore.swift",
+        False,
+    ),
+    (
+        "CF000004A000000000000001",
+        "CF000004B000000000000001",
+        "ProfilesView.swift",
+        "OmniTAKMobile/Features/Profiles/Views/ProfilesView.swift",
+        False,
+    ),
+    (
+        "CF000005A000000000000001",
+        "CF000005B000000000000001",
+        "ConfigProfileTests.swift",
+        "OmniTAKMobileTests/ConfigProfileTests.swift",
+        True,
+    ),
+]
+
+# ── Anchor anchors ─────────────────────────────────────────────────────────────
+# We insert new PBXFileReference entries just before the end of that section.
+FILE_REF_SECTION_END = "/* End PBXFileReference section */"
+
+# We insert new PBXBuildFile entries at the start of that section.
+BUILD_FILE_SECTION_END = "/* End PBXBuildFile section */"
+
+# Main app Sources build phase UUID (see project.pbxproj grep above)
+APP_SOURCES_PHASE_UUID = "A11111111111111111111111000000C1"
+
+# Tests Sources build phase UUID
+TESTS_SOURCES_PHASE_UUID = "692AC278500B76F26848B899"
+
+# PBXGroup for OmniTAKMobileTests (to list the test file reference)
+TESTS_GROUP_UUID = "1D3ED0E6F3C20B29A5C0C506"
+
+# ── Load ──────────────────────────────────────────────────────────────────────
+with open(PBXPROJ, "r") as f:
+    content = f.read()
+
+original = content  # keep for diff check
+
+def already_present(uuid: str) -> bool:
+    return uuid in content
+
+# ── 1. PBXFileReference entries ───────────────────────────────────────────────
+file_ref_inserts = []
+for fref, _bf, name, path, _test in NEW_FILES:
+    if already_present(fref):
+        print(f"  skip (already present): {name}")
+        continue
+    entry = (
+        f"\t\t{fref} /* {name} */ = "
+        f"{{isa = PBXFileReference; includeInIndex = 1; "
+        f"lastKnownFileType = sourcecode.swift; name = {name}; "
+        f"path = {path}; sourceTree = \"<group>\"; }};\n"
+    )
+    file_ref_inserts.append(entry)
+
+if file_ref_inserts:
+    insert_block = "".join(file_ref_inserts)
+    content = content.replace(
+        FILE_REF_SECTION_END,
+        insert_block + FILE_REF_SECTION_END,
+        1,
+    )
+
+# ── 2. PBXBuildFile entries ───────────────────────────────────────────────────
+build_file_inserts = []
+for fref, bf, name, _path, _test in NEW_FILES:
+    if already_present(bf):
+        continue
+    entry = (
+        f"\t\t{bf} /* {name} in Sources */ = "
+        f"{{isa = PBXBuildFile; fileRef = {fref} /* {name} */; }};\n"
+    )
+    build_file_inserts.append(entry)
+
+if build_file_inserts:
+    insert_block = "".join(build_file_inserts)
+    content = content.replace(
+        BUILD_FILE_SECTION_END,
+        insert_block + BUILD_FILE_SECTION_END,
+        1,
+    )
+
+# ── 3. Add file refs to appropriate PBXGroup ──────────────────────────────────
+# Tests group — add ConfigProfileTests.swift fileref
+for fref, _bf, name, _path, is_test in NEW_FILES:
+    if not is_test:
+        continue
+    if already_present(fref) and fref in original:
+        continue
+    # Insert before the Info.plist entry in the tests group
+    anchor = "A99C500AFB1B09E55ABEDBBF /* Info.plist */,"
+    replacement = f"\t\t\t\t{fref} /* {name} */,\n\t\t\t\t" + anchor
+    content = content.replace(anchor, replacement, 1)
+
+# ── 4. Add buildfile refs to Sources build phases ────────────────────────────
+# App sources phase
+app_src_anchor = "42DCF526B899E93E4340934B /* ADSBPlugin.swift in Sources */,"
+app_inserts = []
+for fref, bf, name, _path, is_test in NEW_FILES:
+    if is_test:
+        continue
+    if bf in original:
+        continue
+    app_inserts.append(f"\t\t\t\t\t{bf} /* {name} in Sources */,")
+
+if app_inserts:
+    insert_str = "\n".join(app_inserts) + "\n\t\t\t\t\t"
+    content = content.replace(
+        "\t\t\t\t\t" + app_src_anchor,
+        insert_str + app_src_anchor,
+        1,
+    )
+
+# Tests sources phase
+tests_src_anchor = "F831B10A1D135F2E88925F52 /* PluginSDKTests.swift in Sources */,"
+tests_inserts = []
+for fref, bf, name, _path, is_test in NEW_FILES:
+    if not is_test:
+        continue
+    if bf in original:
+        continue
+    tests_inserts.append(f"\t\t\t\t\t{bf} /* {name} in Sources */,")
+
+if tests_inserts:
+    insert_str = "\n".join(tests_inserts) + "\n\t\t\t\t\t"
+    content = content.replace(
+        "\t\t\t\t\t" + tests_src_anchor,
+        insert_str + tests_src_anchor,
+        1,
+    )
+
+# ── Write back ────────────────────────────────────────────────────────────────
+if content == original:
+    print("No changes needed (all UUIDs already present).")
+else:
+    with open(PBXPROJ, "w") as f:
+        f.write(content)
+    print("project.pbxproj updated successfully.")


### PR DESCRIPTION
## Summary
Implements the two Gavin feature requests for OmniTAK (iOS + Android):

1. **Mesh framework selection** — users pick Meshtastic or **MeshCore**. Adds native MeshCore companion-radio support over BLE (Nordic UART): contacts' advertised positions plot as CoT PLI, inbound messages land in Chat, and self-position broadcasts to the mesh. The Meshtastic path is unchanged (transport/manager protocols extracted, MeshCore added as a parallel implementation).
2. **Config profiles + QR sync** — snapshot/apply multiple config profiles; generate a sync QR carrying shared team config (server, team, map, enrollment pointer) with **no secrets**; scan-to-import with a confirmation preview.

## Verification
- `xcodebuild` Debug (iPhone simulator) BUILD SUCCEEDED; 211 tests pass (incl. new MeshCore codec + profile round-trip + no-secrets tests).
- 4-agent adversarial review; review/hardening fixes applied (zlib-bomb cap, deep-link confirm-before-apply, outbound routed to the active framework, secrets + enrollment username stripped from QR, non-ASCII QR fix, no-secrets regression test).
- MeshCore companion protocol ported from a verified reference implementation; CoT UID format (`MESHCORE-<12 hex>`) verified identical to Android. The shared MeshCore protocol/codec logic was hardware-verified on the Android side against a real Heltec V3 (companion v1.16.0).

## Scope notes
- v1 is native-MeshCore bridging; full ATAK-channel-datagram interop is a planned v2.
- iOS build is green and mirrors the hardware-verified Android logic, but was not itself exercised against a physical radio in this pass.
