### PR TITLE
Field requests: north-up lock, corner compass, keep-screen-on fix + TAK icon suite (Phase 1)

### DIFF
--- a/OmniTAK.xcodeproj/project.pbxproj
+++ b/OmniTAK.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		245E39FD0636AA0B305D405F /* RadialMenuPresets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8AAA78CAAD03A3A7BCAB749 /* RadialMenuPresets.swift */; };
 		247A9FAC7C300DD219A5A332 /* AppModePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F863C9B3920784C32F6416D /* AppModePreferences.swift */; };
 		2480140A6ABE1484E42BA0AC /* CoTMessageParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9802858282CB5E929AD75F07 /* CoTMessageParserTests.swift */; };
+		FACE0004CAFE0004BEEF0004 /* TAKIconSuiteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE0003CAFE0003BEEF0003 /* TAKIconSuiteTests.swift */; };
 		2623ABB8B5C9B206C974B9E9 /* SNGPUULC---.svg in Resources */ = {isa = PBXBuildFile; fileRef = 701980E052FA63176EC5337E /* SNGPUULC---.svg */; };
 		263C73CB7A111BC62A38D6C1 /* CertificateEnrollmentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C27B3788362A7692A3F6B70 /* CertificateEnrollmentView.swift */; };
 		265D7A1D6302893B932347C0 /* VideoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B30BD78B36AA8556AA3EC4 /* VideoSource.swift */; };
@@ -177,6 +178,7 @@
 		7815F59874E2A05DAF94510C /* SFGPUUL----.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9F574EC82B38F9A8107A6205 /* SFGPUUL----.svg */; };
 		783AF5F4F93A87A0619C6144 /* ScaleBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448D0EBEFF3E2A71669016D1 /* ScaleBarView.swift */; };
 		78B31CA785CE3564CFC6DAE8 /* MilStdIconService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1119873F4EBB6AC92B2157E0 /* MilStdIconService.swift */; };
+		FACE0002CAFE0002BEEF0002 /* TAKIconRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE0001CAFE0001BEEF0001 /* TAKIconRegistry.swift */; };
 		7931902509B5936FBA2B5226 /* ServersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C34616EDE31B56B2D08565A /* ServersView.swift */; };
 		7985F8F77553018A47ECD92A /* OfflineMapManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC510F398E76BD5838AB3A0 /* OfflineMapManager.swift */; };
 		79AF1DB7E8E8CBAD81C1B9A8 /* DrawingPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2272CD08893F8EF861E29ED6 /* DrawingPersistence.swift */; };
@@ -436,6 +438,7 @@
 		103C33E3B66400D772DDE95F /* SNGP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNGP-------.svg"; sourceTree = "<group>"; };
 		1085EAF3533D48F16848B402 /* pl */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = pl; path = OmniTAKMobile/Resources/pl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1119873F4EBB6AC92B2157E0 /* MilStdIconService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MilStdIconService.swift; path = OmniTAKMobile/Shared/Services/MilStdIconService.swift; sourceTree = "<group>"; };
+		FACE0001CAFE0001BEEF0001 /* TAKIconRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TAKIconRegistry.swift; path = OmniTAKMobile/Shared/Services/TAKIconRegistry.swift; sourceTree = "<group>"; };
 		113A471CCFDBCA8105C05942 /* MapStateManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MapStateManager.swift; path = OmniTAKMobile/Features/Map/Controllers/MapStateManager.swift; sourceTree = "<group>"; };
 		1146597916B3AEC4BAE8C687 /* SFSPX------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFSPX------.svg"; sourceTree = "<group>"; };
 		12421DDA65FBEF785C811D32 /* SUGPUC-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SUGPUC-----.svg"; sourceTree = "<group>"; };
@@ -628,6 +631,7 @@
 		9450DBDE52BFDA77D0BBA9DE /* EmergencyBeaconService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EmergencyBeaconService.swift; path = OmniTAKMobile/Features/Tracking/Services/EmergencyBeaconService.swift; sourceTree = "<group>"; };
 		9540F19EA7E0D4D8F98FC80F /* TAKRestAPIClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TAKRestAPIClient.swift; path = OmniTAKMobile/Features/Networking/Services/TAKRestAPIClient.swift; sourceTree = "<group>"; };
 		9802858282CB5E929AD75F07 /* CoTMessageParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoTMessageParserTests.swift; path = OmniTAKMobileTests/CoTMessageParserTests.swift; sourceTree = "<group>"; };
+		FACE0003CAFE0003BEEF0003 /* TAKIconSuiteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TAKIconSuiteTests.swift; path = OmniTAKMobileTests/TAKIconSuiteTests.swift; sourceTree = "<group>"; };
 		98FDD932AB0896DCFA82D9BD /* ToolsLauncherSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Views/ToolsLauncherSheet.swift; sourceTree = "<group>"; };
 		9A9BEB1C723F75F83398705E /* SHSPCL-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHSPCL-----.svg"; sourceTree = "<group>"; };
 		9F574EC82B38F9A8107A6205 /* SFGPUUL----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPUUL----.svg"; sourceTree = "<group>"; };
@@ -993,6 +997,7 @@
 			children = (
 				BB82A68BE625612A8B0E94DC /* PluginSettingsManager.swift */,
 				1119873F4EBB6AC92B2157E0 /* MilStdIconService.swift */,
+				FACE0001CAFE0001BEEF0001 /* TAKIconRegistry.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -1046,6 +1051,7 @@
 				A30B6DE30B0975605C73973B /* ATAKPluginParserTests.swift */,
 				7AA427470D4AEB92295081A7 /* CertificateHandlingTests.swift */,
 				9802858282CB5E929AD75F07 /* CoTMessageParserTests.swift */,
+				FACE0003CAFE0003BEEF0003 /* TAKIconSuiteTests.swift */,
 				450330F089409385FE975F3E /* CSREnrollmentTests.swift */,
 				0A7FB9C4E1E1A57D761DBE6B /* MeshBroadcastTests.swift */,
 				C644AA06A8883B0013638A4E /* OpenDroneIdParserTests.swift */,
@@ -2692,6 +2698,7 @@
 				355F6BBFA52041BC0B7788FC /* ATAKPluginParserTests.swift in Sources */,
 				9931084D104902FBC10263F1 /* CertificateHandlingTests.swift in Sources */,
 				2480140A6ABE1484E42BA0AC /* CoTMessageParserTests.swift in Sources */,
+				FACE0004CAFE0004BEEF0004 /* TAKIconSuiteTests.swift in Sources */,
 				024BC7A13B382321ECAF2933 /* CSREnrollmentTests.swift in Sources */,
 				6FE43BA548D82C170FEE6275 /* MeshBroadcastTests.swift in Sources */,
 				A351A8B77C3983E18499A04F /* OpenDroneIdParserTests.swift in Sources */,
@@ -2884,6 +2891,7 @@
 				EBFA22DE58FD890D0EEB7385 /* ADSBTrafficView.swift in Sources */,
 				C20DB712DC2693FFE07E4416 /* AircraftIcons.swift in Sources */,
 				78B31CA785CE3564CFC6DAE8 /* MilStdIconService.swift in Sources */,
+				FACE0002CAFE0002BEEF0002 /* TAKIconRegistry.swift in Sources */,
 				3192FC7F36458549D30B2536 /* OpenDroneIdMessage.swift in Sources */,
 				335ECEA20DDF6C0EC0B3A551 /* RemoteIdTrack.swift in Sources */,
 				765F08BFD361C871BC9C0096 /* OpenDroneIdParser.swift in Sources */,

--- a/OmniTAKMobile/CoT/Generators/MarkerCoTGenerator.swift
+++ b/OmniTAKMobile/CoT/Generators/MarkerCoTGenerator.swift
@@ -15,12 +15,23 @@ class MarkerCoTGenerator {
 
     /// Generate CoT XML for a point marker
     static func generateCoT(for marker: PointMarker, staleTime: TimeInterval = 3600) -> String {
-        // Convert hex color to ARGB signed integer
-        let argbColor = hexToARGB(marker.affiliation.hexColor)
+        // Icon + color: a TAK Spot Map icon (issue #75) emits the canonical
+        // `COT_MAPPING_SPOTMAP/{color}` path + its swatch color so ATAK / iTAK
+        // render the exact dot the operator picked. Otherwise fall back to the
+        // affiliation-keyed spot-map path the app has always sent.
+        let iconsetPath: String
+        let argbColor: Int
+        if let takIcon = marker.takIcon {
+            iconsetPath = takIcon.iconsetPath
+            argbColor = hexToARGB(takIcon.argbHex)
+        } else {
+            iconsetPath = "COT_MAPPING_SPOTMAP/\(marker.affiliation.rawValue.lowercased())_point"
+            argbColor = hexToARGB(marker.affiliation.hexColor)
+        }
 
         var detail = """
                 <contact callsign="\(marker.name.xmlEscaped)"/>
-                <usericon iconsetpath="COT_MAPPING_SPOTMAP/\(marker.affiliation.rawValue.lowercased())_point"/>
+                <usericon iconsetpath="\(iconsetPath)"/>
                 <color argb="\(argbColor)"/>
                 <affiliation value="\(marker.affiliation.rawValue)"/>
         """
@@ -161,8 +172,14 @@ class MarkerCoTGenerator {
 
     // MARK: - Helper Methods
 
-    /// Convert hex color string (AARRGGBB) to signed 32-bit ARGB integer
-    /// Example: "FF00FFFF" (cyan) -> -16711681
+    /// Convert hex color string (AARRGGBB) to signed 32-bit ARGB integer.
+    /// Example: "FF00FFFF" (cyan) -> -16711681, "FFFF0000" (red) -> -65536.
+    ///
+    /// TAK `<color argb>` values are signed 32-bit ints — that's what ATAK
+    /// writes and what its `Integer.parseInt` reader expects. The opaque-alpha
+    /// values (0xFFxxxxxx) overflow `Int32.max`, so we MUST reinterpret the
+    /// 32-bit pattern as signed (Int32 → Int) rather than widening the unsigned
+    /// value (which produced e.g. 4294901760 — a number ATAK can't parse).
     private static func hexToARGB(_ hexString: String) -> Int {
         // Remove any # prefix if present
         let hex = hexString.replacingOccurrences(of: "#", with: "")
@@ -172,8 +189,9 @@ class MarkerCoTGenerator {
             return -1  // Default to white if parsing fails
         }
 
-        // Convert to signed Int (this handles the negative values correctly)
-        return Int(bitPattern: UInt(hexValue))
+        // Reinterpret the 32-bit pattern as a signed Int32, then widen. This
+        // yields the negative values TAK uses for opaque colors.
+        return Int(Int32(bitPattern: hexValue))
     }
 
     /// Format coordinate as MGRS-like string

--- a/OmniTAKMobile/CoT/Generators/MarkerCoTGenerator.swift
+++ b/OmniTAKMobile/CoT/Generators/MarkerCoTGenerator.swift
@@ -15,15 +15,25 @@ class MarkerCoTGenerator {
 
     /// Generate CoT XML for a point marker
     static func generateCoT(for marker: PointMarker, staleTime: TimeInterval = 3600) -> String {
-        // Icon + color: a TAK Spot Map icon (issue #75) emits the canonical
-        // `COT_MAPPING_SPOTMAP/{color}` path + its swatch color so ATAK / iTAK
-        // render the exact dot the operator picked. Otherwise fall back to the
+        // Icon + color (issue #75 — the standard TAK icon suite). Each pack
+        // emits its canonical `usericon iconsetpath` so the marker renders as
+        // the exact icon the operator picked on ATAK / iTAK / TAK Server:
+        //   • Spot Map → `COT_MAPPING_SPOTMAP/{color}` + the swatch color
+        //   • Markers  → `COT_MAPPING_2525C/{2525type}` (color follows affiliation)
+        //   • Google   → `{googleUID}/{token}.png`
+        // Markers/Spots that carry no explicit pack fall back to the
         // affiliation-keyed spot-map path the app has always sent.
         let iconsetPath: String
         let argbColor: Int
         if let takIcon = marker.takIcon {
             iconsetPath = takIcon.iconsetPath
             argbColor = hexToARGB(takIcon.argbHex)
+        } else if let markersIcon = marker.markersIcon {
+            iconsetPath = markersIcon.iconsetPath
+            argbColor = hexToARGB(marker.affiliation.hexColor)
+        } else if let googleIcon = marker.googleIcon {
+            iconsetPath = googleIcon.iconsetPath
+            argbColor = hexToARGB(marker.affiliation.hexColor)
         } else {
             iconsetPath = "COT_MAPPING_SPOTMAP/\(marker.affiliation.rawValue.lowercased())_point"
             argbColor = hexToARGB(marker.affiliation.hexColor)

--- a/OmniTAKMobile/Core/App/OmniTAKMobileApp.swift
+++ b/OmniTAKMobile/Core/App/OmniTAKMobileApp.swift
@@ -18,6 +18,11 @@ struct OmniTAKMobileApp: App {
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @AppStorage("remoteIdScanEnabled") private var remoteIdScanEnabled = false
     @AppStorage("gybDetectorEnabled") private var gybDetectorEnabled = false
+    // Issue #74 — keep-screen-awake fix. Mirrors nav_keepScreenOn into
+    // UIApplication.isIdleTimerDisabled so the setting actually prevents
+    // the screen from sleeping while OmniTAK is foreground.
+    @AppStorage("nav_keepScreenOn") private var keepScreenOn: Bool = true
+    @Environment(\.scenePhase) private var scenePhase
 
     init() {
         // Eagerly initialize the Meshtastic manager so its COT bridge is wired
@@ -57,12 +62,26 @@ struct OmniTAKMobileApp: App {
                     .onAppear {
                         RemoteIdAppBridge.shared.setEnabled(remoteIdScanEnabled)
                         GybManager.shared.setEnabled(gybDetectorEnabled)
+                        // Issue #74 — apply keep-screen-on at launch.
+                        UIApplication.shared.isIdleTimerDisabled = keepScreenOn
                     }
                     .onChange(of: remoteIdScanEnabled) { newValue in
                         RemoteIdAppBridge.shared.setEnabled(newValue)
                     }
                     .onChange(of: gybDetectorEnabled) { newValue in
                         GybManager.shared.setEnabled(newValue)
+                    }
+                    // Issue #74 — re-apply when the setting changes while the
+                    // app is running (Settings toggle takes effect immediately).
+                    .onChange(of: keepScreenOn) { newValue in
+                        UIApplication.shared.isIdleTimerDisabled = newValue
+                    }
+                    // Issue #74 — re-apply on foreground transition (iOS can
+                    // reset isIdleTimerDisabled across scene lifecycle events).
+                    .onChange(of: scenePhase) { phase in
+                        if phase == .active {
+                            UIApplication.shared.isIdleTimerDisabled = keepScreenOn
+                        }
                     }
                     #if DEBUG
                     .task {

--- a/OmniTAKMobile/Features/Drawing/Models/PointMarkerModels.swift
+++ b/OmniTAKMobile/Features/Drawing/Models/PointMarkerModels.swift
@@ -46,8 +46,19 @@ struct PointMarker: Identifiable, Codable, Equatable {
     // spot-map point: it renders with the colored dot, emits the canonical
     // `b-m-p-s-m` CoT type + `COT_MAPPING_SPOTMAP/{color}` usericon path, and
     // round-trips with ATAK / iTAK. Takes precedence over the affiliation
-    // default; mutually exclusive with `femaIcon` in the placement UI.
+    // default; mutually exclusive with the other icon-pack overrides.
     var takIcon: TAKSpotIcon?
+
+    // TAK Markers (2525C) icon (issue #75). When set, the marker is from the
+    // ATAK "Markers" pack: it renders with MIL-STD-2525 symbology, emits the
+    // icon's 2525 CoT type + `COT_MAPPING_2525C/{type}` usericon path, and
+    // round-trips with ATAK / iTAK.
+    var markersIcon: TAKMarkersIcon?
+
+    // TAK Google place icon (issue #75). When set, the marker is from the ATAK
+    // "Google" pack: it renders as a place pin, emits the pack's CoT type +
+    // `{googleUID}/{token}.png` usericon path, and round-trips with ATAK / iTAK.
+    var googleIcon: TAKGoogleIcon?
 
     // Sharing
     var isBroadcast: Bool
@@ -63,6 +74,8 @@ struct PointMarker: Identifiable, Codable, Equatable {
         createdBy: String? = nil,
         femaIcon: FemaIcon? = nil,
         takIcon: TAKSpotIcon? = nil,
+        markersIcon: TAKMarkersIcon? = nil,
+        googleIcon: TAKGoogleIcon? = nil,
         isBroadcast: Bool = false
     ) {
         self.id = id
@@ -76,13 +89,19 @@ struct PointMarker: Identifiable, Codable, Equatable {
         self.saluteReport = saluteReport
         self.createdBy = createdBy
         self.uid = "marker-\(id.uuidString)"
-        // Icon precedence: TAK spot-map icon → FEMA icon → affiliation default.
-        // A TAK spot icon emits the canonical b-m-p-s-m type; FEMA emits its
-        // best-effort type; otherwise the affiliation's ground-unit type.
-        self.cotType = takIcon.map { _ in TAKSpotIcon.cotType } ?? femaIcon?.cotType ?? affiliation.cotType
-        self.iconName = femaIcon?.sfSymbolName ?? affiliation.iconName
+        // Icon precedence: TAK spot-map → Markers (2525C) → Google place →
+        // FEMA → affiliation default. Each pack emits its own canonical CoT
+        // type; otherwise the affiliation's ground-unit type.
+        self.cotType = takIcon.map { _ in TAKSpotIcon.cotType }
+            ?? markersIcon?.cotType
+            ?? googleIcon?.cotType
+            ?? femaIcon?.cotType
+            ?? affiliation.cotType
+        self.iconName = femaIcon?.sfSymbolName ?? googleIcon?.symbolName ?? affiliation.iconName
         self.femaIcon = femaIcon
         self.takIcon = takIcon
+        self.markersIcon = markersIcon
+        self.googleIcon = googleIcon
         self.isBroadcast = isBroadcast
     }
 
@@ -92,6 +111,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         case id, name, affiliation, latitude, longitude, altitude
         case timestamp, modifiedAt, remarks, createdBy, saluteReport
         case uid, cotType, iconName, isBroadcast, femaIcon, takIcon
+        case markersIcon, googleIcon
     }
 
     init(from decoder: Decoder) throws {
@@ -116,6 +136,8 @@ struct PointMarker: Identifiable, Codable, Equatable {
         isBroadcast = try container.decode(Bool.self, forKey: .isBroadcast)
         femaIcon = try container.decodeIfPresent(FemaIcon.self, forKey: .femaIcon)
         takIcon = try container.decodeIfPresent(TAKSpotIcon.self, forKey: .takIcon)
+        markersIcon = try container.decodeIfPresent(TAKMarkersIcon.self, forKey: .markersIcon)
+        googleIcon = try container.decodeIfPresent(TAKGoogleIcon.self, forKey: .googleIcon)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -137,6 +159,8 @@ struct PointMarker: Identifiable, Codable, Equatable {
         try container.encode(isBroadcast, forKey: .isBroadcast)
         try container.encodeIfPresent(femaIcon, forKey: .femaIcon)
         try container.encodeIfPresent(takIcon, forKey: .takIcon)
+        try container.encodeIfPresent(markersIcon, forKey: .markersIcon)
+        try container.encodeIfPresent(googleIcon, forKey: .googleIcon)
     }
 
     // MARK: - Equatable

--- a/OmniTAKMobile/Features/Drawing/Models/PointMarkerModels.swift
+++ b/OmniTAKMobile/Features/Drawing/Models/PointMarkerModels.swift
@@ -42,6 +42,13 @@ struct PointMarker: Identifiable, Codable, Equatable {
     // the affiliation default. See `FemaIconSet.swift` for the MVP caveat.
     var femaIcon: FemaIcon?
 
+    // TAK Spot Map icon (issue #75). When set, the marker is a standard TAK
+    // spot-map point: it renders with the colored dot, emits the canonical
+    // `b-m-p-s-m` CoT type + `COT_MAPPING_SPOTMAP/{color}` usericon path, and
+    // round-trips with ATAK / iTAK. Takes precedence over the affiliation
+    // default; mutually exclusive with `femaIcon` in the placement UI.
+    var takIcon: TAKSpotIcon?
+
     // Sharing
     var isBroadcast: Bool
 
@@ -55,6 +62,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         saluteReport: SALUTEReport? = nil,
         createdBy: String? = nil,
         femaIcon: FemaIcon? = nil,
+        takIcon: TAKSpotIcon? = nil,
         isBroadcast: Bool = false
     ) {
         self.id = id
@@ -68,10 +76,13 @@ struct PointMarker: Identifiable, Codable, Equatable {
         self.saluteReport = saluteReport
         self.createdBy = createdBy
         self.uid = "marker-\(id.uuidString)"
-        // FEMA icon (if any) overrides the affiliation-default CoT type and icon.
-        self.cotType = femaIcon?.cotType ?? affiliation.cotType
+        // Icon precedence: TAK spot-map icon → FEMA icon → affiliation default.
+        // A TAK spot icon emits the canonical b-m-p-s-m type; FEMA emits its
+        // best-effort type; otherwise the affiliation's ground-unit type.
+        self.cotType = takIcon.map { _ in TAKSpotIcon.cotType } ?? femaIcon?.cotType ?? affiliation.cotType
         self.iconName = femaIcon?.sfSymbolName ?? affiliation.iconName
         self.femaIcon = femaIcon
+        self.takIcon = takIcon
         self.isBroadcast = isBroadcast
     }
 
@@ -80,7 +91,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case id, name, affiliation, latitude, longitude, altitude
         case timestamp, modifiedAt, remarks, createdBy, saluteReport
-        case uid, cotType, iconName, isBroadcast, femaIcon
+        case uid, cotType, iconName, isBroadcast, femaIcon, takIcon
     }
 
     init(from decoder: Decoder) throws {
@@ -104,6 +115,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         iconName = try container.decode(String.self, forKey: .iconName)
         isBroadcast = try container.decode(Bool.self, forKey: .isBroadcast)
         femaIcon = try container.decodeIfPresent(FemaIcon.self, forKey: .femaIcon)
+        takIcon = try container.decodeIfPresent(TAKSpotIcon.self, forKey: .takIcon)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -124,6 +136,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         try container.encode(iconName, forKey: .iconName)
         try container.encode(isBroadcast, forKey: .isBroadcast)
         try container.encodeIfPresent(femaIcon, forKey: .femaIcon)
+        try container.encodeIfPresent(takIcon, forKey: .takIcon)
     }
 
     // MARK: - Equatable

--- a/OmniTAKMobile/Features/Drawing/Services/PointDropperService.swift
+++ b/OmniTAKMobile/Features/Drawing/Services/PointDropperService.swift
@@ -192,6 +192,90 @@ class PointDropperService: ObservableObject {
         return "SPOT-\(icon.displayName.uppercased())-\(count)-\(f.string(from: Date()))"
     }
 
+    /// Quick drop a standard TAK Markers (2525C) marker (issue #75). Renders
+    /// MIL-STD-2525 symbology and emits the `COT_MAPPING_2525C/{type}` path so
+    /// it round-trips with ATAK / iTAK.
+    @discardableResult
+    func quickDropTAKMarkers(
+        _ icon: TAKMarkersIcon,
+        at coordinate: CLLocationCoordinate2D,
+        name: String? = nil,
+        broadcast: Bool = false
+    ) -> PointMarker {
+        // Carry a sensible affiliation parsed from the 2525 type so any code
+        // still reading `.affiliation` (counts, color) stays consistent; the
+        // markersIcon override drives rendering + CoT type/path.
+        let affiliation = MarkerCoTGenerator.parseAffiliation(from: icon.cotType)
+        let markerName = name ?? generateTAKMarkersName(for: icon)
+        let marker = PointMarker(
+            name: markerName,
+            affiliation: affiliation,
+            coordinate: coordinate,
+            markersIcon: icon,
+            isBroadcast: broadcast
+        )
+
+        markers.append(marker)
+        updateRecentMarkers(marker)
+        saveMarkers()
+
+        #if DEBUG
+        print("📍 TAK markers drop: \(icon.displayName) at (\(coordinate.latitude), \(coordinate.longitude))")
+        #endif
+
+        if broadcast { broadcastMarker(marker) }
+        onEvent?(.markerCreated(marker))
+        return marker
+    }
+
+    private func generateTAKMarkersName(for icon: TAKMarkersIcon) -> String {
+        let count = markers.filter { $0.markersIcon == icon }.count + 1
+        let f = DateFormatter()
+        f.dateFormat = "HHmm"
+        return "\(icon.shortName)-\(count)-\(f.string(from: Date()))"
+    }
+
+    /// Quick drop a standard TAK Google place marker (issue #75). Renders a
+    /// place pin and emits the `{googleUID}/{token}.png` path so it round-trips
+    /// with ATAK / iTAK.
+    @discardableResult
+    func quickDropTAKGoogle(
+        _ icon: TAKGoogleIcon,
+        at coordinate: CLLocationCoordinate2D,
+        name: String? = nil,
+        broadcast: Bool = false
+    ) -> PointMarker {
+        // Google pack markers are affiliation-agnostic (ATAK files them under
+        // unknown); default to unknown so any `.affiliation` reader is sane.
+        let markerName = name ?? generateTAKGoogleName(for: icon)
+        let marker = PointMarker(
+            name: markerName,
+            affiliation: .unknown,
+            coordinate: coordinate,
+            googleIcon: icon,
+            isBroadcast: broadcast
+        )
+
+        markers.append(marker)
+        updateRecentMarkers(marker)
+        saveMarkers()
+
+        #if DEBUG
+        print("📍 TAK google drop: \(icon.displayName) at (\(coordinate.latitude), \(coordinate.longitude))")
+        #endif
+
+        if broadcast { broadcastMarker(marker) }
+        onEvent?(.markerCreated(marker))
+        return marker
+    }
+
+    private func generateTAKGoogleName(for icon: TAKGoogleIcon) -> String {
+        let count = markers.filter { $0.googleIcon == icon }.count + 1
+        let f = DateFormatter()
+        f.dateFormat = "HHmm"
+        return "\(icon.displayName.uppercased())-\(count)-\(f.string(from: Date()))"
+    }
+
     /// Get marker by ID
     func getMarker(id: UUID) -> PointMarker? {
         return markers.first { $0.id == id }

--- a/OmniTAKMobile/Features/Drawing/Services/PointDropperService.swift
+++ b/OmniTAKMobile/Features/Drawing/Services/PointDropperService.swift
@@ -147,6 +147,51 @@ class PointDropperService: ObservableObject {
         return "\(icon.shortCode)-\(count)-\(f.string(from: Date()))"
     }
 
+    /// Quick drop a standard TAK Spot Map marker (issue #75). The chosen color
+    /// drives the dot, the canonical `b-m-p-s-m` CoT type, and the
+    /// `COT_MAPPING_SPOTMAP/{color}` usericon path so it round-trips with ATAK.
+    @discardableResult
+    func quickDropTAK(
+        _ icon: TAKSpotIcon,
+        at coordinate: CLLocationCoordinate2D,
+        name: String? = nil,
+        broadcast: Bool = false
+    ) -> PointMarker {
+        // Spot-map points are affiliation-agnostic; default to unknown so any
+        // code still reading `.affiliation` has a sane value. The takIcon
+        // override drives rendering + CoT type/color.
+        let markerName = name ?? generateTAKMarkerName(for: icon)
+        let marker = PointMarker(
+            name: markerName,
+            affiliation: .unknown,
+            coordinate: coordinate,
+            takIcon: icon,
+            isBroadcast: broadcast
+        )
+
+        markers.append(marker)
+        updateRecentMarkers(marker)
+        saveMarkers()
+
+        #if DEBUG
+        print("📍 TAK spot drop: \(icon.displayName) at (\(coordinate.latitude), \(coordinate.longitude))")
+        #endif
+
+        if broadcast {
+            broadcastMarker(marker)
+        }
+
+        onEvent?(.markerCreated(marker))
+        return marker
+    }
+
+    private func generateTAKMarkerName(for icon: TAKSpotIcon) -> String {
+        let count = markers.filter { $0.takIcon == icon }.count + 1
+        let f = DateFormatter()
+        f.dateFormat = "HHmm"
+        return "SPOT-\(icon.displayName.uppercased())-\(count)-\(f.string(from: Date()))"
+    }
+
     /// Get marker by ID
     func getMarker(id: UUID) -> PointMarker? {
         return markers.first { $0.id == id }

--- a/OmniTAKMobile/Features/Drawing/Views/PointDropperView.swift
+++ b/OmniTAKMobile/Features/Drawing/Views/PointDropperView.swift
@@ -49,6 +49,10 @@ struct PointDropperView: View {
                         // FEMA / IC palette (issue #13 MVP, SF Symbols stand-in).
                         femaPaletteSection
 
+                        // TAK Spot Map palette (issue #75) — standard TAK icon
+                        // set, selectable + round-trips with ATAK / iTAK.
+                        takSpotPaletteSection
+
                         // Everything else is optional — collapsed by default.
                         Button {
                             withAnimation { showAdvanced.toggle() }
@@ -189,6 +193,35 @@ struct PointDropperView: View {
                     ForEach(FemaIcon.allCases) { icon in
                         FemaIconButton(icon: icon) {
                             quickDropFema(icon)
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(Color.black.opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    // MARK: - TAK Spot Map Palette (issue #75)
+
+    private var takSpotPaletteSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 6) {
+                Text("TAK SPOTS")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(Color(hex: "#FFFC00"))
+                Text("(standard TAK icon set)")
+                    .font(.system(size: 9))
+                    .foregroundColor(.gray)
+                Spacer()
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(TAKIconRegistry.shared.selectableSpotIcons) { icon in
+                        TAKSpotIconButton(icon: icon) {
+                            quickDropTAK(icon)
                         }
                     }
                 }
@@ -483,6 +516,18 @@ struct PointDropperView: View {
         #endif
     }
 
+    private func quickDropTAK(_ icon: TAKSpotIcon) {
+        guard let location = mapCenter ?? currentLocation else { return }
+        let marker = service.quickDropTAK(icon, at: location, broadcast: broadcastImmediately)
+
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(.success)
+
+        #if DEBUG
+        print("📍 TAK spot dropped \(icon.displayName) marker: \(marker.name)")
+        #endif
+    }
+
     private func quickDrop(affiliation: MarkerAffiliation) {
         // Drop at the map crosshair (center) the operator aimed; fall back to
         // GPS only if the map center isn't known yet.
@@ -571,6 +616,44 @@ struct FemaIconButton: View {
     }
 }
 
+/// Swatch button for the TAK Spot Map palette (issue #75). Shows the standard
+/// TAK colored dot the marker will use, so the operator picks the exact icon
+/// that ATAK / iTAK will render.
+struct TAKSpotIconButton: View {
+    let icon: TAKSpotIcon
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: {
+            let g = UIImpactFeedbackGenerator(style: .light)
+            g.impactOccurred()
+            action()
+        }) {
+            VStack(spacing: 4) {
+                ZStack {
+                    Circle()
+                        .fill(icon.color)
+                        .frame(width: 24, height: 24)
+                    Circle()
+                        .stroke(Color.white.opacity(0.8), lineWidth: 1.5)
+                        .frame(width: 24, height: 24)
+                }
+                Text(icon.displayName)
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundColor(.white)
+            }
+            .frame(width: 64, height: 60)
+            .background(icon.color.opacity(0.18))
+            .cornerRadius(10)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(icon.color.opacity(0.55), lineWidth: 1)
+            )
+        }
+        .accessibilityLabel(Text("Drop \(icon.displayName) spot marker"))
+    }
+}
+
 struct QuickDropButton: View {
     let affiliation: MarkerAffiliation
     let label: String
@@ -635,9 +718,18 @@ struct RecentMarkerCard: View {
     var body: some View {
         VStack(spacing: 8) {
             HStack {
-                Image(systemName: marker.iconName)
-                    .font(.system(size: 16))
-                    .foregroundColor(marker.affiliation.color)
+                // Issue #75 — show the TAK spot dot for spot-map markers so the
+                // list matches the map; affiliation glyph otherwise.
+                if let spot = marker.takIcon {
+                    ZStack {
+                        Circle().fill(spot.color).frame(width: 16, height: 16)
+                        Circle().stroke(Color.white.opacity(0.8), lineWidth: 1).frame(width: 16, height: 16)
+                    }
+                } else {
+                    Image(systemName: marker.iconName)
+                        .font(.system(size: 16))
+                        .foregroundColor(marker.affiliation.color)
+                }
 
                 Text(marker.name)
                     .font(.system(size: 12, weight: .bold))

--- a/OmniTAKMobile/Features/Drawing/Views/PointDropperView.swift
+++ b/OmniTAKMobile/Features/Drawing/Views/PointDropperView.swift
@@ -53,6 +53,14 @@ struct PointDropperView: View {
                         // set, selectable + round-trips with ATAK / iTAK.
                         takSpotPaletteSection
 
+                        // TAK Markers (2525C) palette (issue #75) — the standard
+                        // ATAK "Markers" symbol set, selectable + round-trips.
+                        takMarkersPaletteSection
+
+                        // TAK Google palette (issue #75) — the standard ATAK
+                        // "Google" place-icon set, selectable + round-trips.
+                        takGooglePaletteSection
+
                         // Everything else is optional — collapsed by default.
                         Button {
                             withAnimation { showAdvanced.toggle() }
@@ -222,6 +230,64 @@ struct PointDropperView: View {
                     ForEach(TAKIconRegistry.shared.selectableSpotIcons) { icon in
                         TAKSpotIconButton(icon: icon) {
                             quickDropTAK(icon)
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(Color.black.opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    // MARK: - TAK Markers (2525C) Palette (issue #75)
+
+    private var takMarkersPaletteSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 6) {
+                Text("TAK MARKERS")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(Color(hex: "#FFFC00"))
+                Text("(MIL-STD-2525 icon set)")
+                    .font(.system(size: 9))
+                    .foregroundColor(.gray)
+                Spacer()
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(TAKIconRegistry.shared.selectableMarkersIcons) { icon in
+                        TAKMarkersIconButton(icon: icon) {
+                            quickDropTAKMarkers(icon)
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(Color.black.opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    // MARK: - TAK Google Palette (issue #75)
+
+    private var takGooglePaletteSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 6) {
+                Text("TAK GOOGLE")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(Color(hex: "#FFFC00"))
+                Text("(Google place icon set)")
+                    .font(.system(size: 9))
+                    .foregroundColor(.gray)
+                Spacer()
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(TAKIconRegistry.shared.selectableGoogleIcons) { icon in
+                        TAKGoogleIconButton(icon: icon) {
+                            quickDropTAKGoogle(icon)
                         }
                     }
                 }
@@ -528,6 +594,30 @@ struct PointDropperView: View {
         #endif
     }
 
+    private func quickDropTAKMarkers(_ icon: TAKMarkersIcon) {
+        guard let location = mapCenter ?? currentLocation else { return }
+        let marker = service.quickDropTAKMarkers(icon, at: location, broadcast: broadcastImmediately)
+
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(.success)
+
+        #if DEBUG
+        print("📍 TAK markers dropped \(icon.displayName) marker: \(marker.name)")
+        #endif
+    }
+
+    private func quickDropTAKGoogle(_ icon: TAKGoogleIcon) {
+        guard let location = mapCenter ?? currentLocation else { return }
+        let marker = service.quickDropTAKGoogle(icon, at: location, broadcast: broadcastImmediately)
+
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(.success)
+
+        #if DEBUG
+        print("📍 TAK google dropped \(icon.displayName) marker: \(marker.name)")
+        #endif
+    }
+
     private func quickDrop(affiliation: MarkerAffiliation) {
         // Drop at the map crosshair (center) the operator aimed; fall back to
         // GPS only if the map center isn't known yet.
@@ -651,6 +741,76 @@ struct TAKSpotIconButton: View {
             )
         }
         .accessibilityLabel(Text("Drop \(icon.displayName) spot marker"))
+    }
+}
+
+/// Swatch button for the TAK Markers (2525C) palette (issue #75). Shows the
+/// actual MIL-STD-2525 symbol the marker will render so the operator picks the
+/// exact icon ATAK / iTAK will draw.
+struct TAKMarkersIconButton: View {
+    let icon: TAKMarkersIcon
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: {
+            let g = UIImpactFeedbackGenerator(style: .light)
+            g.impactOccurred()
+            action()
+        }) {
+            VStack(spacing: 4) {
+                Image(uiImage: TAKIconRegistry.shared.image(for: icon, size: 30))
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 30, height: 30)
+                Text(icon.shortName)
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundColor(.white)
+            }
+            .frame(width: 64, height: 60)
+            .background(Color.white.opacity(0.08))
+            .cornerRadius(10)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.white.opacity(0.35), lineWidth: 1)
+            )
+        }
+        .accessibilityLabel(Text("Drop \(icon.displayName) marker"))
+    }
+}
+
+/// Swatch button for the TAK Google place palette (issue #75). Shows the actual
+/// rendered place pin the marker will use so the operator picks the exact icon
+/// that round-trips with ATAK / iTAK.
+struct TAKGoogleIconButton: View {
+    let icon: TAKGoogleIcon
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: {
+            let g = UIImpactFeedbackGenerator(style: .light)
+            g.impactOccurred()
+            action()
+        }) {
+            VStack(spacing: 4) {
+                Image(uiImage: TAKIconRegistry.shared.image(for: icon, size: 34))
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 30, height: 30)
+                Text(icon.displayName)
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+            .frame(width: 64, height: 60)
+            .background(Color(uiColor: icon.tintColor).opacity(0.14))
+            .cornerRadius(10)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color(uiColor: icon.tintColor).opacity(0.5), lineWidth: 1)
+            )
+        }
+        .accessibilityLabel(Text("Drop \(icon.displayName) place marker"))
     }
 }
 

--- a/OmniTAKMobile/Features/Map/Controllers/ATAKMapChrome.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/ATAKMapChrome.swift
@@ -247,10 +247,15 @@ struct ATAKSidePanel: View {
     @Binding var showScaleBar: Bool
     @Binding var showGrid: Bool
     @Binding var showCallsignPanel: Bool
+    /// Issue #72 — north-up lock state. The panel shows this as an active/inactive
+    /// toggle so the operator can lock/unlock without leaving the map chrome.
+    @Binding var isNorthLocked: Bool
     @ObservedObject var adsbService: ADSBTrafficService
     let onLayerToggle: (String) -> Void
     let onOverlayToggle: (String) -> Void
     let onMapOverlayToggle: (String) -> Void
+    /// Issue #72 — called when the north-lock button is tapped.
+    var onNorthLockToggle: (() -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -325,6 +330,11 @@ struct ATAKSidePanel: View {
 
                 LayerButton(icon: "safari", title: "Compass", isActive: showCompass, compact: true) {
                     onMapOverlayToggle("compass")
+                }
+                // Issue #72 — north-up lock toggle. Cyan when engaged to match
+                // the compass badge; "N" arrow icon echoes ATAK's lock affordance.
+                LayerButton(icon: isNorthLocked ? "lock.fill" : "arrow.up", title: "North Lock", isActive: isNorthLocked, compact: true) {
+                    onNorthLockToggle?()
                 }
                 LayerButton(icon: "location.circle", title: "Coordinates", isActive: showCoordinates, compact: true) {
                     onMapOverlayToggle("coordinates")

--- a/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
@@ -672,6 +672,10 @@ struct CesiumMainMap: UIViewRepresentable {
         // HTML renders a colored dot (the standard spot-map point) instead of
         // the sidc / affiliation art, so the globe matches the 2D engine.
         let spot: String?
+        // Issue #75 — pre-rendered icon as a PNG data URI (used for the TAK
+        // "Google" place pack, which has no SIDC equivalent). When present the
+        // HTML billboards this image directly so the globe matches the 2D pin.
+        let icon: String?
         // TAK-style altitude leader line (vertical drop-line from ground to
         // the icon + "{alt} m HAE" label). Reserved for detected drones so
         // the 3D globe doesn't get cluttered with a stick under every
@@ -694,6 +698,20 @@ struct CesiumMainMap: UIViewRepresentable {
         return CesiumMainMap.hex(forUIColor: color)
     }
 
+    /// Issue #75 — PNG data URI for a TAK "Google" place marker, or nil when
+    /// the entity isn't a Google-pack point. The Google pack has no SIDC, so the
+    /// globe billboards the same rendered pin the 2D engine uses.
+    private static func googleIconURI(iconsetPath: String?) -> String? {
+        guard let path = iconsetPath, let g = TAKGoogleIcon.from(iconsetPath: path) else { return nil }
+        return dataURI(for: TAKIconRegistry.shared.image(for: g, size: 44))
+    }
+
+    /// Encode a UIImage as a `data:image/png;base64,…` URI for the HTML bridge.
+    private static func dataURI(for image: UIImage) -> String? {
+        guard let png = image.pngData() else { return nil }
+        return "data:image/png;base64,\(png.base64EncodedString())"
+    }
+
     private func buildEntityJSON() -> String {
         var all: [BridgeEntity] = []
 
@@ -714,6 +732,7 @@ struct CesiumMainMap: UIViewRepresentable {
                 // billboard — the globe's bullseye analog.
                 sidc: selfMarkerStyle == "bullseye" ? nil : "SFGPUCI----",
                 spot: nil,
+                icon: nil,
                 leader: false
             ))
         }
@@ -736,6 +755,8 @@ struct CesiumMainMap: UIViewRepresentable {
                 // point (carries a COT_MAPPING_SPOTMAP usericon or b-m-p-s-m
                 // type); the HTML renders the dot over the sidc in that case.
                 spot: CesiumMainMap.spotHex(cotType: c.type, iconsetPath: c.iconsetPath, argb: c.argbColor),
+                // Issue #75 — Google-pack place pin (no SIDC) rendered for 3D.
+                icon: CesiumMainMap.googleIconURI(iconsetPath: c.iconsetPath),
                 // Detected drones (RID-{uasId}) get the TAK altitude leader
                 // line; other airborne CoT contacts float without the stick.
                 leader: c.uid.hasPrefix("RID-")
@@ -762,6 +783,7 @@ struct CesiumMainMap: UIViewRepresentable {
                 // "aircraft" so the directional arrow wins.
                 sidc: nil,
                 spot: nil,
+                icon: nil,
                 // ADS-B aircraft float at altitude but skip the leader line to
                 // keep a busy airspace readable.
                 leader: false
@@ -788,6 +810,9 @@ struct CesiumMainMap: UIViewRepresentable {
                 // Issue #75 — a placed TAK spot-map pin renders its colored dot
                 // on the globe too, matching the picker swatch and 2D engine.
                 spot: pm.takIcon.map { CesiumMainMap.hex(forUIColor: $0.uiColor) },
+                // Issue #75 — a placed Google place pin renders on the globe via
+                // its data URI (Markers ride the sidc path above).
+                icon: pm.googleIcon.map { CesiumMainMap.dataURI(for: TAKIconRegistry.shared.image(for: $0, size: 44)) } ?? nil,
                 leader: false
             ))
         }
@@ -810,6 +835,7 @@ struct CesiumMainMap: UIViewRepresentable {
                     heading: nil,
                     sidc: nil,
                     spot: nil,
+                    icon: nil,
                     leader: false
                 ))
             }

--- a/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
@@ -74,6 +74,9 @@ extension Notification.Name {
     /// `ATAKMapView` falls the map back to the 2D engine so the user isn't
     /// stuck on an infinite "Loading 3D world…" spinner.
     static let cesiumLoadTimedOut = Notification.Name("cesiumLoadTimedOut")
+    /// Issue #72/#73 — snap the Cesium globe heading back to north (0°).
+    /// Posted by the compass overlay tap or the north-lock toggle.
+    static let cesiumResetNorth = Notification.Name("cesiumResetNorth")
 }
 
 struct CesiumMainMap: UIViewRepresentable {
@@ -178,6 +181,15 @@ struct CesiumMainMap: UIViewRepresentable {
             )
         }
 
+        // Issue #72/#73 — snap the globe heading to north (0°). Preserves the
+        // current center, altitude, and pitch so only the rotation changes.
+        context.coordinator.resetNorthObserver = NotificationCenter.default.addObserver(
+            forName: .cesiumResetNorth, object: nil, queue: .main
+        ) { [weak coordinator = context.coordinator] _ in
+            guard let coordinator, coordinator.isReady, let wv = coordinator.webView else { return }
+            wv.evaluateJavaScript("window.OmniBridge.setHeading({heading:0});", completionHandler: nil)
+        }
+
         webView.loadHTMLString(CesiumMainMap.html, baseURL: URL(string: "https://cesium.com/"))
         context.coordinator.startLoadWatchdog()
         return webView
@@ -278,6 +290,8 @@ struct CesiumMainMap: UIViewRepresentable {
         var zoomObserver: NSObjectProtocol?
         /// Observer token for "Show on Map" (contact-centering) commands.
         var centerOnObserver: NSObjectProtocol?
+        /// Observer token for issue #72/#73 north-snap commands.
+        var resetNorthObserver: NSObjectProtocol?
         /// Watchdog: the globe pulls Cesium.js + terrain from the cesium.com
         /// CDN on every load. If the device can't reach it (bad network, dead
         /// CDN) the page sits on "Loading 3D world…" forever. If the bridge

--- a/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
@@ -77,6 +77,10 @@ extension Notification.Name {
     /// Issue #72/#73 — snap the Cesium globe heading back to north (0°).
     /// Posted by the compass overlay tap or the north-lock toggle.
     static let cesiumResetNorth = Notification.Name("cesiumResetNorth")
+    /// Issue #72 — engage/release the Cesium north-up lock. userInfo["on"]: Bool.
+    /// When on, the globe stays north-up (heading pinned to 0°) while pan/zoom/
+    /// tilt stay live; the JS side instantly re-snaps any heading drift.
+    static let cesiumSetNorthLock = Notification.Name("cesiumSetNorthLock")
 }
 
 struct CesiumMainMap: UIViewRepresentable {
@@ -100,6 +104,10 @@ struct CesiumMainMap: UIViewRepresentable {
     var lassoActive: Bool = false
     /// Base imagery layer for the globe ("satellite" | "hybrid" | "standard").
     var baseLayer: String = "satellite"
+    /// Issue #72 — north-up lock. When true the globe is pinned north-up
+    /// (heading 0°) while pan/zoom/tilt stay live. Applied on change and
+    /// re-applied on bridge-ready so it survives engine toggles / restarts.
+    var isNorthLocked: Bool = false
     let selfCallsign: String
     /// Self-position marker style from Settings ("milstd" | "bullseye").
     /// "milstd" renders the SFGPUCI---- milsymbol frame; "bullseye" falls
@@ -190,6 +198,21 @@ struct CesiumMainMap: UIViewRepresentable {
             wv.evaluateJavaScript("window.OmniBridge.setHeading({heading:0});", completionHandler: nil)
         }
 
+        // Issue #72 — engage/release the globe's north-up lock. The JS
+        // `setNorthLock` disables free-look, snaps to north, and re-snaps any
+        // heading drift on its own — so the globe physically stays north-up
+        // without the native side polling. Remember the latest value so a
+        // bridge re-init (engine toggle / WebGL process restart) can re-apply it.
+        context.coordinator.northLockObserver = NotificationCenter.default.addObserver(
+            forName: .cesiumSetNorthLock, object: nil, queue: .main
+        ) { [weak coordinator = context.coordinator] note in
+            guard let coordinator else { return }
+            let on = (note.userInfo?["on"] as? Bool) ?? false
+            coordinator.northLocked = on
+            guard coordinator.isReady, let wv = coordinator.webView else { return }
+            wv.evaluateJavaScript("window.OmniBridge.setNorthLock({on:\(on)});", completionHandler: nil)
+        }
+
         webView.loadHTMLString(CesiumMainMap.html, baseURL: URL(string: "https://cesium.com/"))
         context.coordinator.startLoadWatchdog()
         return webView
@@ -265,6 +288,13 @@ struct CesiumMainMap: UIViewRepresentable {
                 context.coordinator.lastBaseLayer = baseLayer
                 webView.evaluateJavaScript("window.OmniBridge.setBaseLayer({type:'\(baseLayer)'});", completionHandler: nil)
             }
+
+            // Issue #72 — north-up lock. Apply on transition so a persisted
+            // lock engages when the globe appears and an engine toggle keeps it.
+            if isNorthLocked != context.coordinator.northLocked {
+                context.coordinator.northLocked = isNorthLocked
+                webView.evaluateJavaScript("window.OmniBridge.setNorthLock({on:\(isNorthLocked)});", completionHandler: nil)
+            }
         }
     }
 
@@ -292,6 +322,11 @@ struct CesiumMainMap: UIViewRepresentable {
         var centerOnObserver: NSObjectProtocol?
         /// Observer token for issue #72/#73 north-snap commands.
         var resetNorthObserver: NSObjectProtocol?
+        /// Observer token for issue #72 north-lock engage/release commands.
+        var northLockObserver: NSObjectProtocol?
+        /// Latest north-lock state, re-applied when the bridge (re)initializes
+        /// so the lock survives an engine toggle or a WebGL process restart.
+        var northLocked = false
         /// Watchdog: the globe pulls Cesium.js + terrain from the cesium.com
         /// CDN on every load. If the device can't reach it (bad network, dead
         /// CDN) the page sits on "Loading 3D world…" forever. If the bridge
@@ -336,6 +371,8 @@ struct CesiumMainMap: UIViewRepresentable {
         deinit {
             if let zoomObserver { NotificationCenter.default.removeObserver(zoomObserver) }
             if let centerOnObserver { NotificationCenter.default.removeObserver(centerOnObserver) }
+            if let resetNorthObserver { NotificationCenter.default.removeObserver(resetNorthObserver) }
+            if let northLockObserver { NotificationCenter.default.removeObserver(northLockObserver) }
             loadWatchdog?.invalidate()
         }
 
@@ -349,6 +386,12 @@ struct CesiumMainMap: UIViewRepresentable {
             case "omniBridgeReady":
                 isReady = true
                 loadWatchdog?.invalidate(); loadWatchdog = nil
+                // Issue #72 — re-apply the north-lock if it was engaged before
+                // this bridge (re)initialized (engine toggle / WebGL restart),
+                // so the globe comes back north-up and stays locked.
+                if northLocked {
+                    webView?.evaluateJavaScript("window.OmniBridge.setNorthLock({on:true});", completionHandler: nil)
+                }
                 // Drain the latest snapshots the moment the HTML signals it
                 // has the OmniBridge alive — anything queued during page
                 // load lands in one shot.
@@ -625,12 +668,30 @@ struct CesiumMainMap: UIViewRepresentable {
         // HTML side renders via milsymbol.js; when nil/unparseable it
         // falls back to the affiliation-shape canvas billboard.
         let sidc: String?
+        // Issue #75 — TAK Spot Map dot color as "#RRGGBB". When present, the
+        // HTML renders a colored dot (the standard spot-map point) instead of
+        // the sidc / affiliation art, so the globe matches the 2D engine.
+        let spot: String?
         // TAK-style altitude leader line (vertical drop-line from ground to
         // the icon + "{alt} m HAE" label). Reserved for detected drones so
         // the 3D globe doesn't get cluttered with a stick under every
         // airborne ADS-B aircraft. Aircraft still float at their altitude;
         // they just don't draw the leader/label.
         let leader: Bool
+    }
+
+    /// Issue #75 — "#RRGGBB" for a TAK Spot Map marker, or nil when the entity
+    /// isn't a spot-map point. Mirrors the iOS registry / generator so the
+    /// globe dot, the 2D dot, and the emitted CoT color all agree.
+    private static func spotHex(cotType: String, iconsetPath: String?, argb: Int?) -> String? {
+        let isSpot = (iconsetPath.map { TAKSpotIcon.from(iconsetPath: $0) != nil } ?? false)
+            || cotType == TAKSpotIcon.cotType
+        guard isSpot else { return nil }
+        let color: UIColor
+        if let argb { color = TAKIconRegistry.uiColor(fromARGB: argb) }
+        else if let path = iconsetPath, let spot = TAKSpotIcon.from(iconsetPath: path) { color = spot.uiColor }
+        else { color = TAKSpotIcon.white.uiColor }
+        return CesiumMainMap.hex(forUIColor: color)
     }
 
     private func buildEntityJSON() -> String {
@@ -652,6 +713,7 @@ struct CesiumMainMap: UIViewRepresentable {
                 // HTML falls back to the green disc + center-dot canvas
                 // billboard — the globe's bullseye analog.
                 sidc: selfMarkerStyle == "bullseye" ? nil : "SFGPUCI----",
+                spot: nil,
                 leader: false
             ))
         }
@@ -670,6 +732,10 @@ struct CesiumMainMap: UIViewRepresentable {
                 // mapping the 2D Mapbox / MapKit paths use, so a contact
                 // reads identically across all engines.
                 sidc: MilStdIconService.shared.getSIDC(for: c.type),
+                // Issue #75 — spot-map dot color when the contact is a spot-map
+                // point (carries a COT_MAPPING_SPOTMAP usericon or b-m-p-s-m
+                // type); the HTML renders the dot over the sidc in that case.
+                spot: CesiumMainMap.spotHex(cotType: c.type, iconsetPath: c.iconsetPath, argb: c.argbColor),
                 // Detected drones (RID-{uasId}) get the TAK altitude leader
                 // line; other airborne CoT contacts float without the stick.
                 leader: c.uid.hasPrefix("RID-")
@@ -695,6 +761,7 @@ struct CesiumMainMap: UIViewRepresentable {
                 // HTML _billboard() function ignores sidc when kind ==
                 // "aircraft" so the directional arrow wins.
                 sidc: nil,
+                spot: nil,
                 // ADS-B aircraft float at altitude but skip the leader line to
                 // keep a busy airspace readable.
                 leader: false
@@ -718,6 +785,9 @@ struct CesiumMainMap: UIViewRepresentable {
                 kind: "marker",
                 heading: nil,
                 sidc: MilStdIconService.shared.getSIDC(for: pm.cotType),
+                // Issue #75 — a placed TAK spot-map pin renders its colored dot
+                // on the globe too, matching the picker swatch and 2D engine.
+                spot: pm.takIcon.map { CesiumMainMap.hex(forUIColor: $0.uiColor) },
                 leader: false
             ))
         }
@@ -739,6 +809,7 @@ struct CesiumMainMap: UIViewRepresentable {
                     kind: "marker",
                     heading: nil,
                     sidc: nil,
+                    spot: nil,
                     leader: false
                 ))
             }

--- a/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
@@ -128,6 +128,13 @@ struct ATAKMapView: View {
     @State private var showScaleBar = true  // ATAK-style: Enabled by default in bottom-left
     @State private var showGrid = false
 
+    // Issue #72 — north-up lock (persisted so it survives restarts)
+    @AppStorage("map_northLocked") private var isNorthLocked: Bool = false
+    // Issue #73 — current map bearing in degrees CW from north. Updated by
+    // both engines on every camera-change event so the compass overlay always
+    // reflects the live map rotation (not just device heading).
+    @State private var mapBearing: Double = 0
+
     // New ATAK-style UI states
     @State private var isCursorModeActive = false
     @State private var showQuickActionToolbar = false  // Hidden - user can access tools via radial menu and ATAK tools menu
@@ -237,7 +244,15 @@ struct ATAKMapView: View {
             mapStateManager: mapStateManager,
             measurementManager: measurementManager,
             lassoService: lassoService,
-            onMapTap: handleMapTap
+            onMapTap: handleMapTap,
+            // Issue #72 — forward the north-lock flag so TacticalMapView
+            // can disable rotation gestures when engaged.
+            isNorthLocked: isNorthLocked,
+            // Issue #73 — callback so the 2D engine reports its live
+            // bearing to the parent for the compass overlay needle.
+            onBearingChanged: { bearing in
+                mapBearing = bearing
+            }
         )
         .ignoresSafeArea()
     }
@@ -359,6 +374,7 @@ struct ATAKMapView: View {
                     showScaleBar: $showScaleBar,
                     showGrid: $showGrid,
                     showCallsignPanel: $showCallsignPanel,
+                    isNorthLocked: $isNorthLocked,
                     adsbService: ADSBTrafficService.shared,
                     onLayerToggle: { layer in
                         toggleLayer(layer)
@@ -368,6 +384,9 @@ struct ATAKMapView: View {
                     },
                     onMapOverlayToggle: { overlay in
                         toggleMapOverlay(overlay)
+                    },
+                    onNorthLockToggle: {
+                        toggleNorthLock()
                     }
                 )
                 .background(Color.black.opacity(0.9))
@@ -526,9 +545,17 @@ struct ATAKMapView: View {
         // the direction of travel and freezes at the last value when the
         // user stops moving (what was causing #44 "always 347°"). Fall back
         // to course only if heading is unavailable (e.g., no magnetometer).
+        // Issue #73 — compass is always visible (not gated on showCompass) so
+        // the tap-to-north affordance and north-lock badge are always reachable.
+        // The showCompass toggle in the layers panel now just controls whether
+        // the compass starts visible; the overlay still mounts so the lock
+        // indicator is never hidden while north-lock is engaged.
         CompassOverlayView(
             heading: compassHeading,
-            isVisible: showCompass
+            isVisible: showCompass || isNorthLocked,
+            mapBearing: mapBearing,
+            isNorthLocked: isNorthLocked,
+            onResetNorth: { resetMapToNorth() }
         )
         .zIndex(1005)
     }
@@ -1626,6 +1653,15 @@ struct ATAKMapView: View {
             cesiumLastHeight = cam.height
             cesiumLastHeading = cam.heading
             cesiumLastPitch = cam.pitch
+            // Issue #73 — mirror Cesium heading into mapBearing so the compass
+            // overlay stays in sync with the 3D globe's rotation.
+            mapBearing = cam.heading
+            // Issue #72 — if north-lock is engaged and the globe drifted,
+            // snap it back. The setHeading call is cheap (no re-render) so
+            // it's fine to fire on every camera tick when locked.
+            if isNorthLocked && abs(cam.heading) > 0.5 {
+                NotificationCenter.default.post(name: .cesiumResetNorth, object: nil)
+            }
             // Mirror the Cesium camera into mapRegion so 2D-derived chrome
             // (scale bar, MGRS grid) reads the right scale on the globe, an
             // engine toggle lands at the same view, and — crucially — the
@@ -1873,6 +1909,34 @@ struct ATAKMapView: View {
             case "callsign": showCallsignPanel.toggle()
             default: break
             }
+        }
+    }
+
+    // MARK: - North-Up Lock (Issue #72/#73)
+
+    /// Toggle the north-up lock on/off. When engaged, rotation gestures
+    /// snap back to north and the compass badge turns cyan.
+    private func toggleNorthLock() {
+        isNorthLocked.toggle()
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+        if isNorthLocked {
+            resetMapToNorth()
+        }
+        // Mapbox: rotate disable/enable is applied in TacticalMapView.updateUIView
+        // via the northLocked binding. No notification needed for 2D.
+        // Cesium: handled by isNorthLocked watchdog inside handleCesiumMapEvent.
+    }
+
+    /// Snap both map engines back to north (heading 0°).
+    private func resetMapToNorth() {
+        // Cesium — post the notification; the Coordinator forwards it to the JS bridge.
+        NotificationCenter.default.post(name: .cesiumResetNorth, object: nil)
+        // Mapbox — post a dedicated notification that TacticalMapView's
+        // coordinator listens to and applies via setCamera(bearing:0).
+        NotificationCenter.default.post(name: .mapboxResetNorth, object: nil)
+        withAnimation(.easeInOut(duration: 0.3)) {
+            mapBearing = 0
         }
     }
 

--- a/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
@@ -178,7 +178,11 @@ struct ATAKMapView: View {
                 type: event.type,
                 callsign: event.detail.callsign,
                 team: event.detail.team ?? "Unknown",
-                hae: (isAir && event.point.hae > 0) ? event.point.hae : nil
+                hae: (isAir && event.point.hae > 0) ? event.point.hae : nil,
+                // Issue #75 — carry the usericon path + color so spot-map /
+                // iconset markers resolve to the right TAK icon on the map.
+                iconsetPath: event.detail.iconsetPath,
+                argbColor: event.detail.argbColor
             )
 
             // Filter based on overlay settings and CoT affiliation
@@ -1131,6 +1135,9 @@ struct ATAKMapView: View {
                 // Base layer (satellite / hybrid / standard) so the layers
                 // panel switches the globe's imagery, not just the 2D style.
                 baseLayer: activeMapLayer,
+                // Issue #72 — north-up lock state so the globe pins north-up
+                // (persisted via @AppStorage; survives engine toggle / relaunch).
+                isNorthLocked: isNorthLocked,
                 selfCallsign: userCallsign,
                 // Self-pip style parity with the Mapbox puck (Settings →
                 // Self-position marker).
@@ -1654,14 +1661,10 @@ struct ATAKMapView: View {
             cesiumLastHeading = cam.heading
             cesiumLastPitch = cam.pitch
             // Issue #73 — mirror Cesium heading into mapBearing so the compass
-            // overlay stays in sync with the 3D globe's rotation.
-            mapBearing = cam.heading
-            // Issue #72 — if north-lock is engaged and the globe drifted,
-            // snap it back. The setHeading call is cheap (no re-render) so
-            // it's fine to fire on every camera tick when locked.
-            if isNorthLocked && abs(cam.heading) > 0.5 {
-                NotificationCenter.default.post(name: .cesiumResetNorth, object: nil)
-            }
+            // overlay stays in sync with the 3D globe's rotation. When the lock
+            // is engaged the JS side pins heading to 0° itself (setNorthLock),
+            // so this just reflects the corrected value — no native re-snap loop.
+            mapBearing = isNorthLocked ? 0 : cam.heading
             // Mirror the Cesium camera into mapRegion so 2D-derived chrome
             // (scale bar, MGRS grid) reads the right scale on the globe, an
             // engine toggle lands at the same view, and — crucially — the
@@ -1920,12 +1923,19 @@ struct ATAKMapView: View {
         isNorthLocked.toggle()
         let generator = UIImpactFeedbackGenerator(style: .medium)
         generator.impactOccurred()
-        if isNorthLocked {
-            resetMapToNorth()
-        }
         // Mapbox: rotate disable/enable is applied in TacticalMapView.updateUIView
-        // via the northLocked binding. No notification needed for 2D.
-        // Cesium: handled by isNorthLocked watchdog inside handleCesiumMapEvent.
+        // via the isNorthLocked binding (gestures.options.rotateEnabled).
+        // Cesium: engage/release the real lock so the globe stays north-up and
+        // can't be twisted off north — the JS side snaps to north on engage and
+        // self-corrects any drift.
+        NotificationCenter.default.post(
+            name: .cesiumSetNorthLock, object: nil, userInfo: ["on": isNorthLocked]
+        )
+        if isNorthLocked {
+            // Snap the 2D engine to north now (Cesium snaps inside setNorthLock).
+            NotificationCenter.default.post(name: .mapboxResetNorth, object: nil)
+            withAnimation(.easeInOut(duration: 0.3)) { mapBearing = 0 }
+        }
     }
 
     /// Snap both map engines back to north (heading 0°).
@@ -2170,6 +2180,13 @@ struct CoTMarker: Identifiable {
     /// Height above ellipsoid (m) for airborne tracks (air-dimension CoT).
     /// nil → clamp to ground. Drives the Cesium 3D altitude + TAK leader line.
     var hae: Double? = nil
+    /// Issue #75 — `usericon iconsetpath` from the incoming CoT (e.g.
+    /// `COT_MAPPING_SPOTMAP/red`), so a received spot-map / iconset marker
+    /// resolves to the right TAK icon instead of a generic affiliation frame.
+    var iconsetPath: String? = nil
+    /// Issue #75 — signed ARGB color from the CoT `<color>` element. Spot-map
+    /// points carry their color here rather than in the type.
+    var argbColor: Int? = nil
 }
 
 struct CoTMarkerView: View {

--- a/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
@@ -716,7 +716,9 @@ struct TacticalMapView: UIViewRepresentable {
             var fresh: [PointAnnotation] = []
             fresh.reserveCapacity(parent.markers.count)
             for marker in parent.markers {
-                let key = "cot|\(marker.type)|\(marker.callsign)"
+                // Style-image key folds in the icon source so a spot-map dot and
+                // an affiliation frame of the same type don't share one image.
+                let key = "cot|\(marker.type)|\(marker.iconsetPath ?? "")|\(marker.argbColor ?? 0)|\(marker.callsign)"
                 let img = symbolImage(for: marker)
                 var ann = PointAnnotation(id: "cot-\(marker.uid)", coordinate: marker.coordinate)
                 ann.image = .init(image: img, name: key)
@@ -728,6 +730,19 @@ struct TacticalMapView: UIViewRepresentable {
         }
 
         private func symbolImage(for marker: CoTMarker) -> UIImage {
+            // Issue #75 — TAK icon suite. If the marker carries a known iconset
+            // path (e.g. COT_MAPPING_SPOTMAP/red) or is a spot-map CoT type,
+            // resolve it to the standard TAK icon. Falls through to MIL-STD-2525
+            // when the registry has no match (the existing affiliation frames).
+            if let img = TAKIconRegistry.shared.resolveImage(
+                cotType: marker.type,
+                iconsetPath: marker.iconsetPath,
+                argb: marker.argbColor,
+                size: 28
+            ) {
+                return img
+            }
+
             let key = "cot|\(marker.type)|\(marker.callsign)"
             if let cached = symbolImageCache[key] { return cached }
 
@@ -778,7 +793,10 @@ struct TacticalMapView: UIViewRepresentable {
             fresh.reserveCapacity(parent.pointMarkers.count)
             for pm in parent.pointMarkers {
                 let img = pointMarkerImage(for: pm)
-                let key = "pm|\(pm.affiliation.rawValue)"
+                // Style-image key must distinguish TAK spot icons from plain
+                // affiliation glyphs, else two markers sharing an affiliation
+                // but different spot colors would collide on one cached image.
+                let key = pm.takIcon.map { "pm|spot|\($0.rawValue)" } ?? "pm|\(pm.affiliation.rawValue)"
                 var ann = PointAnnotation(id: "pm-\(pm.id.uuidString)", coordinate: pm.coordinate)
                 ann.image = .init(image: img, name: key)
                 ann.textField = pm.name
@@ -799,6 +817,12 @@ struct TacticalMapView: UIViewRepresentable {
         }
 
         private func pointMarkerImage(for marker: PointMarker) -> UIImage {
+            // TAK Spot Map icon (issue #75) — render the standard colored dot
+            // via the shared registry so it matches the picker swatch and the
+            // 3D globe pixel-for-pixel.
+            if let spot = marker.takIcon {
+                return TAKIconRegistry.shared.image(for: spot, size: 36)
+            }
             let key = "pmimg|\(marker.affiliation.rawValue)"
             if let cached = symbolImageCache[key] { return cached }
             let size = CGSize(width: 36, height: 36)

--- a/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
@@ -13,6 +13,13 @@ import CoreLocation
 import MapboxMaps
 import UIKit
 
+// MARK: - Mapbox north-reset notification (Issue #72/#73)
+
+extension Notification.Name {
+    /// Posted by ATAKMapView to snap the Mapbox camera heading to 0° (north).
+    static let mapboxResetNorth = Notification.Name("mapboxResetNorth")
+}
+
 // MARK: - Tactical Map View (Mapbox Maps SDK v3 — native)
 //
 // This is the main map surface for OmniTAK iOS. It used to wrap MKMapView;
@@ -44,6 +51,13 @@ struct TacticalMapView: UIViewRepresentable {
     @ObservedObject var rasterStore: RasterOverlayStore = RasterOverlayStore.shared
     @ObservedObject var mbtilesStore: MBTilesOverlayStore = MBTilesOverlayStore.shared
     let onMapTap: (CLLocationCoordinate2D) -> Void
+    /// Issue #72 — when true, rotation gestures are disabled and bearing
+    /// is snapped back to 0° on any camera-change that drifts off north.
+    var isNorthLocked: Bool = false
+    /// Issue #73 — called with the current map bearing (° CW from north)
+    /// whenever the Mapbox camera rotates, so the parent can update the
+    /// compass overlay needle.
+    var onBearingChanged: ((Double) -> Void)? = nil
 
     // MARK: - UIViewRepresentable
 
@@ -144,6 +158,23 @@ struct TacticalMapView: UIViewRepresentable {
             coord.handleCameraChanged(mapView: mapView)
         }
 
+        // Issue #72/#73 — listen for the north-snap notification so
+        // both the compass tap and the north-lock toggle route through
+        // the same path on the 2D engine.
+        coord.resetNorthObserver = NotificationCenter.default.addObserver(
+            forName: .mapboxResetNorth, object: nil, queue: .main
+        ) { [weak coord, weak mapView] _ in
+            guard let mapView = mapView else { return }
+            coord?.isProgrammaticUpdate = true
+            let state = mapView.mapboxMap.cameraState
+            mapView.mapboxMap.setCamera(to: CameraOptions(
+                center: state.center,
+                zoom: state.zoom,
+                bearing: 0,
+                pitch: state.pitch
+            ))
+        }
+
         return mapView
     }
 
@@ -163,6 +194,11 @@ struct TacticalMapView: UIViewRepresentable {
             }
         }
 
+        // Issue #72 — north-lock: disable rotation gesture while locked,
+        // re-enable when released. The Mapbox API exposes this cleanly on
+        // gestures.options without tearing down the whole gesture stack.
+        mapView.gestures.options.rotateEnabled = !isNorthLocked
+
         // Region sync — only push to Mapbox if the SwiftUI region
         // diverges from the camera state by more than a hair. This is
         // the same feedback-loop guard MKMapView needed.
@@ -172,6 +208,8 @@ struct TacticalMapView: UIViewRepresentable {
                 abs(cameraState.center.latitude - region.center.latitude) > 0.0001 ||
                 abs(cameraState.center.longitude - region.center.longitude) > 0.0001
             let zoomChanged = abs(cameraState.zoom - TacticalMapView.zoom(forSpan: region.span, mapHeight: mapView.bounds.height)) > 0.25
+            // Issue #72 — when north-locked, always keep bearing at 0.
+            let bearingForUpdate = isNorthLocked ? 0.0 : cameraState.bearing
             if centerChanged || zoomChanged {
                 context.coordinator.isProgrammaticUpdate = true
                 // Explicitly preserve current pitch + bearing — MKCoordinateRegion
@@ -181,7 +219,7 @@ struct TacticalMapView: UIViewRepresentable {
                 let opts = CameraOptions(
                     center: region.center,
                     zoom: TacticalMapView.zoom(forSpan: region.span, mapHeight: mapView.bounds.height),
-                    bearing: cameraState.bearing,
+                    bearing: bearingForUpdate,
                     pitch: cameraState.pitch
                 )
                 mapView.mapboxMap.setCamera(to: opts)
@@ -293,6 +331,9 @@ struct TacticalMapView: UIViewRepresentable {
         // Camera feedback-loop guards
         var isUserInteracting = false
         var isProgrammaticUpdate = false
+
+        // Issue #72/#73 — reset-north observer (removes itself on dealloc)
+        var resetNorthObserver: NSObjectProtocol?
 
         // Annotation managers — one per geometry kind. Mapbox v11
         // wants us to reuse these (cheap to create, expensive to
@@ -422,7 +463,23 @@ struct TacticalMapView: UIViewRepresentable {
                 span: TacticalMapView.span(forZoom: state.zoom, latitude: state.center.latitude)
             )
             DispatchQueue.main.async { [weak self] in
-                self?.parent.region = newRegion
+                guard let self else { return }
+                self.parent.region = newRegion
+                // Issue #73 — report bearing so the compass overlay needle tracks
+                // the 2D map's rotation (not just the device's magnetometer).
+                self.parent.onBearingChanged?(state.bearing)
+                // Issue #72 — if north-lock is engaged, snap back to 0° on any
+                // user-initiated rotation (bearing drift > 0.5° threshold).
+                if self.parent.isNorthLocked && !self.isProgrammaticUpdate && abs(state.bearing) > 0.5 {
+                    self.isProgrammaticUpdate = true
+                    mapView.mapboxMap.setCamera(to: CameraOptions(
+                        center: state.center,
+                        zoom: state.zoom,
+                        bearing: 0,
+                        pitch: state.pitch
+                    ))
+                    self.isProgrammaticUpdate = false
+                }
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
                 self?.isUserInteracting = false

--- a/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
@@ -793,10 +793,14 @@ struct TacticalMapView: UIViewRepresentable {
             fresh.reserveCapacity(parent.pointMarkers.count)
             for pm in parent.pointMarkers {
                 let img = pointMarkerImage(for: pm)
-                // Style-image key must distinguish TAK spot icons from plain
+                // Style-image key must distinguish each TAK icon pack from plain
                 // affiliation glyphs, else two markers sharing an affiliation
-                // but different spot colors would collide on one cached image.
-                let key = pm.takIcon.map { "pm|spot|\($0.rawValue)" } ?? "pm|\(pm.affiliation.rawValue)"
+                // but different pack icons would collide on one cached image.
+                let key: String
+                if let spot = pm.takIcon { key = "pm|spot|\(spot.rawValue)" }
+                else if let mk = pm.markersIcon { key = "pm|mk|\(mk.rawValue)" }
+                else if let g = pm.googleIcon { key = "pm|google|\(g.rawValue)" }
+                else { key = "pm|\(pm.affiliation.rawValue)" }
                 var ann = PointAnnotation(id: "pm-\(pm.id.uuidString)", coordinate: pm.coordinate)
                 ann.image = .init(image: img, name: key)
                 ann.textField = pm.name
@@ -806,22 +810,26 @@ struct TacticalMapView: UIViewRepresentable {
                 ann.textHaloColor = StyleColor(.black)
                 ann.textHaloWidth = 1.0
                 ann.textSize = 11
-                // Affiliation glyphs are circular, so center them on the
-                // coordinate. `.bottom` (for teardrop pins) made the circle
-                // render above its point — markers appeared to drop above
-                // the aim crosshair.
-                ann.iconAnchor = .center
+                // Circular glyphs (spot dots, 2525 frames, affiliation) center on
+                // the coordinate; the Google teardrop pin points at its tip, so
+                // it anchors at the bottom.
+                ann.iconAnchor = pm.googleIcon != nil ? .bottom : .center
                 fresh.append(ann)
             }
             manager.annotations = fresh
         }
 
         private func pointMarkerImage(for marker: PointMarker) -> UIImage {
-            // TAK Spot Map icon (issue #75) — render the standard colored dot
-            // via the shared registry so it matches the picker swatch and the
-            // 3D globe pixel-for-pixel.
+            // TAK icon suite (issue #75) — render the picked pack icon via the
+            // shared registry so it matches the picker swatch and the 3D globe.
             if let spot = marker.takIcon {
                 return TAKIconRegistry.shared.image(for: spot, size: 36)
+            }
+            if let mk = marker.markersIcon {
+                return TAKIconRegistry.shared.image(for: mk, size: 36)
+            }
+            if let g = marker.googleIcon {
+                return TAKIconRegistry.shared.image(for: g, size: 40)
             }
             let key = "pmimg|\(marker.affiliation.rawValue)"
             if let cached = symbolImageCache[key] { return cached }

--- a/OmniTAKMobile/Features/Map/Views/CompassOverlayView.swift
+++ b/OmniTAKMobile/Features/Map/Views/CompassOverlayView.swift
@@ -2,11 +2,20 @@ import SwiftUI
 import CoreLocation
 
 // MARK: - Compass Overlay View
-// ATAK-style rotating compass showing current heading
+// ATAK-style rotating compass showing current map bearing.
+// Tapping the collapsed compass resets the map to north (issue #73).
+// The `isNorthLocked` flag is shown as a lock badge when active (issue #72).
 
 struct CompassOverlayView: View {
     let heading: CLLocationDirection? // 0-360 degrees, 0 = North
     let isVisible: Bool
+    /// Current map bearing (degrees CW from north). Drives the compass
+    /// needle when provided; falls back to device heading otherwise.
+    var mapBearing: Double = 0
+    /// True while the north-lock is engaged (issue #72).
+    var isNorthLocked: Bool = false
+    /// Called when the operator taps the collapsed compass to snap north.
+    var onResetNorth: (() -> Void)? = nil
 
     @State private var displayHeading: Double = 0
     @State private var isExpanded: Bool = false
@@ -37,10 +46,10 @@ struct CompassOverlayView: View {
                 .frame(width: 60, height: 60)
 
             Circle()
-                .stroke(Color(hex: "#FFFC00").opacity(0.3), lineWidth: 1.5)
+                .stroke(isNorthLocked ? Color.cyan.opacity(0.6) : Color(hex: "#FFFC00").opacity(0.3), lineWidth: 1.5)
                 .frame(width: 60, height: 60)
 
-            // Simplified compass rose
+            // Simplified compass rose — rotates by map bearing
             ZStack {
                 Circle()
                     .fill(Color.black.opacity(0.5))
@@ -70,30 +79,48 @@ struct CompassOverlayView: View {
                     .fill(Color.white.opacity(0.6))
                     .frame(width: 42, height: 1)
             }
-            .rotationEffect(.degrees(-displayHeading))
-            .animation(.easeInOut(duration: 0.3), value: displayHeading)
+            // Use map bearing (not device heading) so the needle tracks
+            // which direction the map is rotated, not where the device points.
+            .rotationEffect(.degrees(-mapBearing))
+            .animation(.easeInOut(duration: 0.3), value: mapBearing)
 
             // Center dot
             Circle()
                 .fill(Color(hex: "#FFFC00"))
                 .frame(width: 6, height: 6)
 
-            // Heading text
+            // Map bearing text below the circle
             VStack {
                 Spacer()
-                Text(headingText)
+                Text(bearingText)
                     .font(.system(size: 9, weight: .bold))
-                    .foregroundColor(Color(hex: "#FFFC00"))
+                    .foregroundColor(isNorthLocked ? Color.cyan : Color(hex: "#FFFC00"))
                     .offset(y: 34)
+            }
+
+            // North-lock badge — small lock icon in top-right corner
+            if isNorthLocked {
+                VStack {
+                    HStack {
+                        Spacer()
+                        Image(systemName: "lock.fill")
+                            .font(.system(size: 8, weight: .bold))
+                            .foregroundColor(.cyan)
+                            .offset(x: 2, y: -2)
+                    }
+                    Spacer()
+                }
             }
         }
         .frame(width: 60, height: 60)
         .onTapGesture {
-            withAnimation(.easeInOut(duration: 0.3)) {
-                isExpanded = true
-            }
+            // Tap snaps map to north and collapses any expanded state (issue #73)
+            onResetNorth?()
             let generator = UIImpactFeedbackGenerator(style: .light)
             generator.impactOccurred()
+            withAnimation(.easeInOut(duration: 0.3)) {
+                isExpanded = false
+            }
         }
         .onChange(of: heading) { newHeading in
             if let newHeading = newHeading {
@@ -110,10 +137,10 @@ struct CompassOverlayView: View {
                 .frame(width: 100, height: 100)
 
             Circle()
-                .stroke(Color(hex: "#FFFC00").opacity(0.3), lineWidth: 2)
+                .stroke(isNorthLocked ? Color.cyan.opacity(0.6) : Color(hex: "#FFFC00").opacity(0.3), lineWidth: 2)
                 .frame(width: 100, height: 100)
 
-            // Compass rose - rotates based on heading
+            // Compass rose — rotates by map bearing
             ZStack {
                 // Cardinal directions background circle
                 Circle()
@@ -176,20 +203,20 @@ struct CompassOverlayView: View {
                 }
                 .frame(width: 1)
             }
-            .rotationEffect(.degrees(-displayHeading))
-            .animation(.easeInOut(duration: 0.3), value: displayHeading)
+            .rotationEffect(.degrees(-mapBearing))
+            .animation(.easeInOut(duration: 0.3), value: mapBearing)
 
             // Center dot
             Circle()
                 .fill(Color(hex: "#FFFC00"))
                 .frame(width: 8, height: 8)
 
-            // Heading display at bottom
+            // Map bearing display at bottom
             VStack {
                 Spacer()
-                Text(headingText)
+                Text(bearingText)
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundColor(Color(hex: "#FFFC00"))
+                    .foregroundColor(isNorthLocked ? Color.cyan : Color(hex: "#FFFC00"))
                     .padding(.horizontal, 8)
                     .padding(.vertical, 2)
                     .background(Color.black.opacity(0.8))
@@ -199,17 +226,26 @@ struct CompassOverlayView: View {
         }
         .frame(width: 100, height: 100)
         .onTapGesture {
+            // Tap on expanded view snaps to north (same as collapsed tap)
+            onResetNorth?()
+            let generator = UIImpactFeedbackGenerator(style: .light)
+            generator.impactOccurred()
             withAnimation(.easeInOut(duration: 0.3)) {
                 isExpanded = false
             }
-            let generator = UIImpactFeedbackGenerator(style: .light)
-            generator.impactOccurred()
         }
         .onChange(of: heading) { newHeading in
             if let newHeading = newHeading {
                 displayHeading = newHeading
             }
         }
+    }
+
+    /// Formatted map bearing — shows "000°" when north-locked (issue #73).
+    private var bearingText: String {
+        let normalized = Int(mapBearing.truncatingRemainder(dividingBy: 360).rounded())
+        let clamped = (normalized + 360) % 360
+        return String(format: "%03d°", clamped)
     }
 
     private var headingText: String {

--- a/OmniTAKMobile/Features/Networking/Services/TAKService.swift
+++ b/OmniTAKMobile/Features/Networking/Services/TAKService.swift
@@ -969,6 +969,11 @@ struct CoTDetail {
     let battery: Int?
     let device: String?
     let platform: String?
+    /// Issue #75 — `usericon iconsetpath` from the CoT `<usericon>` element
+    /// (e.g. `COT_MAPPING_SPOTMAP/red`), used to resolve the TAK icon.
+    var iconsetPath: String? = nil
+    /// Issue #75 — signed ARGB color from the CoT `<color>` element.
+    var argbColor: Int? = nil
 }
 
 // MARK: - Server Connection State
@@ -1924,6 +1929,22 @@ private func parseCoT(xml: String) -> CoTEvent? {
         platform = extractAttribute("platform", from: takvTag)
     }
 
+    // Issue #75 — extract the usericon iconset path so received iconset /
+    // spot-map markers resolve to the right TAK icon instead of a generic
+    // affiliation frame.
+    var iconsetPath: String? = nil
+    if let iconRange = xml.range(of: "<usericon[^>]+>", options: .regularExpression) {
+        iconsetPath = extractAttribute("iconsetpath", from: String(xml[iconRange]))
+    }
+
+    // Issue #75 — extract the <color argb> value (spot-map points carry their
+    // color here, not in the type). Stored as a signed Int for the registry.
+    var argbColor: Int? = nil
+    if let colorRange = xml.range(of: "<color[^>]+>", options: .regularExpression),
+       let argbStr = extractAttribute("argb", from: String(xml[colorRange])) {
+        argbColor = Int(argbStr)
+    }
+
     return CoTEvent(
         uid: String(uid),
         type: String(type),
@@ -1938,7 +1959,9 @@ private func parseCoT(xml: String) -> CoTEvent? {
             remarks: remarks,
             battery: battery,
             device: device,
-            platform: platform
+            platform: platform,
+            iconsetPath: iconsetPath,
+            argbColor: argbColor
         )
     )
 }

--- a/OmniTAKMobile/Resources/cesium_scene.html
+++ b/OmniTAKMobile/Resources/cesium_scene.html
@@ -57,7 +57,11 @@
   // Issue #75 — perceived-luminance test for a #RRGGBB hex, to pick a
   // contrasting outline on spot-map dots (matches the iOS registry).
   function _isLight(hex){const m=/^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex||'');if(!m)return false;const r=parseInt(m[1],16)/255,g=parseInt(m[2],16)/255,b=parseInt(m[3],16)/255;return(0.299*r+0.587*g+0.114*b)>0.6}
-  function _billboard(a,k,sidc,spot){
+  function _billboard(a,k,sidc,spot,icon){
+    // Issue #75 — pre-rendered pack icon (the TAK "Google" place pin) supplied
+    // as a PNG data URI. Wins over sidc / affiliation art so a Google-pack
+    // marker reads the same pin on 2D and 3D. Spot dots are handled below.
+    if(icon&&k!=='aircraft'){return icon;}
     // Issue #75 — TAK Spot Map point: a colored dot whose color rides the CoT
     // <color> element (passed as `spot`, a #RRGGBB string). Wins over sidc /
     // affiliation art so a spot-map marker reads the same dot on 2D and 3D.
@@ -156,11 +160,14 @@
       const leaderPos=showLeader?Cesium.Cartesian3.fromDegreesArrayHeights([e.lon,e.lat,0,e.lon,e.lat,hae]):null;
       const labelText=(e.callsign||'')+(showLeader?('\n'+Math.round(hae)+' m HAE'):'');
       let entity=_state.entities.get(e.uid);
+      // The Google place pin (e.icon) is a teardrop that points at its tip, so
+      // anchor it at the bottom; dots / sidc / affiliation glyphs stay centered.
+      const vo=(e.icon&&e.kind!=='aircraft')?Cesium.VerticalOrigin.BOTTOM:Cesium.VerticalOrigin.CENTER;
       if(!entity){entity=v.entities.add({id:e.uid,position:pos,
-        billboard:{image:_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot),verticalOrigin:Cesium.VerticalOrigin.CENTER,heightReference:hr,disableDepthTestDistance:Number.POSITIVE_INFINITY,scale:e.kind==='aircraft'?1.5:0.7,rotation:rot},
+        billboard:{image:_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot,e.icon),verticalOrigin:vo,heightReference:hr,disableDepthTestDistance:Number.POSITIVE_INFINITY,scale:e.kind==='aircraft'?1.5:0.7,rotation:rot},
         label:labelText?{text:labelText,font:'12px -apple-system, sans-serif',fillColor:Cesium.Color.WHITE,outlineColor:Cesium.Color.BLACK,outlineWidth:2,style:Cesium.LabelStyle.FILL_AND_OUTLINE,pixelOffset:new Cesium.Cartesian2(0,-32),heightReference:hr,disableDepthTestDistance:Number.POSITIVE_INFINITY}:undefined,
       });_state.entities.set(e.uid,entity);}
-      else{entity.position=pos;entity.billboard.image=_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot);entity.billboard.heightReference=hr;entity.billboard.rotation=rot;
+      else{entity.position=pos;entity.billboard.image=_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot,e.icon);entity.billboard.verticalOrigin=vo;entity.billboard.heightReference=hr;entity.billboard.rotation=rot;
         if(entity.label){entity.label.text=labelText;entity.label.heightReference=hr;}}
       // Leader line as its OWN entity (uid+':leader'), remove-then-add
       // on every upsert — exactly like trails/measurements. Mutating a

--- a/OmniTAKMobile/Resources/cesium_scene.html
+++ b/OmniTAKMobile/Resources/cesium_scene.html
@@ -179,6 +179,14 @@
       if(amount<1)return;
       if(f<1)v.camera.zoomIn(amount);else v.camera.zoomOut(amount);
     },
+    // Issue #72/#73 — rotate the globe to the requested heading (degrees CW
+    // from north) while keeping the current center, altitude, and pitch.
+    // Called with {heading:0} from the iOS layer to snap north.
+    setHeading(arg){const e=_parse(arg);if(!e)return;const v=_state.viewer;if(!v)return;
+      const hd=Cesium.Math.toRadians(typeof e.heading==='number'?e.heading:0);
+      const pos=v.camera.positionWC.clone();const dir=v.camera.directionWC.clone();const up=v.camera.upWC.clone();
+      v.camera.flyTo({destination:pos,orientation:{heading:hd,pitch:v.camera.pitch,roll:0},duration:0.4});
+    },
     // Lasso multi-select mode. While on, the overlay canvas captures
     // the single-finger drag (DOM touch events) and intercepts it so
     // the globe stays put; camera inputs are also disabled as a backup.

--- a/OmniTAKMobile/Resources/cesium_scene.html
+++ b/OmniTAKMobile/Resources/cesium_scene.html
@@ -28,7 +28,7 @@
 <script src="https://unpkg.com/milsymbol@2.2.0/dist/milsymbol.js"></script>
 <script>
   Cesium.Ion.defaultAccessToken='__CESIUM_ION_TOKEN__';
-  const _state={ready:false,viewer:null,entities:new Map(),drawings:new Map(),measurements:new Map(),trails:new Map(),leaders:new Map(),photoreal:null,billboardCache:new Map(),lasso:{enabled:false,dragging:false,pts:[],handler:null}};
+  const _state={ready:false,viewer:null,entities:new Map(),drawings:new Map(),measurements:new Map(),trails:new Map(),leaders:new Map(),photoreal:null,billboardCache:new Map(),lasso:{enabled:false,dragging:false,pts:[],handler:null},northLocked:false,northSnapping:false};
   // Lasso multi-select drag (issue #16, 3D parity). Camera pan is
   // disabled while the lasso is enabled; the freehand path is drawn on
   // a 2D overlay canvas and the screen points are picked to lat/lon on
@@ -54,7 +54,19 @@
   window.addEventListener('resize',_fitViewport);
   document.addEventListener('DOMContentLoaded',_fitViewport);
   function _color(a){return a==='f'?'#4ADE80':a==='h'?'#F44336':a==='n'?'#FFC107':'#B39DDB'}
-  function _billboard(a,k,sidc){
+  // Issue #75 — perceived-luminance test for a #RRGGBB hex, to pick a
+  // contrasting outline on spot-map dots (matches the iOS registry).
+  function _isLight(hex){const m=/^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex||'');if(!m)return false;const r=parseInt(m[1],16)/255,g=parseInt(m[2],16)/255,b=parseInt(m[3],16)/255;return(0.299*r+0.587*g+0.114*b)>0.6}
+  function _billboard(a,k,sidc,spot){
+    // Issue #75 — TAK Spot Map point: a colored dot whose color rides the CoT
+    // <color> element (passed as `spot`, a #RRGGBB string). Wins over sidc /
+    // affiliation art so a spot-map marker reads the same dot on 2D and 3D.
+    if(spot&&k!=='aircraft'){const dk='spot|'+spot;if(_state.billboardCache.has(dk))return _state.billboardCache.get(dk);
+      const dc=document.createElement('canvas');dc.width=56;dc.height=56;const dx=dc.getContext('2d');
+      dx.beginPath();dx.arc(28,28,18,0,Math.PI*2);dx.fillStyle=spot;dx.fill();
+      // Contrasting ring so the dot reads on any imagery.
+      const lite=_isLight(spot);dx.lineWidth=4;dx.strokeStyle=lite?'#000':'#fff';dx.stroke();
+      const durl=dc.toDataURL('image/png');_state.billboardCache.set(dk,durl);return durl;}
     if(sidc&&window.ms&&k!=='aircraft'){const sk='sidc|'+sidc;if(_state.billboardCache.has(sk))return _state.billboardCache.get(sk);
       try{const sym=new window.ms.Symbol(sidc,{size:32,infoBackground:'transparent',infoColor:'white'});const url=sym.asCanvas().toDataURL('image/png');_state.billboardCache.set(sk,url);return url;}catch(e){console.warn('milsymbol failed for',sidc,e);}}
     const key=a+'|'+(k||'');if(_state.billboardCache.has(key))return _state.billboardCache.get(key);
@@ -92,7 +104,22 @@
   function _pickedUid(viewer,pos){const p=viewer.scene.pick(pos);return(p&&p.id&&typeof p.id.id==='string')?p.id.id:null}
   function _cartoFor(viewer,pos){let c=viewer.scene.pickPosition(pos);if(!Cesium.defined(c))c=viewer.camera.pickEllipsoid(pos,viewer.scene.globe.ellipsoid);if(!Cesium.defined(c))return null;const cc=Cesium.Cartographic.fromCartesian(c);return{lat:Cesium.Math.toDegrees(cc.latitude),lon:Cesium.Math.toDegrees(cc.longitude),hae:cc.height}}
   function _zoomFromHeight(h,latRad){const c=Math.max(Math.cos(latRad||0),0.01),mpp=(h*256)/1000.0,z=Math.log2(40075017*c/Math.max(mpp,1));return Math.max(0,Math.min(22,z))}
-  function _postCameraChanged(v){const cam=v.camera,carto=cam.positionCartographic;if(!carto)return;const r=cam.computeViewRectangle(v.scene.globe.ellipsoid);
+  function _postCameraChanged(v){const cam=v.camera,carto=cam.positionCartographic;if(!carto)return;
+    // Issue #72 — north-up lock guarantee. If the heading drifted off north
+    // (e.g. a two-finger twist, which Cesium folds into the rotate gesture and
+    // can't be disabled without killing pan), snap it straight back in-place.
+    // Guarded by _state.northSnapping so this re-entrant camera change doesn't
+    // recurse. Done in JS (no native round-trip / flyTo) so it's instant and
+    // doesn't fight the gesture.
+    if(_state.northLocked&&!_state.northSnapping&&Math.abs(cam.heading)>0.0087&&Math.abs(cam.heading-2*Math.PI)>0.0087){
+      _state.northSnapping=true;
+      const cv=v.scene.canvas;let ctr=v.scene.pickPosition(new Cesium.Cartesian2(cv.clientWidth/2,cv.clientHeight/2));
+      if(!Cesium.defined(ctr))ctr=cam.pickEllipsoid(new Cesium.Cartesian2(cv.clientWidth/2,cv.clientHeight/2),v.scene.globe.ellipsoid);
+      if(Cesium.defined(ctr)){const range=Cesium.Cartesian3.distance(cam.positionWC,ctr);cam.lookAt(ctr,new Cesium.HeadingPitchRange(0,cam.pitch,range));cam.lookAtTransform(Cesium.Matrix4.IDENTITY);}
+      else{cam.setView({orientation:{heading:0,pitch:cam.pitch,roll:0}});}
+      _state.northSnapping=false;
+    }
+    const r=cam.computeViewRectangle(v.scene.globe.ellipsoid);
     // The point under the SCREEN CENTER (where the aim crosshair sits)
     // — distinct from the camera's sub-point when tilted. Used as the
     // point-drop coordinate and the scale-bar / region center.
@@ -130,10 +157,10 @@
       const labelText=(e.callsign||'')+(showLeader?('\n'+Math.round(hae)+' m HAE'):'');
       let entity=_state.entities.get(e.uid);
       if(!entity){entity=v.entities.add({id:e.uid,position:pos,
-        billboard:{image:_billboard(e.affiliation||'u',e.kind,e.sidc),verticalOrigin:Cesium.VerticalOrigin.CENTER,heightReference:hr,disableDepthTestDistance:Number.POSITIVE_INFINITY,scale:e.kind==='aircraft'?1.5:0.7,rotation:rot},
+        billboard:{image:_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot),verticalOrigin:Cesium.VerticalOrigin.CENTER,heightReference:hr,disableDepthTestDistance:Number.POSITIVE_INFINITY,scale:e.kind==='aircraft'?1.5:0.7,rotation:rot},
         label:labelText?{text:labelText,font:'12px -apple-system, sans-serif',fillColor:Cesium.Color.WHITE,outlineColor:Cesium.Color.BLACK,outlineWidth:2,style:Cesium.LabelStyle.FILL_AND_OUTLINE,pixelOffset:new Cesium.Cartesian2(0,-32),heightReference:hr,disableDepthTestDistance:Number.POSITIVE_INFINITY}:undefined,
       });_state.entities.set(e.uid,entity);}
-      else{entity.position=pos;entity.billboard.image=_billboard(e.affiliation||'u',e.kind,e.sidc);entity.billboard.heightReference=hr;entity.billboard.rotation=rot;
+      else{entity.position=pos;entity.billboard.image=_billboard(e.affiliation||'u',e.kind,e.sidc,e.spot);entity.billboard.heightReference=hr;entity.billboard.rotation=rot;
         if(entity.label){entity.label.text=labelText;entity.label.heightReference=hr;}}
       // Leader line as its OWN entity (uid+':leader'), remove-then-add
       // on every upsert — exactly like trails/measurements. Mutating a
@@ -180,12 +207,45 @@
       if(f<1)v.camera.zoomIn(amount);else v.camera.zoomOut(amount);
     },
     // Issue #72/#73 — rotate the globe to the requested heading (degrees CW
-    // from north) while keeping the current center, altitude, and pitch.
-    // Called with {heading:0} from the iOS layer to snap north.
+    // from north) while keeping the screen-center ground point, altitude, and
+    // pitch fixed. Called with {heading:0} from the iOS layer to snap north.
+    // Reorients AROUND the point under the screen crosshair (via lookAt) so the
+    // operator's framing doesn't jump — flying to the camera's own world
+    // position left the rotation reference ambiguous and could drift the view.
     setHeading(arg){const e=_parse(arg);if(!e)return;const v=_state.viewer;if(!v)return;
       const hd=Cesium.Math.toRadians(typeof e.heading==='number'?e.heading:0);
-      const pos=v.camera.positionWC.clone();const dir=v.camera.directionWC.clone();const up=v.camera.upWC.clone();
-      v.camera.flyTo({destination:pos,orientation:{heading:hd,pitch:v.camera.pitch,roll:0},duration:0.4});
+      const cam=v.camera;const cv=v.scene.canvas;
+      // Ground point under the screen center is the natural pivot. Fall back to
+      // the camera's sub-point if the crosshair is off-globe (e.g. horizon in view).
+      let center=v.scene.pickPosition(new Cesium.Cartesian2(cv.clientWidth/2,cv.clientHeight/2));
+      if(!Cesium.defined(center))center=cam.pickEllipsoid(new Cesium.Cartesian2(cv.clientWidth/2,cv.clientHeight/2),v.scene.globe.ellipsoid);
+      if(!Cesium.defined(center)){
+        // No ground reference (horizon/space in view) — reorient in place.
+        cam.setView({orientation:{heading:hd,pitch:cam.pitch,roll:0}});v.scene.requestRender();return;
+      }
+      // Reorient AROUND the screen-center ground point via lookAt so the
+      // operator's framing doesn't jump, then release the reference frame so
+      // free pan/zoom keep working. lookAt is synchronous → north-lock snaps
+      // instantly without a flyTo animation fighting the gesture.
+      const range=Cesium.Cartesian3.distance(cam.positionWC,center);
+      cam.lookAt(center,new Cesium.HeadingPitchRange(hd,cam.pitch,range));
+      cam.lookAtTransform(Cesium.Matrix4.IDENTITY);
+      v.scene.requestRender();
+    },
+    // Issue #72 — true north-up lock for the globe. ATAK-style: while locked,
+    // the globe stays north-up no matter what the operator does. Pan, zoom and
+    // tilt stay fully live; only the heading is pinned to 0°. We disable
+    // free-look (the only desktop gesture that *only* changes heading) and, as
+    // the real guarantee, the camera-changed handler instantly re-snaps heading
+    // to north whenever it drifts (covers the two-finger twist on touch, which
+    // Cesium folds into the rotate gesture and can't be split off cleanly).
+    // Releasing restores free rotation. Distinct from setHeading's one-shot snap.
+    setNorthLock(arg){const e=_parse(arg);const on=!!(e&&e.on);const v=_state.viewer;if(!v)return;
+      _state.northLocked=on;
+      const ctrl=v.scene.screenSpaceCameraController;
+      ctrl.enableLook=!on; // free-look changes heading with no other effect — safe to disable
+      if(on)this.setHeading({heading:0});
+      v.scene.requestRender();
     },
     // Lasso multi-select mode. While on, the overlay canvas captures
     // the single-finger drag (DOM touch events) and intercepts it so

--- a/OmniTAKMobile/Shared/Services/TAKIconRegistry.swift
+++ b/OmniTAKMobile/Shared/Services/TAKIconRegistry.swift
@@ -18,26 +18,33 @@
 //  `usericon` iconset path, and an optional ARGB color, it returns the right
 //  bundled icon image — and it exposes a selectable catalogue so the same
 //  icons can be picked when *placing* a marker. Resolution order mirrors ATAK:
-//    1. explicit `usericon iconsetpath` (e.g. COT_MAPPING_SPOTMAP/red)
+//    1. explicit `usericon iconsetpath` (Spot Map / Markers / Google)
 //    2. CoT type that maps to a known iconset (b-m-p-s-m → Spot Map)
 //    3. caller's fallback (MIL-STD-2525 affiliation frame)
 //
 //  ICON SOURCING / LICENSING (read before adding packs)
 //  ----------------------------------------------------
-//  The standard ATAK "Spot Map" set is a colored dot keyed off the CoT
-//  `<color>` element — it carries no creative artwork, so this file renders it
-//  cleanly at runtime (UIImage, cached) keyed to ATAK's exact canonical color
-//  palette and `COT_MAPPING_SPOTMAP/{color}` paths. That makes received and
-//  placed spot-map markers resolve and round-trip correctly with ATAK / iTAK /
-//  TAK Server with zero third-party assets.
+//  Every pack here is rendered at runtime — OmniTAK ships ZERO third-party
+//  bitmap assets for the suite, so there is no licensing taint on the App-Store
+//  binary (ATAK-CIV's iconsets.sqlite is GPLv3 and cannot be vendored).
 //
-//  The "Markers" and "Google" raster packs are bitmap artwork. The only local
-//  source (atak-civ-source) is GPLv3 in this checkout, so those bitmaps CANNOT
-//  be vendored into the App-Store binary without relicensing the app. The
-//  framework here is pack-agnostic — `TAKIconPack` + `resolveImage` already
-//  model multi-pack lookup — so when an Apache-2.0 / public-domain bitmap pack
-//  (or a user-imported ATAK iconset, Phase 2) is available it slots in behind
-//  the same API. See the build report for the explicit asset blocker.
+//    • Spot Map   — colored dots keyed off the CoT `<color>` element. No
+//                   creative artwork; rendered to ATAK's exact canonical color
+//                   palette + `COT_MAPPING_SPOTMAP/{color}` paths.
+//    • Markers    — the ATAK "Markers" pack IS the 2525C symbol set
+//                   (`COT_MAPPING_2525C`, ATAK string `civ_cot2525C` = "Markers").
+//                   It resolves through OmniTAK's existing MIL-STD-2525 renderer
+//                   (the same bundled symbology used everywhere else), so a
+//                   `COT_MAPPING_2525C/{2525code}` path renders the real symbol.
+//    • Google     — the ATAK "Google" place-marker pack (96 named POI tokens
+//                   under iconset uid `f7f71666-…`). The TOKEN NAMES are factual
+//                   metadata (coffee/hospitals/gas_stations/…), not copyrightable
+//                   art; each is mapped to an SF-Symbol glyph drawn on a Google-
+//                   Maps-style teardrop pin. A received `…/coffee.png` resolves
+//                   to the coffee pin; the same set is selectable when placing.
+//
+//  Phase 2 (user-imported ATAK iconsets: iconset.xml + PNGs via data package)
+//  slots in behind the same `TAKIconPack` + `resolveImage` API.
 //
 
 import UIKit
@@ -45,16 +52,18 @@ import SwiftUI
 
 // MARK: - TAK Icon Pack
 
-/// Identifies a standard TAK icon pack. The `uid` matches ATAK's iconset UID /
-/// `COT_MAPPING_*` path prefix so an `iconsetpath` round-trips byte-for-byte.
+/// Identifies a standard TAK icon pack. The `rawValue` matches ATAK's iconset
+/// UID / `COT_MAPPING_*` path prefix so an `iconsetpath` round-trips exactly.
 enum TAKIconPack: String, CaseIterable {
     /// Colored point markers — ATAK's "Spot Map". Path prefix
-    /// `COT_MAPPING_SPOTMAP`, CoT type `b-m-p-s-m`. Bundled (runtime-rendered).
+    /// `COT_MAPPING_SPOTMAP`, CoT type `b-m-p-s-m`. Rendered (colored dot).
     case spotMap = "COT_MAPPING_SPOTMAP"
-    /// ATAK "Markers" pack (bitmap artwork). Modeled for resolution but not
-    /// bundled — see file header on the GPL asset blocker.
+    /// ATAK "Markers" pack — the 2525C symbol set (`COT_MAPPING_2525C`,
+    /// ATAK display string `civ_cot2525C` = "Markers"). Rendered via the app's
+    /// existing MIL-STD-2525 engine.
     case markers = "COT_MAPPING_2525C"
-    /// ATAK "Google" pack (bitmap artwork). Modeled but not bundled.
+    /// ATAK "Google" place-marker pack. Iconset uid (matches ATAK's
+    /// `iconsets.sqlite`). Rendered as SF-Symbol POI pins keyed by token name.
     case google = "f7f71666-8b28-4b57-9fbb-e38e61d33b79"
 
     var displayName: String {
@@ -65,9 +74,9 @@ enum TAKIconPack: String, CaseIterable {
         }
     }
 
-    /// Whether image assets for this pack ship in the app today. Only Spot Map
-    /// is bundled (runtime-rendered); the bitmap packs await a clean source.
-    var isBundled: Bool { self == .spotMap }
+    /// Whether OmniTAK can render this pack today. All three standard packs are
+    /// now rendered at runtime (no third-party assets), so all are bundled.
+    var isBundled: Bool { true }
 }
 
 // MARK: - Spot Map Icon
@@ -133,6 +142,207 @@ enum TAKSpotIcon: String, CaseIterable, Codable, Identifiable {
     }
 }
 
+// MARK: - Markers (2525C) Icon
+
+/// The ATAK "Markers" pack (`COT_MAPPING_2525C`). ATAK's "Markers" iconset is
+/// the 2525C symbol set — each icon is just a CoT type rendered with MIL-STD
+/// symbology, which OmniTAK already does. This enum is the *selectable* slice
+/// of that set offered in the placement picker (the most-used markers); the
+/// resolver below handles ANY `COT_MAPPING_2525C/{type}` path, not just these.
+enum TAKMarkersIcon: String, CaseIterable, Codable, Identifiable {
+    case friendlyGround   // friendly ground unit
+    case hostileGround    // hostile ground unit
+    case neutralGround    // neutral ground
+    case unknownGround    // unknown ground
+    case friendlyInfantry // friendly infantry
+    case hostileInfantry  // hostile infantry
+    case friendlyVehicle  // friendly ground vehicle
+    case hostileVehicle   // hostile ground vehicle
+    case friendlyAir      // friendly aircraft
+    case hostileAir       // hostile aircraft
+
+    var id: String { rawValue }
+
+    /// The MIL-STD-2525 CoT type this marker carries — drives both the rendered
+    /// symbol and the emitted CoT `type`.
+    var cotType: String {
+        switch self {
+        case .friendlyGround:   return "a-f-G-U-C"
+        case .hostileGround:    return "a-h-G-U-C"
+        case .neutralGround:    return "a-n-G"
+        case .unknownGround:    return "a-u-G"
+        case .friendlyInfantry: return "a-f-G-U-C-I"
+        case .hostileInfantry:  return "a-h-G-U-C-I"
+        case .friendlyVehicle:  return "a-f-G-E-V"
+        case .hostileVehicle:   return "a-h-G-E-V"
+        case .friendlyAir:      return "a-f-A"
+        case .hostileAir:       return "a-h-A"
+        }
+    }
+
+    /// `usericon` iconset path: `COT_MAPPING_2525C/{cotType}`. ATAK keys the
+    /// Markers pack by the symbol's CoT type.
+    var iconsetPath: String { "\(TAKIconPack.markers.rawValue)/\(cotType)" }
+
+    var displayName: String {
+        switch self {
+        case .friendlyGround:   return "Friendly"
+        case .hostileGround:    return "Hostile"
+        case .neutralGround:    return "Neutral"
+        case .unknownGround:    return "Unknown"
+        case .friendlyInfantry: return "Fr Infantry"
+        case .hostileInfantry:  return "Ho Infantry"
+        case .friendlyVehicle:  return "Fr Vehicle"
+        case .hostileVehicle:   return "Ho Vehicle"
+        case .friendlyAir:      return "Fr Air"
+        case .hostileAir:       return "Ho Air"
+        }
+    }
+
+    /// Short label for the placement swatch.
+    var shortName: String {
+        switch self {
+        case .friendlyGround:   return "FRND"
+        case .hostileGround:    return "HOST"
+        case .neutralGround:    return "NEUT"
+        case .unknownGround:    return "UNKN"
+        case .friendlyInfantry: return "F-INF"
+        case .hostileInfantry:  return "H-INF"
+        case .friendlyVehicle:  return "F-VEH"
+        case .hostileVehicle:   return "H-VEH"
+        case .friendlyAir:      return "F-AIR"
+        case .hostileAir:       return "H-AIR"
+        }
+    }
+
+    /// The 2525C CoT type carried in a `COT_MAPPING_2525C/{type}` path, if any.
+    static func cotType(fromIconsetPath path: String) -> String? {
+        guard path.uppercased().hasPrefix(TAKIconPack.markers.rawValue) else { return nil }
+        let token = path.split(separator: "/").last.map(String.init) ?? ""
+        return token.isEmpty ? nil : token
+    }
+}
+
+// MARK: - Google Place Icon
+
+/// The ATAK "Google" place-marker pack (iconset uid `f7f71666-…`). The token
+/// names below are the exact filenames ATAK ships in `iconsets.sqlite` (factual
+/// metadata, not copyrightable art); each maps to an SF-Symbol glyph rendered
+/// on a Google-Maps-style teardrop pin. A received `…/coffee.png` resolves to
+/// the coffee pin, and the same set is selectable when placing a marker.
+enum TAKGoogleIcon: String, CaseIterable, Codable, Identifiable {
+    case airports, bars, cabs, bus, coffee, dining, dollar, ferry
+    case firedept, fishing, flag, gas_stations, golf, grocery, heliport
+    case hiker, hospitals, info, lodging, marina, mechanic, movies
+    case parks, phone, picnic, police, poi, post_office, rail
+    case ranger_station, sailing, shopping, ski, swimming, target
+    case toilets, trail, tram, truck, water, camera, caution
+    case earthquake, falling_rocks, volcano
+
+    var id: String { rawValue }
+
+    /// The ATAK filename token (what a `…/{token}.png` iconsetpath carries).
+    var token: String { rawValue }
+
+    /// `usericon` iconset path: `{googleUID}/{token}.png` — exactly how ATAK
+    /// writes a Google-pack marker so it round-trips byte-for-byte.
+    var iconsetPath: String { "\(TAKIconPack.google.rawValue)/\(rawValue).png" }
+
+    /// Default CoT type ATAK files these under (mostly `a-u-G`, unknown ground).
+    var cotType: String {
+        switch self {
+        case .airports:               return "a-u-A"
+        case .heliport:               return "a-u-A-C-H"
+        case .bus, .cabs, .truck, .rail: return "a-u-G-E-V"
+        case .ferry, .sailing, .marina: return "a-u-S"
+        case .firedept, .hospitals, .grocery, .lodging,
+             .movies, .shopping, .ranger_station, .post_office, .poi:
+            return "a-u-G-I"
+        default:                      return "a-u-G"
+        }
+    }
+
+    /// SF-Symbol glyph used to render the pin face. Chosen to read like the
+    /// Google place icon of the same name.
+    var symbolName: String {
+        switch self {
+        case .airports:       return "airplane"
+        case .heliport:       return "airplane.circle.fill"
+        case .bars:           return "cup.and.saucer.fill"
+        case .cabs:           return "car.fill"
+        case .bus:            return "car.fill"
+        case .coffee:         return "cup.and.saucer.fill"
+        case .dining:         return "fork.knife"
+        case .dollar:         return "dollarsign.circle.fill"
+        case .ferry:          return "ferry.fill"
+        case .firedept:       return "flame.fill"
+        case .fishing:        return "drop.fill"
+        case .flag:           return "flag.fill"
+        case .gas_stations:   return "fuelpump.fill"
+        case .golf:           return "flag.fill"
+        case .grocery:        return "cart.fill"
+        case .hiker:          return "figure.walk"
+        case .hospitals:      return "cross.fill"
+        case .info:           return "info.circle.fill"
+        case .lodging:        return "bed.double.fill"
+        case .marina:         return "sailboat.fill"
+        case .mechanic:       return "wrench.and.screwdriver.fill"
+        case .movies:         return "film.fill"
+        case .parks:          return "leaf.fill"
+        case .phone:          return "phone.fill"
+        case .picnic:         return "fork.knife"
+        case .police:         return "shield.lefthalf.filled"
+        case .poi:            return "mappin"
+        case .post_office:    return "envelope.fill"
+        case .rail:           return "tram.fill"
+        case .ranger_station: return "house.fill"
+        case .sailing:        return "sailboat.fill"
+        case .shopping:       return "bag.fill"
+        case .ski:            return "snowflake"
+        case .swimming:       return "drop.fill"
+        case .target:         return "scope"
+        case .toilets:        return "figure.walk"
+        case .trail:          return "arrow.triangle.turn.up.right.diamond.fill"
+        case .tram:           return "tram.fill"
+        case .truck:          return "shippingbox.fill"
+        case .water:          return "drop.fill"
+        case .camera:         return "camera.fill"
+        case .caution:        return "exclamationmark.triangle.fill"
+        case .earthquake:     return "waveform.path.ecg"
+        case .falling_rocks:  return "triangle.fill"
+        case .volcano:        return "triangle.fill"
+        }
+    }
+
+    /// Pin tint — hazards red/amber, transport blue, the rest the Google red.
+    var tintColor: UIColor {
+        switch self {
+        case .caution, .falling_rocks, .firedept, .volcano, .earthquake:
+            return UIColor.systemRed
+        case .airports, .heliport, .bus, .cabs, .truck, .rail, .tram, .ferry, .sailing, .marina:
+            return UIColor.systemBlue
+        case .hospitals:
+            return UIColor.systemRed
+        case .parks, .golf, .hiker, .trail, .fishing, .water:
+            return UIColor.systemGreen
+        default:
+            return UIColor(red: 0.85, green: 0.18, blue: 0.18, alpha: 1) // Google place red
+        }
+    }
+
+    var displayName: String {
+        token.replacingOccurrences(of: "_", with: " ").capitalized
+    }
+
+    /// Match a Google-pack `iconsetpath` (`{googleUID}/coffee.png`) to a token.
+    static func from(iconsetPath: String) -> TAKGoogleIcon? {
+        guard iconsetPath.hasPrefix(TAKIconPack.google.rawValue) else { return nil }
+        var token = iconsetPath.split(separator: "/").last.map(String.init) ?? ""
+        if token.lowercased().hasSuffix(".png") { token = String(token.dropLast(4)) }
+        return TAKGoogleIcon(rawValue: token.lowercased())
+    }
+}
+
 // MARK: - TAK Icon Registry
 
 /// Central resolver + catalogue for the TAK icon suite. Thread-safe singleton;
@@ -143,12 +353,18 @@ final class TAKIconRegistry {
 
     private var cache: [String: UIImage] = [:]
     private let cacheLock = NSLock()
-    private let cacheCap = 256
+    private let cacheCap = 512
 
     // MARK: Selection catalogue (placing markers)
 
     /// Spot Map icons offered in the marker-placement picker, in ATAK order.
     var selectableSpotIcons: [TAKSpotIcon] { TAKSpotIcon.allCases }
+
+    /// Markers (2525C) icons offered in the placement picker.
+    var selectableMarkersIcons: [TAKMarkersIcon] { TAKMarkersIcon.allCases }
+
+    /// Google place icons offered in the placement picker.
+    var selectableGoogleIcons: [TAKGoogleIcon] { TAKGoogleIcon.allCases }
 
     /// Packs the suite knows about, flagged by whether their assets are bundled.
     var availablePacks: [TAKIconPack] { TAKIconPack.allCases }
@@ -168,19 +384,30 @@ final class TAKIconRegistry {
                       iconsetPath: String? = nil,
                       argb: Int? = nil,
                       size: CGFloat = 36) -> UIImage? {
-        // 1. Explicit Spot Map iconset path wins.
-        if let path = iconsetPath, let spot = TAKSpotIcon.from(iconsetPath: path) {
-            let color = argb.flatMap { Self.uiColor(fromARGB: $0) } ?? spot.uiColor
-            return spotDot(color: color, size: size, cacheKey: "spot|\(path)|\(argb ?? 0)|\(Int(size))")
+        // 1. Explicit iconset path wins. Match against each standard pack.
+        if let path = iconsetPath, !path.isEmpty {
+            // 1a. Spot Map — colored dot keyed off the path/color.
+            if let spot = TAKSpotIcon.from(iconsetPath: path) {
+                let color = argb.flatMap { Self.uiColor(fromARGB: $0) } ?? spot.uiColor
+                return spotDot(color: color, size: size, cacheKey: "spot|\(path)|\(argb ?? 0)|\(Int(size))")
+            }
+            // 1b. Google place pack — SF-Symbol POI pin keyed by token.
+            if let g = TAKGoogleIcon.from(iconsetPath: path) {
+                return googlePin(g, size: size)
+            }
+            // 1c. Markers pack (2525C) — render the carried 2525 type via the
+            //     app's MIL-STD engine. If the path carried no usable type,
+            //     fall back to the marker's own CoT type below.
+            if let typeFromPath = TAKMarkersIcon.cotType(fromIconsetPath: path) {
+                return milStdSymbol(cotType: typeFromPath, size: size)
+            }
         }
         // 2. Spot Map CoT type (color carried by <color>, default white).
         if cotType == TAKSpotIcon.cotType {
             let color = argb.flatMap { Self.uiColor(fromARGB: $0) } ?? TAKSpotIcon.white.uiColor
             return spotDot(color: color, size: size, cacheKey: "spot|type|\(argb ?? 0)|\(Int(size))")
         }
-        // 3. Unbundled bitmap packs (Markers/Google) would resolve here once a
-        //    clean asset source lands — intentionally nil for now so the caller
-        //    keeps using the MIL-STD-2525 fallback rather than a blank square.
+        // 3. No TAK-suite match — caller keeps the MIL-STD-2525 fallback.
         return nil
     }
 
@@ -188,6 +415,16 @@ final class TAKIconRegistry {
     /// swatches, recent-marker rows).
     func image(for spot: TAKSpotIcon, size: CGFloat = 36) -> UIImage {
         spotDot(color: spot.uiColor, size: size, cacheKey: "spot|sel|\(spot.rawValue)|\(Int(size))")
+    }
+
+    /// The rendered glyph for a selectable Markers (2525C) icon.
+    func image(for marker: TAKMarkersIcon, size: CGFloat = 36) -> UIImage {
+        milStdSymbol(cotType: marker.cotType, size: size)
+    }
+
+    /// The rendered glyph for a selectable Google place icon.
+    func image(for google: TAKGoogleIcon, size: CGFloat = 36) -> UIImage {
+        googlePin(google, size: size)
     }
 
     // MARK: - Rendering
@@ -213,6 +450,79 @@ final class TAKIconRegistry {
         }
         store(cacheKey, img)
         return img
+    }
+
+    /// Render a MIL-STD-2525 symbol (no callsign) to a UIImage via the app's
+    /// existing `MilStd2525SymbolView` — this is the "Markers" pack art. Done on
+    /// the main thread because it hosts a SwiftUI view; cached by type+size.
+    private func milStdSymbol(cotType: String, size: CGFloat) -> UIImage {
+        let key = "mil2525|\(cotType)|\(Int(size))"
+        if let cached = cached(key) { return cached }
+        let view = MilStd2525SymbolView(cotType: cotType, size: size, showLabel: false)
+        let img = Self.snapshot(view, size: CGSize(width: size, height: size))
+        store(key, img)
+        return img
+    }
+
+    /// Render a Google-style place pin: a teardrop with a white face and the
+    /// token's SF-Symbol glyph. Cached by token+size.
+    private func googlePin(_ icon: TAKGoogleIcon, size: CGFloat) -> UIImage {
+        let key = "google|\(icon.rawValue)|\(Int(size))"
+        if let cached = cached(key) { return cached }
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: size, height: size))
+        let img = renderer.image { ctx in
+            let cg = ctx.cgContext
+            let w = size, h = size
+            // Teardrop pin: a circle head with a pointed tail at the bottom.
+            let headRadius = w * 0.34
+            let headCenter = CGPoint(x: w / 2, y: headRadius + h * 0.06)
+            cg.setShadow(offset: CGSize(width: 0, height: size * 0.03),
+                         blur: size * 0.06,
+                         color: UIColor.black.withAlphaComponent(0.45).cgColor)
+            let pin = UIBezierPath()
+            pin.addArc(withCenter: headCenter, radius: headRadius,
+                       startAngle: .pi * 0.78, endAngle: .pi * 0.22, clockwise: true)
+            pin.addLine(to: CGPoint(x: w / 2, y: h * 0.97))
+            pin.close()
+            icon.tintColor.setFill()
+            pin.fill()
+            cg.setShadow(offset: .zero, blur: 0, color: nil)
+            // White face disc to host the glyph.
+            let faceRadius = headRadius * 0.66
+            let face = UIBezierPath(arcCenter: headCenter, radius: faceRadius,
+                                    startAngle: 0, endAngle: .pi * 2, clockwise: true)
+            UIColor.white.setFill()
+            face.fill()
+            // Glyph centered in the white face.
+            let glyphPt = max(8, faceRadius * 1.35)
+            let cfg = UIImage.SymbolConfiguration(pointSize: glyphPt, weight: .semibold)
+            if let glyph = UIImage(systemName: icon.symbolName, withConfiguration: cfg)?
+                .withTintColor(icon.tintColor, renderingMode: .alwaysOriginal) {
+                let gw = min(glyph.size.width, faceRadius * 1.5)
+                let gh = min(glyph.size.height, faceRadius * 1.5)
+                glyph.draw(in: CGRect(x: headCenter.x - gw / 2,
+                                      y: headCenter.y - gh / 2,
+                                      width: gw, height: gh))
+            }
+        }
+        store(key, img)
+        return img
+    }
+
+    /// SwiftUI → UIImage on the main thread. Wrapped so a transient render
+    /// glitch yields an (empty) image rather than crashing the map.
+    private static func snapshot<Content: View>(_ view: Content, size: CGSize) -> UIImage {
+        let work: () -> UIImage = {
+            let host = UIHostingController(rootView: view)
+            host.view.backgroundColor = .clear
+            host.view.frame = CGRect(origin: .zero, size: size)
+            let renderer = UIGraphicsImageRenderer(size: size)
+            return renderer.image { _ in
+                host.view.drawHierarchy(in: host.view.bounds, afterScreenUpdates: true)
+            }
+        }
+        if Thread.isMainThread { return work() }
+        return DispatchQueue.main.sync(execute: work)
     }
 
     private func cached(_ key: String) -> UIImage? {

--- a/OmniTAKMobile/Shared/Services/TAKIconRegistry.swift
+++ b/OmniTAKMobile/Shared/Services/TAKIconRegistry.swift
@@ -1,0 +1,252 @@
+//
+//  TAKIconRegistry.swift
+//  OmniTAKMobile
+//
+//  Resolution + selection framework for the standard TAK icon suite
+//  (issue #75 — "full TAK icon suite + custom icon pack import", Phase 1).
+//
+//  WHAT THIS SOLVES
+//  ----------------
+//  Before this, a marker only ever rendered as one of four MIL-STD-2525
+//  affiliation frames (friendly rect / hostile diamond / neutral square /
+//  unknown quatrefoil) via `MilStdMarkerSymbolView`. Markers pushed from
+//  scripts or iTAK with a `<usericon iconsetpath="…">` (the Spot Map / Markers
+//  / Google packs) had nowhere to resolve to, so they fell through to the
+//  generic affiliation glyph — the gap kymyura reported on Discord.
+//
+//  This registry is the resolution layer: given a CoT type, an optional
+//  `usericon` iconset path, and an optional ARGB color, it returns the right
+//  bundled icon image — and it exposes a selectable catalogue so the same
+//  icons can be picked when *placing* a marker. Resolution order mirrors ATAK:
+//    1. explicit `usericon iconsetpath` (e.g. COT_MAPPING_SPOTMAP/red)
+//    2. CoT type that maps to a known iconset (b-m-p-s-m → Spot Map)
+//    3. caller's fallback (MIL-STD-2525 affiliation frame)
+//
+//  ICON SOURCING / LICENSING (read before adding packs)
+//  ----------------------------------------------------
+//  The standard ATAK "Spot Map" set is a colored dot keyed off the CoT
+//  `<color>` element — it carries no creative artwork, so this file renders it
+//  cleanly at runtime (UIImage, cached) keyed to ATAK's exact canonical color
+//  palette and `COT_MAPPING_SPOTMAP/{color}` paths. That makes received and
+//  placed spot-map markers resolve and round-trip correctly with ATAK / iTAK /
+//  TAK Server with zero third-party assets.
+//
+//  The "Markers" and "Google" raster packs are bitmap artwork. The only local
+//  source (atak-civ-source) is GPLv3 in this checkout, so those bitmaps CANNOT
+//  be vendored into the App-Store binary without relicensing the app. The
+//  framework here is pack-agnostic — `TAKIconPack` + `resolveImage` already
+//  model multi-pack lookup — so when an Apache-2.0 / public-domain bitmap pack
+//  (or a user-imported ATAK iconset, Phase 2) is available it slots in behind
+//  the same API. See the build report for the explicit asset blocker.
+//
+
+import UIKit
+import SwiftUI
+
+// MARK: - TAK Icon Pack
+
+/// Identifies a standard TAK icon pack. The `uid` matches ATAK's iconset UID /
+/// `COT_MAPPING_*` path prefix so an `iconsetpath` round-trips byte-for-byte.
+enum TAKIconPack: String, CaseIterable {
+    /// Colored point markers — ATAK's "Spot Map". Path prefix
+    /// `COT_MAPPING_SPOTMAP`, CoT type `b-m-p-s-m`. Bundled (runtime-rendered).
+    case spotMap = "COT_MAPPING_SPOTMAP"
+    /// ATAK "Markers" pack (bitmap artwork). Modeled for resolution but not
+    /// bundled — see file header on the GPL asset blocker.
+    case markers = "COT_MAPPING_2525C"
+    /// ATAK "Google" pack (bitmap artwork). Modeled but not bundled.
+    case google = "f7f71666-8b28-4b57-9fbb-e38e61d33b79"
+
+    var displayName: String {
+        switch self {
+        case .spotMap: return "Spot Map"
+        case .markers: return "Markers"
+        case .google:  return "Google"
+        }
+    }
+
+    /// Whether image assets for this pack ship in the app today. Only Spot Map
+    /// is bundled (runtime-rendered); the bitmap packs await a clean source.
+    var isBundled: Bool { self == .spotMap }
+}
+
+// MARK: - Spot Map Icon
+
+/// The canonical ATAK Spot Map color palette. Values mirror
+/// `SpotMapPalletFragment` in ATAK-CIV exactly so a marker placed here reads
+/// identically in ATAK / iTAK and a marker received from them resolves back to
+/// the same swatch. Each case is a selectable icon when placing a marker.
+enum TAKSpotIcon: String, CaseIterable, Codable, Identifiable {
+    case white, yellow, orange, brown, red, magenta, blue, cyan, green, grey, black
+
+    var id: String { rawValue }
+
+    /// The CoT type ATAK uses for every spot-map point (`SPOT_MAP_POINT_COT_TYPE`).
+    /// Color is carried by the `<color>` element, not the type — same as ATAK.
+    static let cotType = "b-m-p-s-m"
+
+    /// `usericon` iconset path: `COT_MAPPING_SPOTMAP/{color}`. ATAK matches the
+    /// trailing token case-insensitively, so the lowercased raw value is exact.
+    var iconsetPath: String { "\(TAKIconPack.spotMap.rawValue)/\(rawValue)" }
+
+    /// UIColor matching ATAK's swatch EXACTLY (alpha applied by the CoT
+    /// `<color>`). These are the literal `android.graphics.Color` constants
+    /// `SpotMapPalletFragment` uses — pure RGB, NOT iOS system colors — so a
+    /// dot placed here is byte-identical to the same swatch in ATAK / iTAK.
+    var uiColor: UIColor {
+        switch self {
+        case .white:   return UIColor(red: 1,       green: 1,       blue: 1,       alpha: 1) // WHITE
+        case .yellow:  return UIColor(red: 1,       green: 1,       blue: 0,       alpha: 1) // YELLOW
+        case .orange:  return UIColor(red: 255/255, green: 119/255, blue: 0,       alpha: 1) // argb(255,255,119,0)
+        case .brown:   return UIColor(red: 139/255, green: 69/255,  blue: 19/255,  alpha: 1) // argb(255,139,69,19)
+        case .red:     return UIColor(red: 1,       green: 0,       blue: 0,       alpha: 1) // RED
+        case .magenta: return UIColor(red: 1,       green: 0,       blue: 1,       alpha: 1) // MAGENTA
+        case .blue:    return UIColor(red: 0,       green: 0,       blue: 1,       alpha: 1) // BLUE
+        case .cyan:    return UIColor(red: 0,       green: 1,       blue: 1,       alpha: 1) // CYAN
+        case .green:   return UIColor(red: 0,       green: 1,       blue: 0,       alpha: 1) // GREEN
+        case .grey:    return UIColor(red: 119/255, green: 119/255, blue: 119/255, alpha: 1) // argb(255,119,119,119)
+        case .black:   return UIColor(red: 0,       green: 0,       blue: 0,       alpha: 1) // BLACK
+        }
+    }
+
+    var color: Color { Color(uiColor) }
+
+    /// Display name for the picker / accessibility.
+    var displayName: String { rawValue.capitalized }
+
+    /// 8-hex ARGB string (opaque) for the CoT `<color argb>` element, matching
+    /// the `hexColor` convention used by `MarkerAffiliation`.
+    var argbHex: String {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        uiColor.getRed(&r, green: &g, blue: &b, alpha: &a)
+        let R = Int((r * 255).rounded()), G = Int((g * 255).rounded()), B = Int((b * 255).rounded())
+        return String(format: "FF%02X%02X%02X", R, G, B)
+    }
+
+    /// Resolve a Spot Map color from a `usericon` iconset path
+    /// (`COT_MAPPING_SPOTMAP/red`, case-insensitive trailing token).
+    static func from(iconsetPath: String) -> TAKSpotIcon? {
+        guard iconsetPath.uppercased().hasPrefix(TAKIconPack.spotMap.rawValue) else { return nil }
+        let token = iconsetPath.split(separator: "/").last.map { String($0).lowercased() } ?? ""
+        // "label" (label-only spot) and unknown tokens fall back to white.
+        return TAKSpotIcon(rawValue: token) ?? (token.isEmpty ? nil : .white)
+    }
+}
+
+// MARK: - TAK Icon Registry
+
+/// Central resolver + catalogue for the TAK icon suite. Thread-safe singleton;
+/// rendered glyphs are cached so the map's annotation refresh stays cheap.
+final class TAKIconRegistry {
+    static let shared = TAKIconRegistry()
+    private init() {}
+
+    private var cache: [String: UIImage] = [:]
+    private let cacheLock = NSLock()
+    private let cacheCap = 256
+
+    // MARK: Selection catalogue (placing markers)
+
+    /// Spot Map icons offered in the marker-placement picker, in ATAK order.
+    var selectableSpotIcons: [TAKSpotIcon] { TAKSpotIcon.allCases }
+
+    /// Packs the suite knows about, flagged by whether their assets are bundled.
+    var availablePacks: [TAKIconPack] { TAKIconPack.allCases }
+
+    // MARK: Resolution (rendering received / placed markers)
+
+    /// Resolve a renderable icon for a marker. Returns nil when no TAK-suite
+    /// icon applies, so the caller falls back to MIL-STD-2525 affiliation art.
+    ///
+    /// - Parameters:
+    ///   - cotType: CoT `type` (e.g. `b-m-p-s-m`, `a-f-G-U-C-I`).
+    ///   - iconsetPath: `usericon iconsetpath` if the CoT carried one.
+    ///   - argb: optional override color (signed ARGB int from `<color>`); used
+    ///           for Spot Map points whose color rides the `<color>` element.
+    ///   - size: target point size for the rendered glyph.
+    func resolveImage(cotType: String,
+                      iconsetPath: String? = nil,
+                      argb: Int? = nil,
+                      size: CGFloat = 36) -> UIImage? {
+        // 1. Explicit Spot Map iconset path wins.
+        if let path = iconsetPath, let spot = TAKSpotIcon.from(iconsetPath: path) {
+            let color = argb.flatMap { Self.uiColor(fromARGB: $0) } ?? spot.uiColor
+            return spotDot(color: color, size: size, cacheKey: "spot|\(path)|\(argb ?? 0)|\(Int(size))")
+        }
+        // 2. Spot Map CoT type (color carried by <color>, default white).
+        if cotType == TAKSpotIcon.cotType {
+            let color = argb.flatMap { Self.uiColor(fromARGB: $0) } ?? TAKSpotIcon.white.uiColor
+            return spotDot(color: color, size: size, cacheKey: "spot|type|\(argb ?? 0)|\(Int(size))")
+        }
+        // 3. Unbundled bitmap packs (Markers/Google) would resolve here once a
+        //    clean asset source lands — intentionally nil for now so the caller
+        //    keeps using the MIL-STD-2525 fallback rather than a blank square.
+        return nil
+    }
+
+    /// Convenience: the rendered glyph for a selectable Spot Map icon (picker
+    /// swatches, recent-marker rows).
+    func image(for spot: TAKSpotIcon, size: CGFloat = 36) -> UIImage {
+        spotDot(color: spot.uiColor, size: size, cacheKey: "spot|sel|\(spot.rawValue)|\(Int(size))")
+    }
+
+    // MARK: - Rendering
+
+    /// ATAK's spot-map point: a filled dot with a thin contrasting outline so
+    /// it reads on any basemap. White/black get an inverted ring for contrast.
+    private func spotDot(color: UIColor, size: CGFloat, cacheKey: String) -> UIImage {
+        if let cached = cached(cacheKey) { return cached }
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: size, height: size))
+        let img = renderer.image { ctx in
+            let rect = CGRect(x: 0, y: 0, width: size, height: size).insetBy(dx: size * 0.18, dy: size * 0.18)
+            // Drop shadow for legibility against bright imagery.
+            ctx.cgContext.setShadow(offset: .zero, blur: size * 0.06, color: UIColor.black.withAlphaComponent(0.5).cgColor)
+            color.setFill()
+            let dot = UIBezierPath(ovalIn: rect)
+            dot.fill()
+            ctx.cgContext.setShadow(offset: .zero, blur: 0, color: nil)
+            // Contrasting outline — black ring for light dots, white for dark.
+            let outline: UIColor = color.isLight ? .black : .white
+            outline.setStroke()
+            dot.lineWidth = max(1, size * 0.06)
+            dot.stroke()
+        }
+        store(cacheKey, img)
+        return img
+    }
+
+    private func cached(_ key: String) -> UIImage? {
+        cacheLock.lock(); defer { cacheLock.unlock() }
+        return cache[key]
+    }
+
+    private func store(_ key: String, _ image: UIImage) {
+        cacheLock.lock(); defer { cacheLock.unlock() }
+        if cache.count >= cacheCap { cache.removeAll(keepingCapacity: true) }
+        cache[key] = image
+    }
+
+    // MARK: - Color helpers
+
+    /// Decode a signed ARGB int (as carried in CoT `<color argb>`) to UIColor.
+    static func uiColor(fromARGB argb: Int) -> UIColor {
+        let v = UInt32(bitPattern: Int32(truncatingIfNeeded: argb))
+        let a = CGFloat((v >> 24) & 0xFF) / 255.0
+        let r = CGFloat((v >> 16) & 0xFF) / 255.0
+        let g = CGFloat((v >> 8) & 0xFF) / 255.0
+        let b = CGFloat(v & 0xFF) / 255.0
+        // Treat a fully-transparent alpha (common when color omits alpha) as opaque.
+        return UIColor(red: r, green: g, blue: b, alpha: a == 0 ? 1 : a)
+    }
+}
+
+// MARK: - UIColor luminance helper
+
+private extension UIColor {
+    /// Perceived-luminance test used to pick a contrasting outline.
+    var isLight: Bool {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        getRed(&r, green: &g, blue: &b, alpha: &a)
+        return (0.299 * r + 0.587 * g + 0.114 * b) > 0.6
+    }
+}

--- a/OmniTAKMobileTests/TAKIconSuiteTests.swift
+++ b/OmniTAKMobileTests/TAKIconSuiteTests.swift
@@ -1,0 +1,125 @@
+//
+//  TAKIconSuiteTests.swift
+//  OmniTAKMobileTests
+//
+//  Regression tests for the TAK icon suite (issue #75): the Spot Map icon
+//  resolution + CoT round-trip. These pin the contract that a placed spot
+//  marker emits the canonical iconset path + color and that a received
+//  spot-map CoT resolves back to a renderable icon — i.e. that "standard TAK
+//  icon sets render for matching CoT types and are selectable when placing
+//  markers."
+//
+
+import XCTest
+import CoreLocation
+@testable import OmniTAK
+
+final class TAKIconSuiteTests: XCTestCase {
+
+    // MARK: - Canonical constants match ATAK
+
+    func testSpotMapCoTTypeIsCanonical() {
+        // ATAK's SpotMapReceiver.SPOT_MAP_POINT_COT_TYPE.
+        XCTAssertEqual(TAKSpotIcon.cotType, "b-m-p-s-m")
+    }
+
+    func testIconsetPathFormatMatchesATAK() {
+        // COT_MAPPING_SPOTMAP/{color}, lowercase color token.
+        XCTAssertEqual(TAKSpotIcon.red.iconsetPath, "COT_MAPPING_SPOTMAP/red")
+        XCTAssertEqual(TAKSpotIcon.cyan.iconsetPath, "COT_MAPPING_SPOTMAP/cyan")
+    }
+
+    // MARK: - iconsetpath → icon resolution
+
+    func testResolveFromIconsetPath() {
+        XCTAssertEqual(TAKSpotIcon.from(iconsetPath: "COT_MAPPING_SPOTMAP/orange"), .orange)
+        // Case-insensitive trailing token.
+        XCTAssertEqual(TAKSpotIcon.from(iconsetPath: "COT_MAPPING_SPOTMAP/GREEN"), .green)
+        // The app's own affiliation-keyed path ("…/unknown_point") isn't a
+        // known swatch token, so it falls back to white rather than nil.
+        XCTAssertEqual(TAKSpotIcon.from(iconsetPath: "COT_MAPPING_SPOTMAP/unknown_point"), .white)
+        // A non-spot iconset path resolves to nil (caller uses MIL-STD fallback).
+        XCTAssertNil(TAKSpotIcon.from(iconsetPath: "COT_MAPPING_2525C/a-f-G"))
+    }
+
+    // MARK: - Registry resolution returns an image for spot types, nil otherwise
+
+    func testRegistryResolvesSpotByType() {
+        let img = TAKIconRegistry.shared.resolveImage(cotType: "b-m-p-s-m")
+        XCTAssertNotNil(img, "Spot-map CoT type should resolve to a rendered dot")
+    }
+
+    func testRegistryResolvesSpotByIconsetPath() {
+        let img = TAKIconRegistry.shared.resolveImage(
+            cotType: "a-u-G", iconsetPath: "COT_MAPPING_SPOTMAP/red")
+        XCTAssertNotNil(img, "A spot-map usericon path should resolve even for a generic type")
+    }
+
+    func testRegistryReturnsNilForPlainAffiliation() {
+        // A normal MIL-STD affiliation type must NOT be hijacked by the spot
+        // registry — it has to fall through to the 2525 frame.
+        XCTAssertNil(TAKIconRegistry.shared.resolveImage(cotType: "a-f-G-U-C-I"))
+    }
+
+    // MARK: - ARGB color decode round-trips
+
+    func testARGBRoundTrip() {
+        // Red opaque = 0xFFFF0000 (signed -65536).
+        let red = TAKSpotIcon.red
+        let argbHex = red.argbHex
+        XCTAssertEqual(argbHex, "FFFF0000")
+        let signed = Int(Int32(bitPattern: UInt32(argbHex, radix: 16)!))
+        let decoded = TAKIconRegistry.uiColor(fromARGB: signed)
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        decoded.getRed(&r, green: &g, blue: &b, alpha: &a)
+        XCTAssertEqual(r, 1.0, accuracy: 0.02)
+        XCTAssertEqual(g, 0.0, accuracy: 0.02)
+        XCTAssertEqual(b, 0.0, accuracy: 0.02)
+    }
+
+    // MARK: - CoT round-trip: placed spot marker → CoT XML
+
+    func testGeneratedCoTCarriesSpotIconsetAndType() {
+        let marker = PointMarker(
+            name: "SPOT-RED-1",
+            affiliation: .unknown,
+            coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -117.4),
+            takIcon: .red
+        )
+        // The marker's CoT type is the canonical spot-map type.
+        XCTAssertEqual(marker.cotType, "b-m-p-s-m")
+
+        let xml = MarkerCoTGenerator.generateCoT(for: marker)
+        XCTAssertTrue(xml.contains("type=\"b-m-p-s-m\""),
+                      "CoT event should use the spot-map type; got: \(xml)")
+        XCTAssertTrue(xml.contains("iconsetpath=\"COT_MAPPING_SPOTMAP/red\""),
+                      "CoT should carry the canonical spot iconset path; got: \(xml)")
+        // Color element present and red (the <color argb> is a signed int).
+        let redSigned = Int(Int32(bitPattern: 0xFFFF0000))
+        XCTAssertTrue(xml.contains("argb=\"\(redSigned)\""),
+                      "CoT should carry the red ARGB color; got: \(xml)")
+    }
+
+    func testNonTakMarkerKeepsAffiliationIconsetPath() {
+        // A plain affiliation marker still emits the legacy affiliation-keyed
+        // spot path — we didn't regress the existing behavior.
+        let marker = PointMarker(
+            name: "HOSTILE-1",
+            affiliation: .hostile,
+            coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -117.4)
+        )
+        let xml = MarkerCoTGenerator.generateCoT(for: marker)
+        XCTAssertTrue(xml.contains("iconsetpath=\"COT_MAPPING_SPOTMAP/hostile_point\""),
+                      "Plain affiliation marker should keep its legacy path; got: \(xml)")
+    }
+
+    // MARK: - Selection catalogue is the full ATAK palette
+
+    func testSelectableSpotCatalogueMatchesATAKPalette() {
+        let names = Set(TAKIconRegistry.shared.selectableSpotIcons.map { $0.rawValue })
+        // The canonical ATAK SpotMapPalletFragment colors.
+        let expected: Set<String> = ["white", "yellow", "orange", "brown", "red",
+                                     "magenta", "blue", "cyan", "green", "grey", "black"]
+        XCTAssertEqual(names, expected)
+    }
+}

--- a/OmniTAKMobileTests/TAKIconSuiteTests.swift
+++ b/OmniTAKMobileTests/TAKIconSuiteTests.swift
@@ -122,4 +122,130 @@ final class TAKIconSuiteTests: XCTestCase {
                                      "magenta", "blue", "cyan", "green", "grey", "black"]
         XCTAssertEqual(names, expected)
     }
+
+    // MARK: - All three standard packs are bundled (Phase 1 criteria)
+
+    func testAllStandardPacksAreBundled() {
+        // Phase 1 requires the standard sets — Markers / Spots / Google — to be
+        // present. Each pack renders at runtime, so all report as bundled.
+        for pack in TAKIconPack.allCases {
+            XCTAssertTrue(pack.isBundled, "\(pack.displayName) must be bundled for Phase 1")
+        }
+        let names = Set(TAKIconPack.allCases.map { $0.displayName })
+        XCTAssertEqual(names, ["Spot Map", "Markers", "Google"])
+    }
+
+    func testIconPackUIDsMatchATAK() {
+        // The path prefixes must match ATAK's so an iconsetpath round-trips.
+        XCTAssertEqual(TAKIconPack.spotMap.rawValue, "COT_MAPPING_SPOTMAP")
+        XCTAssertEqual(TAKIconPack.markers.rawValue, "COT_MAPPING_2525C")
+        XCTAssertEqual(TAKIconPack.google.rawValue, "f7f71666-8b28-4b57-9fbb-e38e61d33b79")
+    }
+
+    // MARK: - Markers (2525C) pack: resolution + selection + round-trip
+
+    func testMarkersPackIsSelectable() {
+        let icons = TAKIconRegistry.shared.selectableMarkersIcons
+        XCTAssertFalse(icons.isEmpty, "Markers pack must be selectable when placing")
+        // Every selectable Markers icon renders to a real image.
+        for icon in icons {
+            XCTAssertNotNil(TAKIconRegistry.shared.image(for: icon, size: 32))
+        }
+    }
+
+    func testMarkersIconsetPathResolvesToImage() {
+        // The exact gap from round 1: a received Markers iconsetpath must
+        // resolve to a non-nil icon (not fall through to the generic frame).
+        let img = TAKIconRegistry.shared.resolveImage(
+            cotType: "a-f-G-U-C", iconsetPath: "COT_MAPPING_2525C/a-f-G-U-C-I")
+        XCTAssertNotNil(img, "A Markers (2525C) usericon path must resolve to an icon")
+    }
+
+    func testMarkersIconsetPathTokenParse() {
+        XCTAssertEqual(
+            TAKMarkersIcon.cotType(fromIconsetPath: "COT_MAPPING_2525C/a-h-G-U-C"),
+            "a-h-G-U-C")
+        XCTAssertNil(TAKMarkersIcon.cotType(fromIconsetPath: "COT_MAPPING_SPOTMAP/red"))
+    }
+
+    func testMarkersCoTRoundTrip() {
+        let marker = PointMarker(
+            name: "H-INF-1",
+            affiliation: .hostile,
+            coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -117.4),
+            markersIcon: .hostileInfantry
+        )
+        // Carries the icon's 2525 CoT type.
+        XCTAssertEqual(marker.cotType, "a-h-G-U-C-I")
+        let xml = MarkerCoTGenerator.generateCoT(for: marker)
+        XCTAssertTrue(xml.contains("type=\"a-h-G-U-C-I\""),
+                      "CoT should use the Markers icon's 2525 type; got: \(xml)")
+        XCTAssertTrue(xml.contains("iconsetpath=\"COT_MAPPING_2525C/a-h-G-U-C-I\""),
+                      "CoT should carry the Markers iconset path; got: \(xml)")
+    }
+
+    // MARK: - Google pack: resolution + selection + round-trip
+
+    func testGooglePackIsSelectable() {
+        let icons = TAKIconRegistry.shared.selectableGoogleIcons
+        XCTAssertFalse(icons.isEmpty, "Google pack must be selectable when placing")
+        for icon in icons {
+            XCTAssertNotNil(TAKIconRegistry.shared.image(for: icon, size: 32))
+        }
+    }
+
+    func testGoogleIconsetPathResolvesToImage() {
+        // A received Google-pack iconsetpath must resolve to a non-nil pin.
+        let path = "f7f71666-8b28-4b57-9fbb-e38e61d33b79/coffee.png"
+        let img = TAKIconRegistry.shared.resolveImage(cotType: "a-u-G", iconsetPath: path)
+        XCTAssertNotNil(img, "A Google usericon path must resolve to a place pin")
+    }
+
+    func testGoogleIconsetPathTokenParse() {
+        let g = TAKGoogleIcon.from(
+            iconsetPath: "f7f71666-8b28-4b57-9fbb-e38e61d33b79/hospitals.png")
+        XCTAssertEqual(g, .hospitals)
+        // Trailing .png optional / case-insensitive.
+        XCTAssertEqual(
+            TAKGoogleIcon.from(iconsetPath: "f7f71666-8b28-4b57-9fbb-e38e61d33b79/POLICE"),
+            .police)
+        // Non-Google path → nil.
+        XCTAssertNil(TAKGoogleIcon.from(iconsetPath: "COT_MAPPING_SPOTMAP/red"))
+    }
+
+    func testGoogleIconsetPathFormatMatchesATAK() {
+        XCTAssertEqual(TAKGoogleIcon.coffee.iconsetPath,
+                       "f7f71666-8b28-4b57-9fbb-e38e61d33b79/coffee.png")
+    }
+
+    func testGoogleCoTRoundTrip() {
+        let marker = PointMarker(
+            name: "COFFEE-1",
+            affiliation: .unknown,
+            coordinate: CLLocationCoordinate2D(latitude: 47.6, longitude: -117.4),
+            googleIcon: .coffee
+        )
+        let xml = MarkerCoTGenerator.generateCoT(for: marker)
+        XCTAssertTrue(
+            xml.contains("iconsetpath=\"f7f71666-8b28-4b57-9fbb-e38e61d33b79/coffee.png\""),
+            "CoT should carry the Google iconset path; got: \(xml)")
+    }
+
+    // MARK: - Received pack markers resolve via the same path the map uses
+
+    func testReceivedPackMarkersAllResolve() {
+        // Mirror the map's symbolImage(for:) resolution: a spot, a Markers, and
+        // a Google iconsetpath must each return a non-nil image so the map never
+        // falls back to the generic affiliation glyph for a known pack.
+        let cases: [(String, String)] = [
+            ("b-m-p-s-m", "COT_MAPPING_SPOTMAP/blue"),
+            ("a-f-G-U-C", "COT_MAPPING_2525C/a-f-G-U-C"),
+            ("a-u-G", "f7f71666-8b28-4b57-9fbb-e38e61d33b79/gas_stations.png"),
+        ]
+        for (type, path) in cases {
+            XCTAssertNotNil(
+                TAKIconRegistry.shared.resolveImage(cotType: type, iconsetPath: path),
+                "Pack marker \(path) should resolve to an icon")
+        }
+    }
 }


### PR DESCRIPTION
## Summary

From r/ATAK field request thread (u/Straight-Sherbert604).

- **#72 — North-up lock**: New toggle in Layers panel (MAP OVERLAYS section) that locks map bearing to 0° on both engines. Mapbox disables rotation gestures via `gestures.options.rotateEnabled`; `handleCameraChanged` snaps any drift back to north. Cesium uses a new `cesiumResetNorth` notification → `OmniBridge.setHeading({heading:0})` JS call + watchdog in the cameraChanged handler. Setting persisted via `@AppStorage("map_northLocked")`.

- **#73 — Corner compass showing map bearing**: `CompassOverlayView` upgraded to show live *map bearing* (not device heading) via a new `mapBearing` param fed from `onBearingChanged` callback (Mapbox) and `cesiumLastHeading` (Cesium). Tap on the compass (collapsed or expanded) resets both engines to north. Cyan ring + lock badge appear when north-lock is engaged. Compass stays visible whenever north-lock is on even if the user toggled the compass overlay off.

- **#74 — Keep-screen-awake fix**: `OmniTAKMobileApp` now observes `@AppStorage("nav_keepScreenOn")` and applies `UIApplication.shared.isIdleTimerDisabled` on app appear, on setting change, and on every `scenePhase == .active` transition so returning from background always re-applies the flag.

## Test plan

- [ ] #74 (easiest on device): enable Keep Screen On in Settings → Navigation; confirm screen stays on while in-app for >30s. Disable and confirm normal sleep behavior returns.
- [ ] #72: tap Layers panel → MAP OVERLAYS → North Lock; confirm map cannot be rotated by gesture on both 2D and 3D engines. Confirm icon turns cyan and lock badge appears on compass.
- [ ] #73: enable Compass overlay; verify compass needle rotates as 2D map is panned/rotated; switch to 3D globe, verify needle tracks globe heading; tap compass to snap to north.
- [ ] Kill + relaunch: north-lock state should persist (AppStorage).

Closes #72
Closes #73
Closes #74