### PR TITLE
QR enrollment: scan a TAK/ATAK enrollment QR (tak://...enroll)

### DIFF
--- a/OmniTAKMobile/Features/Authentication/Views/CertificateEnrollmentView.swift
+++ b/OmniTAKMobile/Features/Authentication/Views/CertificateEnrollmentView.swift
@@ -451,6 +451,22 @@ struct CertificateEnrollmentView: View {
         print("🔍 QR Code Handler: Code = \(code)")
         #endif
 
+        // Standard ATAK/TAK enrollment deep link scanned with the in-app
+        // camera — e.g. tak://com.atakmap.app/enroll?host=&username=&token=.
+        // Route through the shared DeepLinkHandler so it takes the exact same
+        // CSR-enroll → add-server → connect path as an OS-camera-app open.
+        let lower = code.lowercased()
+        if (lower.hasPrefix("tak://") || lower.hasPrefix("atak://") || lower.hasPrefix("omnitak://")),
+           let url = URL(string: code.trimmingCharacters(in: .whitespacesAndNewlines)),
+           TAKDeepLink.parse(url: url) != nil {
+            #if DEBUG
+            print("🔍 QR Code Handler: Detected TAK deep link, routing to DeepLinkHandler")
+            #endif
+            DeepLinkHandler.shared.handleURL(url)
+            dismiss()
+            return
+        }
+
         // Check if this is a certificate enrollment URL
         if code.lowercased().contains("enroll") && code.lowercased().hasPrefix("http") {
             #if DEBUG

--- a/OmniTAKMobile/Features/Map/Controllers/ATAKMapChrome.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/ATAKMapChrome.swift
@@ -83,7 +83,7 @@ struct ATAKStatusBar: View {
                     HStack(spacing: 2) {
                         Image(systemName: "server.rack")
                             .font(.system(size: 9))
-                        Text(serverName ?? "Offi...")
+                        Text(serverName ?? (isConnected ? "Connected" : "Offline"))
                             .font(.system(size: 10, weight: .medium))
                             .lineLimit(1)
                     }

--- a/OmniTAKMobile/Features/Networking/Services/DeepLinkHandler.swift
+++ b/OmniTAKMobile/Features/Networking/Services/DeepLinkHandler.swift
@@ -39,7 +39,10 @@ enum TAKDeepLink {
             ($0.name.lowercased() == "password" || $0.name.lowercased() == "pw") && !($0.value ?? "").isEmpty
         }
 
-        // If path contains "enroll" AND has a token, it's token enrollment (OpenTAKServer)
+        // Path contains "enroll" AND has a token → the standard ATAK / TAK
+        // Server / ArgusTAK enrollment deep link:
+        //   tak://com.atakmap.app/enroll?host=&username=&token=
+        // (also covers OpenTAKServer's token form). Driven via CSREnrollment.
         if path.contains("enroll") && hasToken {
             if let enrollment = EnrollmentDeepLink.parse(url: url) {
                 return .enrollment(enrollment)
@@ -111,13 +114,23 @@ struct ConnectDeepLink {
 }
 
 // MARK: - Enrollment Deep Link
+//
+// The standard ATAK enrollment deep link / QR:
+//   tak://com.atakmap.app/enroll?host=<host>[:port]&username=<u>&token=<t>
+// The host is frequently URL-encoded, e.g. host=argustak.com%3A8089 (the
+// %3A is a ':' separating host:port). URLComponents percent-decodes query
+// values for us, so we split any embedded ":port" off the host here and
+// surface a bare `host` plus the embedded `port`. The one-time `token` is
+// the CSR-enrollment credential — TAK servers (and ATAK itself) Basic-auth
+// the signClient call with username + this token, so downstream it is used
+// as the password to the standard CSREnrollmentService flow.
 
 struct EnrollmentDeepLink {
-    let host: String
+    let host: String          // bare hostname (any embedded :port stripped)
     let username: String
     let token: String
-    let port: Int?
-    let enrollmentPort: Int?
+    let port: Int?            // streaming port — from host:port or &port=
+    let enrollmentPort: Int?  // CSR enrollment port — from &enrollmentport=
 
     static func parse(url: URL) -> EnrollmentDeepLink? {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
@@ -134,24 +147,47 @@ struct EnrollmentDeepLink {
         }
 
         // Required parameters
-        guard let host = params["host"],
+        guard let rawHost = params["host"],
               let username = params["username"],
-              let token = params["token"] else {
+              let token = params["token"],
+              !rawHost.isEmpty, !username.isEmpty, !token.isEmpty else {
             print("[DeepLink] Missing required parameters: host, username, or token")
             return nil
         }
 
-        // Optional parameters
-        let port = params["port"].flatMap { Int($0) }
-        let enrollmentPort = params["enrollmentport"].flatMap { Int($0) }
+        // Split host:port (host may arrive URL-encoded as "host%3Aport",
+        // already decoded to "host:port" by URLComponents).
+        let (bareHost, embeddedPort) = splitHostPort(rawHost)
+
+        // Explicit &port= wins over a port embedded in the host string.
+        let port = params["port"].flatMap { Int($0) } ?? embeddedPort
+        let enrollmentPort = (params["enrollmentport"] ?? params["enrollport"]).flatMap { Int($0) }
 
         return EnrollmentDeepLink(
-            host: host,
+            host: bareHost,
             username: username,
             token: token,
             port: port,
             enrollmentPort: enrollmentPort
         )
+    }
+
+    /// Split a "host" or "host:port" string into its components. Tolerates a
+    /// stray scheme prefix and a trailing path. Returns the bare host and the
+    /// parsed port (nil when none / unparseable).
+    static func splitHostPort(_ raw: String) -> (host: String, port: Int?) {
+        var s = raw.trimmingCharacters(in: .whitespaces)
+        if let schemeRange = s.range(of: "://") {
+            s = String(s[schemeRange.upperBound...])
+        }
+        if let slash = s.firstIndex(of: "/") {
+            s = String(s[..<slash])
+        }
+        guard let colon = s.lastIndex(of: ":"),
+              let p = Int(s[s.index(after: colon)...]) else {
+            return (s, nil)
+        }
+        return (String(s[..<colon]), p)
     }
 }
 
@@ -225,23 +261,9 @@ class DeepLinkHandler: ObservableObject {
     /// on confirm). Set by processConfigProfile; cleared by confirmPendingProfile.
     @Published var pendingDeepLinkProfile: ConfigProfile?
 
+    // CSREnrollmentService owns its own (untrusted-bootstrapping) URLSession,
+    // so both the token-enroll and password-enroll deep-link paths reuse it.
     private let csrEnrollmentService = CSREnrollmentService()
-    private let urlSession: URLSession
-
-    init() {
-        // Deep-link enrollment bootstraps the truststore from the server
-        // itself, so this session explicitly accepts untrusted certs
-        // (shared TAKTLSSessionDelegate, .acceptUntrusted mode).
-        let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForRequest = 30
-        configuration.timeoutIntervalForResource = 60
-
-        self.urlSession = URLSession(
-            configuration: configuration,
-            delegate: TAKTLSSessionDelegate(trustMode: .acceptUntrusted),
-            delegateQueue: nil
-        )
-    }
 
     // MARK: - Handle Incoming URL
 
@@ -396,7 +418,13 @@ class DeepLinkHandler: ObservableObject {
         print("[DeepLink] ✅ Connected to \(serverName) via \(connect.protocolType.uppercased())")
     }
 
-    // MARK: - Token-Based Enrollment (OpenTAKServer)
+    // MARK: - Token-Based Enrollment (standard ATAK enrollment QR)
+    //
+    // tak://com.atakmap.app/enroll?host=&username=&token= → drive the SAME
+    // CSREnrollmentService used by the manual "Quick Connect" form, then add
+    // the server and connect exactly like SimpleEnrollView does on success.
+    // The one-time `token` is supplied as the Basic-auth password to the
+    // signClient endpoint (this is how ATAK / TAK Server enroll).
 
     private func processEnrollment(_ enrollment: EnrollmentDeepLink) async {
         await MainActor.run {
@@ -404,17 +432,50 @@ class DeepLinkHandler: ObservableObject {
             lastError = nil
         }
 
-        print("[DeepLink] Starting token-based enrollment for \(enrollment.username)@\(enrollment.host)")
+        // Streaming (CoT) port: explicit value or the TAK SSL default 8089.
+        // Enrollment (CSR signClient) port: explicit value or the TAK
+        // default 8446 — distinct from the streaming port. NOTE: ArgusTAK
+        // and other reverse-proxied deployments sometimes terminate the
+        // enrollment API on the same 8089 host:port; if 8446 fails on device,
+        // an &enrollmentport= override (or a future host probe) is the lever.
+        let streamingPort = enrollment.port ?? 8089
+        let enrollPort = enrollment.enrollmentPort ?? 8446
+
+        print("[DeepLink] CSR enrollment for \(enrollment.username)@\(enrollment.host) " +
+              "(stream \(streamingPort), enroll \(enrollPort))")
+
+        let config = CSREnrollmentConfiguration(
+            serverHost: enrollment.host,
+            serverPort: streamingPort,
+            enrollmentPort: enrollPort,
+            username: enrollment.username,
+            password: enrollment.token,
+            useSSL: true,
+            // Bootstrap trust from the server during enrollment so both
+            // self-signed and publicly-trusted (Let's Encrypt) endpoints work;
+            // the resulting stream is still pinned to the enrolled CA chain.
+            trustSelfSignedCerts: true
+        )
 
         do {
-            // OpenTAKServer token enrollment flow:
-            // 1. Use JWT token to authenticate
-            // 2. Generate CSR and submit to server
-            // 3. Get signed certificate
-
-            let server = try await enrollWithToken(enrollment)
+            // enrollWithCSR runs the full CSR flow and registers the server
+            // with ServerManager. We then connect using the stored cert,
+            // validating against the CA chain it enrolled.
+            let server = try await csrEnrollmentService.enrollWithCSR(config: config)
 
             await MainActor.run {
+                ServerManager.shared.setActiveServer(server)
+                TAKService.shared.connect(
+                    host: server.host,
+                    port: server.port,
+                    protocolType: server.protocolType,
+                    useTLS: server.useTLS,
+                    certificateName: server.certificateName,
+                    certificatePassword: server.certificatePassword,
+                    caCertificateName: server.caCertificateName,
+                    caCertificatePassword: server.caCertificatePassword,
+                    allowUntrustedTLS: server.allowUntrustedTLS
+                )
                 isProcessing = false
                 enrolledServerName = server.name
                 showEnrollmentSuccess = true
@@ -427,353 +488,6 @@ class DeepLinkHandler: ObservableObject {
                 lastError = error.localizedDescription
                 print("[DeepLink] ❌ Enrollment failed: \(error)")
             }
-        }
-    }
-
-    private func enrollWithToken(_ enrollment: EnrollmentDeepLink) async throws -> TAKServer {
-        let host = enrollment.host
-        let enrollmentPort = enrollment.enrollmentPort ?? 8446
-        let streamingPort = enrollment.port ?? 8089
-
-        // Determine protocol based on port (common TAK conventions)
-        // 8089 = SSL/TLS streaming, 8088 = TCP streaming
-        let useSSL = streamingPort != 8088
-
-        // Build URLs
-        let baseURL = "https://\(host):\(enrollmentPort)"
-        let configURL = URL(string: "\(baseURL)/Marti/api/tls/config")!
-
-        // Create Bearer token auth header
-        let authHeader = "Bearer \(enrollment.token)"
-
-        print("[DeepLink] Fetching CA config from \(configURL)")
-
-        // Step 1: Get CA configuration
-        var configRequest = URLRequest(url: configURL)
-        configRequest.httpMethod = "GET"
-        configRequest.setValue(authHeader, forHTTPHeaderField: "Authorization")
-        configRequest.setValue("text/plain; charset=utf-8", forHTTPHeaderField: "Content-Type")
-
-        let (configData, configResponse) = try await urlSession.data(for: configRequest)
-
-        guard let httpConfigResponse = configResponse as? HTTPURLResponse else {
-            throw DeepLinkError.invalidResponse("Not an HTTP response")
-        }
-
-        print("[DeepLink] Config response: \(httpConfigResponse.statusCode)")
-
-        guard (200...299).contains(httpConfigResponse.statusCode) else {
-            if httpConfigResponse.statusCode == 401 {
-                throw DeepLinkError.authenticationFailed("Token expired or invalid")
-            }
-            let errorBody = String(data: configData, encoding: .utf8) ?? ""
-            throw DeepLinkError.serverError(httpConfigResponse.statusCode, errorBody)
-        }
-
-        // Parse CA configuration
-        let caConfig = parseCAConfigXML(data: configData)
-        print("[DeepLink] CA config: O=\(caConfig.organizationNames), OU=\(caConfig.organizationalUnitNames)")
-
-        // Step 2: Generate CSR
-        let certificateAlias = "omnitak-\(host)"
-        let csrGenerator = CSRGenerator()
-
-        print("[DeepLink] Generating CSR with alias: \(certificateAlias)")
-
-        let csrResult = try csrGenerator.generateCSR(
-            username: enrollment.username,
-            caConfig: caConfig,
-            keyTag: certificateAlias
-        )
-
-        // Step 3: Submit CSR with token authentication
-        let clientUid = UUID().uuidString
-        let clientVersion = "OmniTAK-1.0"
-        let escapedUid = clientUid.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? clientUid
-        let escapedVersion = clientVersion.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? clientVersion
-
-        guard let csrSubmitURL = URL(string: "\(baseURL)/Marti/api/tls/signClient/v2?clientUid=\(escapedUid)&version=\(escapedVersion)") else {
-            throw DeepLinkError.invalidURL("Invalid CSR submission URL")
-        }
-
-        print("[DeepLink] Submitting CSR to \(csrSubmitURL)")
-
-        var csrRequest = URLRequest(url: csrSubmitURL)
-        csrRequest.httpMethod = "POST"
-        csrRequest.setValue(authHeader, forHTTPHeaderField: "Authorization")
-        csrRequest.setValue("text/plain; charset=utf-8", forHTTPHeaderField: "Content-Type")
-        csrRequest.httpBody = csrResult.csrBase64.data(using: .utf8)
-
-        var csrData: Data
-        var csrResponse: URLResponse
-
-        do {
-            (csrData, csrResponse) = try await urlSession.data(for: csrRequest)
-
-            // If Bearer auth failed, try alternative methods
-            if let httpResp = csrResponse as? HTTPURLResponse, httpResp.statusCode == 401 {
-                print("[DeepLink] Bearer auth failed (401), trying alternatives...")
-
-                // Try 1: Basic auth with token as password
-                print("[DeepLink] Trying Basic auth with token as password")
-                let basicCredentials = "\(enrollment.username):\(enrollment.token)"
-                let basicAuth = "Basic \(Data(basicCredentials.utf8).base64EncodedString())"
-
-                var basicRequest = URLRequest(url: csrSubmitURL)
-                basicRequest.httpMethod = "POST"
-                basicRequest.setValue(basicAuth, forHTTPHeaderField: "Authorization")
-                basicRequest.setValue("text/plain; charset=utf-8", forHTTPHeaderField: "Content-Type")
-                basicRequest.httpBody = csrResult.csrBase64.data(using: .utf8)
-
-                (csrData, csrResponse) = try await urlSession.data(for: basicRequest)
-
-                // Try 2: Token as query param if still 401
-                if let httpResp2 = csrResponse as? HTTPURLResponse, httpResp2.statusCode == 401 {
-                    print("[DeepLink] Basic auth also failed, trying token as query param")
-                    let tokenParam = enrollment.token.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? enrollment.token
-                    guard let tokenURL = URL(string: "\(baseURL)/Marti/api/tls/signClient/v2?clientUid=\(escapedUid)&version=\(escapedVersion)&token=\(tokenParam)") else {
-                        throw DeepLinkError.invalidURL("Invalid token URL")
-                    }
-
-                    var tokenRequest = URLRequest(url: tokenURL)
-                    tokenRequest.httpMethod = "POST"
-                    tokenRequest.setValue("text/plain; charset=utf-8", forHTTPHeaderField: "Content-Type")
-                    tokenRequest.httpBody = csrResult.csrBase64.data(using: .utf8)
-
-                    (csrData, csrResponse) = try await urlSession.data(for: tokenRequest)
-                }
-            }
-        } catch {
-            throw DeepLinkError.invalidResponse("Network error: \(error)")
-        }
-
-        guard let httpCSRResponse = csrResponse as? HTTPURLResponse else {
-            throw DeepLinkError.invalidResponse("Not an HTTP response")
-        }
-
-        print("[DeepLink] CSR response: \(httpCSRResponse.statusCode)")
-
-        guard (200...299).contains(httpCSRResponse.statusCode) else {
-            if httpCSRResponse.statusCode == 401 {
-                throw DeepLinkError.authenticationFailed("Token expired or invalid")
-            }
-            let errorBody = String(data: csrData, encoding: .utf8) ?? ""
-            throw DeepLinkError.serverError(httpCSRResponse.statusCode, errorBody)
-        }
-
-        // Step 4: Parse enrollment response
-        let enrollmentResponse = try parseEnrollmentResponse(data: csrData)
-        print("[DeepLink] Received signed certificate")
-
-        // Step 5: Store certificate
-        try storeCertificateIdentity(
-            response: enrollmentResponse,
-            privateKeyTag: csrResult.privateKeyTag,
-            certificateAlias: certificateAlias
-        )
-        print("[DeepLink] Certificate stored successfully")
-
-        // Step 6: Create and save server configuration
-        let serverInstance = TAKServer(
-            id: UUID(),
-            name: "\(host) (\(enrollment.username))",
-            host: host,
-            port: UInt16(streamingPort),
-            protocolType: useSSL ? "ssl" : "tcp",
-            useTLS: useSSL,
-            isDefault: false,
-            enabled: true,
-            certificateName: certificateAlias,
-            certificatePassword: "omnitak",
-            // Pin the stream to the CA chain stored during enrollment (the CA
-            // certs live under "\(certificateAlias)-ca-N"; the "-ca" prefix
-            // lets loadCACertificates collect them — same pattern as the CSR
-            // password-enrollment flow). Without this the stream would fall
-            // into the no-CA path and self-signed servers would be rejected
-            // by system trust.
-            caCertificateName: "\(certificateAlias)-ca",
-            username: enrollment.username
-        )
-
-        // Add to server manager on main thread
-        await MainActor.run {
-            ServerManager.shared.addServer(serverInstance)
-            ServerManager.shared.setActiveServer(serverInstance)
-
-            // Auto-connect to the server, validating against the enrolled CA.
-            TAKService.shared.connect(
-                host: serverInstance.host,
-                port: serverInstance.port,
-                protocolType: serverInstance.protocolType,
-                useTLS: serverInstance.useTLS,
-                certificateName: serverInstance.certificateName,
-                certificatePassword: serverInstance.certificatePassword,
-                caCertificateName: serverInstance.caCertificateName,
-                caCertificatePassword: serverInstance.caCertificatePassword,
-                allowUntrustedTLS: serverInstance.allowUntrustedTLS
-            )
-        }
-
-        return serverInstance
-    }
-
-    // MARK: - XML Parsing
-
-    private func parseCAConfigXML(data: Data) -> CAConfiguration {
-        var caConfig = CAConfiguration()
-
-        guard let xmlString = String(data: data, encoding: .utf8) else {
-            return caConfig
-        }
-
-        let pattern = #"<nameEntry\s+name="([^"]+)"\s+value="([^"]+)"/?"#
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
-            return caConfig
-        }
-
-        let range = NSRange(xmlString.startIndex..., in: xmlString)
-        let matches = regex.matches(in: xmlString, options: [], range: range)
-
-        for match in matches {
-            guard match.numberOfRanges == 3,
-                  let nameRange = Range(match.range(at: 1), in: xmlString),
-                  let valueRange = Range(match.range(at: 2), in: xmlString) else {
-                continue
-            }
-
-            let name = String(xmlString[nameRange]).uppercased()
-            let value = String(xmlString[valueRange])
-
-            switch name {
-            case "O": caConfig.organizationNames.append(value)
-            case "OU": caConfig.organizationalUnitNames.append(value)
-            case "DC": caConfig.domainComponents.append(value)
-            default: break
-            }
-        }
-
-        return caConfig
-    }
-
-    // MARK: - Response Parsing
-
-    private func parseEnrollmentResponse(data: Data) throws -> EnrollmentResponse {
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
-            let responseStr = String(data: data, encoding: .utf8) ?? "Unable to decode"
-            throw DeepLinkError.invalidResponse("Invalid JSON: \(responseStr)")
-        }
-
-        guard let signedCertPEM = json["signedCert"] else {
-            throw DeepLinkError.invalidResponse("Missing signedCert")
-        }
-
-        let signedCertDER = try pemToDER(signedCertPEM)
-
-        var trustChain: [Data] = []
-        let caEntries = json.filter { $0.key.starts(with: "ca") }.sorted { $0.key < $1.key }
-
-        for (_, caPEM) in caEntries {
-            if let caDER = try? pemToDER(caPEM) {
-                trustChain.append(caDER)
-            }
-        }
-
-        return EnrollmentResponse(
-            signedCertificate: signedCertDER,
-            trustChain: trustChain,
-            privateKeyTag: "temp"
-        )
-    }
-
-    private func pemToDER(_ pem: String) throws -> Data {
-        var lines = pem.components(separatedBy: .newlines)
-        lines = lines.filter { line in
-            !line.contains("-----BEGIN") &&
-            !line.contains("-----END") &&
-            !line.trimmingCharacters(in: .whitespaces).isEmpty
-        }
-
-        let base64String = lines.joined()
-
-        guard let derData = Data(base64Encoded: base64String, options: .ignoreUnknownCharacters) else {
-            throw DeepLinkError.invalidResponse("Failed to decode PEM")
-        }
-
-        return derData
-    }
-
-    // MARK: - Certificate Storage
-
-    private func storeCertificateIdentity(
-        response: EnrollmentResponse,
-        privateKeyTag: String,
-        certificateAlias: String
-    ) throws {
-        guard let certificate = SecCertificateCreateWithData(nil, response.signedCertificate as CFData) else {
-            throw DeepLinkError.certificateStorageFailed("Failed to create certificate")
-        }
-
-        // Clear existing
-        let deleteQuery: [String: Any] = [
-            kSecClass as String: kSecClassCertificate,
-            kSecAttrLabel as String: certificateAlias
-        ]
-        SecItemDelete(deleteQuery as CFDictionary)
-
-        // Add certificate
-        let addQuery: [String: Any] = [
-            kSecClass as String: kSecClassCertificate,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
-            kSecAttrLabel as String: certificateAlias,
-            kSecValueRef as String: certificate,
-            kSecReturnAttributes as String: true
-        ]
-
-        var resultRef: AnyObject?
-        let status = SecItemAdd(addQuery as CFDictionary, &resultRef)
-
-        guard status == errSecSuccess else {
-            throw DeepLinkError.certificateStorageFailed("Failed to add certificate: \(status)")
-        }
-
-        // Store mapping for TAKService
-        UserDefaults.standard.set(privateKeyTag, forKey: "csr_key_tag_\(certificateAlias)")
-        UserDefaults.standard.set(response.signedCertificate, forKey: "csr_cert_data_\(certificateAlias)")
-
-        // Store CA chain
-        for (index, caData) in response.trustChain.enumerated() {
-            if let caCert = SecCertificateCreateWithData(nil, caData as CFData) {
-                let caQuery: [String: Any] = [
-                    kSecClass as String: kSecClassCertificate,
-                    kSecValueRef as String: caCert,
-                    kSecAttrLabel as String: "\(certificateAlias)-ca-\(index)",
-                    kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-                ]
-                SecItemDelete(caQuery as CFDictionary)
-                SecItemAdd(caQuery as CFDictionary, nil)
-            }
-        }
-
-        print("[DeepLink] ✅ Certificate identity stored")
-    }
-}
-
-// MARK: - Deep Link Errors
-
-enum DeepLinkError: LocalizedError {
-    case invalidURL(String)
-    case invalidResponse(String)
-    case authenticationFailed(String)
-    case serverError(Int, String)
-    case certificateStorageFailed(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .invalidURL(let msg): return "Invalid URL: \(msg)"
-        case .invalidResponse(let msg): return "Invalid response: \(msg)"
-        case .authenticationFailed(let msg): return "Auth failed: \(msg)"
-        case .serverError(let code, let msg): return "Server error (\(code)): \(msg)"
-        case .certificateStorageFailed(let msg): return "Certificate storage failed: \(msg)"
         }
     }
 }

--- a/OmniTAKMobile/Features/Networking/Views/ServersView.swift
+++ b/OmniTAKMobile/Features/Networking/Views/ServersView.swift
@@ -16,6 +16,7 @@ struct ServersView: View {
     @ObservedObject private var takService = TAKService.shared
 
     @State private var showEnrollment = false
+    @State private var showQRScan = false
     @State private var showDataPackageImport = false
     @State private var serverToEdit: TAKServer? = nil
     @State private var showActionsMenu = false
@@ -37,6 +38,9 @@ struct ServersView: View {
 
                         // Add Server Button
                         addServerButton
+
+                        // Scan Enrollment QR Button
+                        scanQRButton
 
                         // Import Data Package Button
                         importDataPackageButton
@@ -63,6 +67,10 @@ struct ServersView: View {
                             Label("Quick Connect", systemImage: "bolt.circle")
                         }
 
+                        Button(action: { showQRScan = true }) {
+                            Label("Scan QR", systemImage: "qrcode.viewfinder")
+                        }
+
                         Button(action: { showDataPackageImport = true }) {
                             Label("Data Package", systemImage: "doc.badge.plus")
                         }
@@ -80,6 +88,12 @@ struct ServersView: View {
         }
         .sheet(isPresented: $showEnrollment) {
             SimpleEnrollView()
+        }
+        .sheet(isPresented: $showQRScan) {
+            // Reuse the camera QR scanner. A scanned standard ATAK/TAK
+            // enrollment QR (tak://…/enroll?host=&username=&token=) is routed
+            // through DeepLinkHandler → CSR enroll → add server → connect.
+            CertificateEnrollmentView()
         }
         .sheet(isPresented: $showDataPackageImport) {
             DataPackageImportView()
@@ -172,6 +186,40 @@ struct ServersView: View {
                         .foregroundColor(.white)
 
                     Text("Sign in with username & password")
+                        .font(.system(size: 12))
+                        .foregroundColor(Color(hex: "#888888"))
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .foregroundColor(Color(hex: "#444444"))
+            }
+            .padding(16)
+            .background(Color(white: 0.08))
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color(hex: "#FFFC00").opacity(0.3), lineWidth: 1)
+            )
+        }
+    }
+
+    // MARK: - Scan QR Button
+
+    private var scanQRButton: some View {
+        Button(action: { showQRScan = true }) {
+            HStack(spacing: 12) {
+                Image(systemName: "qrcode.viewfinder")
+                    .font(.system(size: 24))
+                    .foregroundColor(Color(hex: "#FFFC00"))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Scan QR Code")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.white)
+
+                    Text("Onboard from a TAK/ATAK enrollment QR")
                         .font(.system(size: 12))
                         .foregroundColor(Color(hex: "#888888"))
                 }


### PR DESCRIPTION
Closes #77

Onboard OmniTAK to **ArgusTAK / TAK Server / ATAK** by scanning the standard enrollment QR:

```
tak://com.atakmap.app/enroll?host=<host>[:port]&username=<u>&token=<t>
```

Most of the plumbing already existed (`tak`/`atak`/`omnitak` schemes registered in `Info.plist`; `.onOpenURL` → `DeepLinkHandler`; an `EnrollmentDeepLink` that parses `host/username/token`; a reusable AVFoundation QR scanner). The gaps this PR closes: the enroll path wasn't using `CSREnrollmentService`, the host `host:port` form was mis-parsed, and the in-app scanner didn't route `tak://…enroll`.

### DeepLinkHandler (`Features/Networking/Services/DeepLinkHandler.swift`)
- `EnrollmentDeepLink` now splits an **embedded `host:port`** — handles the URL-encoded `argustak.com%3A8089` case (`URLComponents` percent-decodes, then we split off `:port`). Explicit `&port=` wins over the embedded port; adds `&enrollport=` alias and empty-value guards.
- The enroll path now drives the **existing `CSREnrollmentService`** (CSR → Marti `signClient` → store client cert + CA chain → add server → connect), mirroring `SimpleEnrollView`'s success wiring exactly. The one-time `token` is passed as the Basic-auth **password**. Streaming port defaults to **8089**, CSR enrollment port to **8446** (both derivable/overridable).
- Removed the old inline Bearer-token CSR reimplementation and its now-dead helpers (`enrollWithToken`, `parseCAConfigXML`, `parseEnrollmentResponse`, `pemToDER`, `storeCertificateIdentity`, `DeepLinkError`, a redundant `URLSession`) — net **−222 lines**, all routed through the one shared service.

### In-app scanner
- `CertificateEnrollmentView` (`Features/Authentication/Views/`): a scanned `tak://`/`atak://`/`omnitak://` enrollment deep link is now routed through `DeepLinkHandler` (same CSR-enroll path) instead of falling into the p12-download/JSON branches.
- `ServersView` (`Features/Networking/Views/`): adds a **"Scan QR Code"** action — a visible button plus an overflow-menu item — that opens the reused camera scanner as a **modal sheet** (full-screen map stays sacred). This is the reliable in-app path, independent of OS scheme routing.

### Verification
`xcodebuild -scheme OmniTAKMobile -destination 'platform=iOS Simulator,name=iPhone 17' build` → `** BUILD SUCCEEDED **`. No new warnings. App version unchanged.

### Assumptions to verify on device (against ArgusTAK)
- **CSR enroll endpoint port/path**: defaults to **8446** + `/Marti/api/tls/config` & `/Marti/api/tls/signClient/v2`. ArgusTAK's QR carries the **8089** streaming port; if its enrollment API is actually on 8089 (or a proxied path), the QR needs `&enrollmentport=` / `&enrollport=`, or we add a host probe.
- **QR param names**: assumes `host` / `username` / `token`. Confirm ArgusTAK emits exactly these (vs `user`, etc.).
- **`token` as Basic-auth password**: assumes ATAK-style Basic auth (`username:token`) to `signClient`. If ArgusTAK expects the token as a Bearer/JWT, the auth header needs adjusting.
- **Lead path**: both the OS-camera-app deep link and the in-app scanner reach the identical flow; in-app scanner is the more reliable demo path.

Do not merge — pending device verification.