### PR TITLE
3D drawing parity: selection/edit/delete, marker render, live draw feedback + 2D compass inset

### DIFF
--- a/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
@@ -89,6 +89,12 @@ struct CesiumMainMap: UIViewRepresentable {
     let lineDrawings: [LineDrawing]
     let circleDrawings: [CircleDrawing]
     let polygonDrawings: [PolygonDrawing]
+    // Drawing-tool point markers (DrawingStore.markers — MarkerDrawing).
+    // The 2D Mapbox path renders these via refreshDrawingMarkers(); without
+    // this parameter the 3D engine never saw a drawing marker, so a dropped
+    // drawing-tool pin was invisible on the globe (issue #61). Distinct from
+    // `pointMarkers` (PointDropperService) — these come from the Draw tools.
+    let markerDrawings: [MarkerDrawing]
     let rangeRings: [RangeRing]
     // Dropped point markers (PointDropperService). The 2D Mapbox path
     // renders these via refreshPointMarkers(); without this the 3D
@@ -123,6 +129,20 @@ struct CesiumMainMap: UIViewRepresentable {
     // as it's built — parity with the Mapbox path's systemYellow temp line.
     // Empty when no measurement is active.
     var liveMeasurementPoints: [CLLocationCoordinate2D] = []
+    // Live in-progress DRAWING vertices (DrawingToolsManager.temporaryPoints
+    // while a line/polygon/circle is being placed). Mirrored as a solid line
+    // + vertex dots in the active drawing color so the globe shows the shape
+    // as the operator taps — parity with the Mapbox temp overlay (issue #63).
+    // Empty when no drawing is in progress. `liveDrawingMode` tells the bridge
+    // whether to close the ring (polygon) and how to render a circle preview.
+    var liveDrawingPoints: [CLLocationCoordinate2D] = []
+    /// "line" | "polygon" | "circle" | nil — the in-progress drawing kind so
+    /// the temp overlay matches the committed shape (closed ring for polygon,
+    /// radius preview for circle). Nil when no drawing is active.
+    var liveDrawingMode: String? = nil
+    /// Active drawing color as "#RRGGBB" so the temp shape reads the same as
+    /// the committed drawing. Defaults to the systemBlue the 2D temp line uses.
+    var liveDrawingColor: String = "#007AFF"
     // Active navigation route (RoutePlanningService.activeRoute) — bridged
     // as a polyline + waypoint billboards so starting navigation on the 3D
     // globe shows the route instead of silently rendering nothing.
@@ -223,10 +243,12 @@ struct CesiumMainMap: UIViewRepresentable {
         let entities = buildEntityJSON()
         let drawings = buildDrawingJSON()
         let measurementsJSON = buildMeasurementJSON()
+        let tempDrawingJSON = buildTempDrawingJSON()
         let trailsJSON = buildTrailJSON()
         context.coordinator.lastSnapshot = entities
         context.coordinator.lastDrawingsSnapshot = drawings
         context.coordinator.lastMeasurementsSnapshot = measurementsJSON
+        context.coordinator.lastTempDrawingSnapshot = tempDrawingJSON
         context.coordinator.lastTrailsSnapshot = trailsJSON
         if context.coordinator.isReady {
             // Dedup ALL the bulk bridge calls — `updateUIView` fires on every
@@ -247,6 +269,13 @@ struct CesiumMainMap: UIViewRepresentable {
             }
             if context.coordinator.shouldPublishBridge(call: "setMeasurements", signature: measurementsJSON.hashValue) {
                 webView.evaluateJavaScript("window.OmniBridge.setMeasurements(\(measurementsJSON));", completionHandler: nil)
+            }
+            // Issue #63 — in-progress drawing preview (solid line + vertices in
+            // the drawing color). Deduped like the others; the `draw-live` uid
+            // makes each vertex replace the prior preview, and an empty payload
+            // on complete/cancel clears it.
+            if context.coordinator.shouldPublishBridge(call: "setTempDrawing", signature: tempDrawingJSON.hashValue) {
+                webView.evaluateJavaScript("window.OmniBridge.setTempDrawing(\(tempDrawingJSON));", completionHandler: nil)
             }
             if context.coordinator.shouldPublishBridge(call: "setTrails", signature: trailsJSON.hashValue) {
                 webView.evaluateJavaScript("window.OmniBridge.setTrails(\(trailsJSON));", completionHandler: nil)
@@ -307,6 +336,8 @@ struct CesiumMainMap: UIViewRepresentable {
         var lastSnapshot: String = "[]"
         var lastDrawingsSnapshot: String = "[]"
         var lastMeasurementsSnapshot: String = "[]"
+        /// Last in-progress drawing preview pushed to the globe (issue #63).
+        var lastTempDrawingSnapshot: String = "[]"
         var lastTrailsSnapshot: String = "[]"
         /// Last coordinate we recentered on in follow mode (dedupe key).
         var lastFollowKey: String?
@@ -405,6 +436,10 @@ struct CesiumMainMap: UIViewRepresentable {
                 )
                 webView?.evaluateJavaScript(
                     "window.OmniBridge.setMeasurements(\(lastMeasurementsSnapshot));",
+                    completionHandler: nil
+                )
+                webView?.evaluateJavaScript(
+                    "window.OmniBridge.setTempDrawing(\(lastTempDrawingSnapshot));",
                     completionHandler: nil
                 )
                 webView?.evaluateJavaScript(
@@ -817,6 +852,32 @@ struct CesiumMainMap: UIViewRepresentable {
             ))
         }
 
+        // Drawing-tool markers (DrawingStore.markers — MarkerDrawing). The 2D
+        // Mapbox path renders these via refreshDrawingMarkers() as a colored
+        // disc; the Cesium bridge never received them, so a drawing-tool pin was
+        // invisible on the 3D engine (issue #61). They carry no CoT type / SIDC
+        // — render the affiliation-shape billboard in the drawing's color via a
+        // friendly affiliation fallback, and tag them with a `dmark-` uid so the
+        // tap handler can open the drawing edit/delete menu (issue #60).
+        for dm in markerDrawings {
+            all.append(BridgeEntity(
+                uid: "dmark-\(dm.id.uuidString)",
+                lat: dm.coordinate.latitude,
+                lon: dm.coordinate.longitude,
+                hae: nil,
+                callsign: dm.label,
+                affiliation: "f",
+                kind: "marker",
+                heading: nil,
+                // No SIDC — fall through to the dot billboard, recolored to the
+                // drawing's tactical color so it matches the 2D disc.
+                sidc: nil,
+                spot: CesiumMainMap.hex(forDrawingColor: dm.color),
+                icon: nil,
+                leader: false
+            ))
+        }
+
         // Active-route waypoints — labelled billboards so the operator can
         // see where the route goes on the globe (the 2D path renders these
         // via RouteOverlayCoordinator's MKAnnotations). Friendly affiliation
@@ -915,6 +976,38 @@ struct CesiumMainMap: UIViewRepresentable {
         }
 
         guard let data = try? JSONEncoder().encode(all),
+              let str = String(data: data, encoding: .utf8) else { return "[]" }
+        return str
+    }
+
+    // MARK: - Live drawing bridge (issue #63)
+
+    /// In-progress drawing geometry for the globe — a solid polyline + vertex
+    /// dots in the active drawing color, so multi-tap line/polygon placement
+    /// shows feedback BEFORE the operator hits Complete (parity with the 2D
+    /// Mapbox temp overlay). Single fixed uid (`draw-live`) so each new vertex
+    /// replaces the prior preview; cleared (empty payload) on complete/cancel.
+    private struct BridgeTempDrawing: Encodable {
+        let uid: String
+        let kind: String          // "line" | "polygon" | "circle"
+        let coords: [[Double]]    // [lon, lat] per vertex
+        let color: String
+        let width: Double
+    }
+
+    private func buildTempDrawingJSON() -> String {
+        // Need an active mode and at least one placed vertex. A circle with a
+        // center but no radius point still shows its center dot; a line/polygon
+        // needs its growing vertex chain.
+        guard let mode = liveDrawingMode, !liveDrawingPoints.isEmpty else { return "[]" }
+        let temp = BridgeTempDrawing(
+            uid: "draw-live",
+            kind: mode,
+            coords: liveDrawingPoints.map { [$0.longitude, $0.latitude] },
+            color: liveDrawingColor,
+            width: 2
+        )
+        guard let data = try? JSONEncoder().encode([temp]),
               let str = String(data: data, encoding: .utf8) else { return "[]" }
         return str
     }

--- a/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
@@ -1121,6 +1121,10 @@ struct ATAKMapView: View {
                 lineDrawings: drawingStore.lines,
                 circleDrawings: drawingStore.circles,
                 polygonDrawings: drawingStore.polygons,
+                // Issue #61 — drawing-tool markers (DrawingStore.markers). The
+                // 2D path renders these as colored discs; feed the same source
+                // so a drawing-tool pin shows on the globe too.
+                markerDrawings: drawingStore.markers,
                 rangeRings: measurementManager.rangeRings,
                 // Dropped pins — same source the 2D Mapbox path reads, so
                 // a pin shows on whichever engine is active.
@@ -1151,6 +1155,15 @@ struct ATAKMapView: View {
                 liveMeasurementPoints: measurementManager.isActive
                     ? measurementManager.temporaryPoints
                     : [],
+                // Issue #63 — in-progress drawing → solid line + vertices on
+                // the globe so multi-tap line/polygon (and the circle center
+                // tap) show feedback before Complete, matching the 2D temp
+                // overlay. Empty / nil while no shape is being placed.
+                liveDrawingPoints: drawingManager.isDrawingActive
+                    ? drawingManager.temporaryPoints
+                    : [],
+                liveDrawingMode: cesiumLiveDrawingMode,
+                liveDrawingColor: cesiumLiveDrawingColorHex,
                 // Active navigation route → polyline + waypoint billboards.
                 activeRoute: routeService.activeRoute,
                 // Phase 3b — operator's own recorded breadcrumb trail.
@@ -1174,6 +1187,33 @@ struct ATAKMapView: View {
                 }
             )
             .ignoresSafeArea()
+    }
+
+    /// Issue #63 — the in-progress drawing kind for the Cesium temp overlay,
+    /// or nil when no shape is being placed. Lasso doesn't create a shape, so
+    /// it's excluded (its selection feedback rides the lasso path).
+    private var cesiumLiveDrawingMode: String? {
+        guard drawingManager.isDrawingActive, let mode = drawingManager.currentMode else { return nil }
+        switch mode {
+        case .line:    return "line"
+        case .polygon: return "polygon"
+        case .circle:  return "circle"
+        case .marker, .lasso: return nil
+        }
+    }
+
+    /// Issue #63 — active drawing color as "#RRGGBB" for the Cesium temp
+    /// overlay, so the preview shape matches the committed drawing's color.
+    private var cesiumLiveDrawingColorHex: String {
+        let c = drawingManager.currentColor.uiColor
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        c.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return String(
+            format: "#%02X%02X%02X",
+            Int((max(0, min(1, r)) * 255).rounded()),
+            Int((max(0, min(1, g)) * 255).rounded()),
+            Int((max(0, min(1, b)) * 255).rounded())
+        )
     }
 
     /// Compact measurement HUD (ATAK-style) — engine-agnostic SwiftUI
@@ -1686,6 +1726,11 @@ struct ATAKMapView: View {
             // Mapbox long-press path produces. Empty-map and other
             // entities fall through to the map-context menu.
             if openCesiumPointMarkerMenu(uid: event.entityUid, at: event) { return }
+            // Issue #60 — a long-press on a drawing (line / polygon / circle /
+            // drawing-marker) opens its Edit/Delete radial menu, same as the 2D
+            // Mapbox long-press path. Without this the 3D engine dropped the
+            // drawing uid and the shape was unselectable.
+            if openCesiumDrawingMenu(uid: event.entityUid, at: event) { return }
             radialMenuCoordinator.showContextMenu(
                 at: event.screenPoint,
                 for: event.coordinate,
@@ -1703,13 +1748,18 @@ struct ATAKMapView: View {
             // operator can edit it without hunting for the long-press —
             // the 3D engine has no MKMapView callout to lean on.
             if openCesiumPointMarkerMenu(uid: uid, at: event) { return }
+            // Issue #60 — a tap on a drawing (line / polygon / circle /
+            // drawing-marker) opens its Edit/Delete radial menu, mirroring the
+            // 2D Mapbox tap-to-select. These uids were previously dropped, so
+            // the operator could never select/edit/delete a shape on the globe.
+            if openCesiumDrawingMenu(uid: uid, at: event) { return }
             // The HTML emits `__self__` for the operator's own pip and
-            // namespaced uids (`ads-…`, `line-…`, `poly-…`, `circ-…`,
-            // `rring-…`, `meas-…`, `trail-…`, `:v<idx>` vertex labels)
-            // for non-contact entities. None of those have a CoT event
-            // behind them, so skip the marker-context menu for them.
+            // namespaced uids (`ads-…`, `rring-…`, `meas-…`, `trail-…`,
+            // `route-…`, `:v<idx>` vertex labels) for entities with no CoT
+            // event and no editable model behind them — skip the marker-context
+            // menu for those. (line-/poly-/circ-/dmark- are handled above.)
             if uid == "__self__" { return }
-            let nonContactPrefixes = ["ads-", "line-", "poly-", "circ-", "rring-", "meas-", "trail-", "route-"]
+            let nonContactPrefixes = ["ads-", "rring-", "meas-", "trail-", "route-"]
             if nonContactPrefixes.contains(where: { uid.hasPrefix($0) }) { return }
             if uid.contains(":v") { return }
             // CoT contact match — open the marker-context radial menu
@@ -1755,6 +1805,47 @@ struct ATAKMapView: View {
             at: event.screenPoint,
             coordinate: pm.coordinate,
             marker: pm
+        )
+        return true
+    }
+
+    /// Issue #60 — if `uid` is a Cesium drawing entity (`line-`, `poly-`,
+    /// `circ-`, or `dmark-` followed by the drawing's UUID), open the
+    /// Edit/Delete radial menu for that shape and return true. Mirrors the 2D
+    /// Mapbox path, which passes `drawingId` + `drawingType` into
+    /// `showContextMenu(...)`; the radial Edit/Delete actions then route through
+    /// the shared `RadialMenuActionExecutor` drawing handlers. Returns false for
+    /// any uid that isn't an editable drawing so the caller can fall through.
+    private func openCesiumDrawingMenu(uid: String?, at event: CesiumMapEvent) -> Bool {
+        guard let uid else { return false }
+        // The bridge namespaces drawing uids as "<prefix>-<UUID>".
+        let mapping: [(prefix: String, type: RadialMenuContext.DrawingType)] = [
+            ("line-",  .line),
+            ("poly-",  .polygon),
+            ("circ-",  .circle),
+            ("dmark-", .marker),
+        ]
+        guard let match = mapping.first(where: { uid.hasPrefix($0.prefix) }) else { return false }
+        let idString = String(uid.dropFirst(match.prefix.count))
+        guard let drawingId = UUID(uuidString: idString) else { return false }
+
+        // Confirm the drawing still exists in the store (it may have been
+        // deleted between the snapshot and the tap) before popping the menu.
+        let exists: Bool
+        switch match.type {
+        case .line:    exists = drawingStore.lines.contains { $0.id == drawingId }
+        case .polygon: exists = drawingStore.polygons.contains { $0.id == drawingId }
+        case .circle:  exists = drawingStore.circles.contains { $0.id == drawingId }
+        case .marker:  exists = drawingStore.markers.contains { $0.id == drawingId }
+        }
+        guard exists else { return false }
+
+        radialMenuCoordinator.showContextMenu(
+            at: event.screenPoint,
+            for: event.coordinate,
+            menuType: .markerContext,
+            drawingId: drawingId,
+            drawingType: match.type
         )
         return true
     }

--- a/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
@@ -105,6 +105,20 @@ struct TacticalMapView: UIViewRepresentable {
         // native one produced a double scale bar on the 2D map.
         mapView.ornaments.options.scaleBar.visibility = .hidden
 
+        // Issue #64 — the built-in rotate-compass ornament keeps the SDK
+        // default (.topTrailing, 8pt margins, adaptive visibility), so when the
+        // operator rotates the map it pops UNDER the full-width opaque status
+        // strip and is unreachable. Push it down below the status bar so the
+        // tap-to-reset-north affordance is visible. OmniTAK's own
+        // CompassOverlayView (also top-trailing) only mounts when the compass
+        // overlay toggle or north-lock is on; this keeps the native rotate
+        // affordance usable the rest of the time without the two stacking.
+        // The y margin clears the status strip (~44pt) plus a small gap; x
+        // keeps it off the right edge a touch more than the 8pt default so it
+        // doesn't sit directly beneath OmniTAK's compass when both are shown.
+        mapView.ornaments.options.compass.position = .topTrailing
+        mapView.ornaments.options.compass.margins = CGPoint(x: 12, y: 96)
+
         // Tap → contact hit-test / map-tap fan-out
         let tap = UITapGestureRecognizer(
             target: context.coordinator,

--- a/OmniTAKMobile/Resources/cesium_scene.html
+++ b/OmniTAKMobile/Resources/cesium_scene.html
@@ -28,7 +28,7 @@
 <script src="https://unpkg.com/milsymbol@2.2.0/dist/milsymbol.js"></script>
 <script>
   Cesium.Ion.defaultAccessToken='__CESIUM_ION_TOKEN__';
-  const _state={ready:false,viewer:null,entities:new Map(),drawings:new Map(),measurements:new Map(),trails:new Map(),leaders:new Map(),photoreal:null,billboardCache:new Map(),lasso:{enabled:false,dragging:false,pts:[],handler:null},northLocked:false,northSnapping:false};
+  const _state={ready:false,viewer:null,entities:new Map(),drawings:new Map(),measurements:new Map(),tempDrawings:new Map(),trails:new Map(),leaders:new Map(),photoreal:null,billboardCache:new Map(),lasso:{enabled:false,dragging:false,pts:[],handler:null},northLocked:false,northSnapping:false};
   // Lasso multi-select drag (issue #16, 3D parity). Camera pan is
   // disabled while the lasso is enabled; the freehand path is drawn on
   // a 2D overlay canvas and the screen points are picked to lat/lon on
@@ -341,6 +341,37 @@
       for(const m of list)if(m&&m.uid){seen.add(m.uid);window.OmniBridge.upsertMeasurement(m);}
       const v=_state.viewer;if(!v)return;
       for(const uid of Array.from(_state.measurements.keys()))if(!seen.has(uid)){const rec=_state.measurements.get(uid);if(rec.entity)v.entities.remove(rec.entity);(rec.vertexEntities||[]).forEach(ve=>v.entities.remove(ve));_state.measurements.delete(uid);}
+    },
+    // Issue #63 — in-progress drawing preview. Renders the partial shape the
+    // operator is placing (before Complete) so multi-tap line/polygon and the
+    // circle center→radius flow give live feedback on the globe, matching the
+    // 2D Mapbox temp overlay. Solid line + vertex dots in the drawing color;
+    // a polygon closes its ring, a circle (center+edge) previews its disc.
+    upsertTempDrawing(arg){const d=_parse(arg);if(!d||!d.uid||!d.kind||!Array.isArray(d.coords)||d.coords.length===0)return;const v=_state.viewer;if(!v)return;
+      const color=_drawColor(d.color||'#007AFF',0.95),fillC=_drawColor(d.color||'#007AFF',0.25),width=typeof d.width==='number'?d.width:2;
+      const prior=_state.tempDrawings.get(d.uid);if(prior){if(prior.line)v.entities.remove(prior.line);if(prior.shape)v.entities.remove(prior.shape);(prior.vertexEntities||[]).forEach(ve=>v.entities.remove(ve));}
+      let line=null,shape=null;
+      if(d.kind==='circle'&&d.coords.length>=2){
+        // Center + radius point → preview disc (parity with the 2D temp circle).
+        const center=d.coords[0],edge=d.coords[1],radius=_havDist(center,edge);
+        shape=v.entities.add({id:d.uid+':disc',position:Cesium.Cartesian3.fromDegrees(center[0],center[1],0),
+          ellipse:{semiMajorAxis:radius,semiMinorAxis:radius,material:fillC,outline:true,outlineColor:color,outlineWidth:width,heightReference:Cesium.HeightReference.CLAMP_TO_GROUND}});
+      }else if(d.coords.length>=2){
+        // Line / polygon → solid polyline; close the ring for a polygon so the
+        // shape reads as the area it will become.
+        const pts=d.coords.slice();if(d.kind==='polygon'&&pts.length>=3)pts.push(pts[0]);
+        line=v.entities.add({id:d.uid+':line',polyline:{positions:pts.map(c=>Cesium.Cartesian3.fromDegrees(c[0],c[1],0)),width:width,material:color,clampToGround:true}});
+      }
+      // Vertex dots on every placed point (including a lone circle center or the
+      // first line point) so the operator sees each tap land.
+      const vertexEntities=d.coords.map((c,i)=>v.entities.add({id:d.uid+':v'+i,position:Cesium.Cartesian3.fromDegrees(c[0],c[1],0),
+        point:{pixelSize:10,color:Cesium.Color.fromCssColorString('#FFFC00'),outlineColor:Cesium.Color.WHITE,outlineWidth:2,heightReference:Cesium.HeightReference.CLAMP_TO_GROUND,disableDepthTestDistance:Number.POSITIVE_INFINITY}}));
+      _state.tempDrawings.set(d.uid,{line:line,shape:shape,vertexEntities:vertexEntities});
+    },
+    setTempDrawing(arg){const list=_parse(arg);if(!Array.isArray(list))return;const seen=new Set();
+      for(const d of list)if(d&&d.uid){seen.add(d.uid);window.OmniBridge.upsertTempDrawing(d);}
+      const v=_state.viewer;if(!v)return;
+      for(const uid of Array.from(_state.tempDrawings.keys()))if(!seen.has(uid)){const rec=_state.tempDrawings.get(uid);if(rec.line)v.entities.remove(rec.line);if(rec.shape)v.entities.remove(rec.shape);(rec.vertexEntities||[]).forEach(ve=>v.entities.remove(ve));_state.tempDrawings.delete(uid);}
     },
     upsertTrail(arg){const t=_parse(arg);if(!t||!t.uid||!Array.isArray(t.coords)||t.coords.length<2)return;const v=_state.viewer;if(!v)return;
       const color=_drawColor(t.color||'#FFC107',0.85),width=typeof t.width==='number'?t.width:3;


### PR DESCRIPTION
Fixes a cluster of rendering / parity bugs the r/ATAK tester (mozios) hit on the map engines. All four were audited with file:line evidence in the linked issues; these are the iOS twins of Android #75–#85.

The recurring theme is engine parity: the 2D Mapbox path and the 3D Cesium globe drifted, and the Cesium JS bridge (`OmniBridge` in `cesium_scene.html`) was missing whole categories of drawing data.

## #60 — 3D engine: drawings can't be selected/edited/deleted
The Cesium tap/long-press handler dropped every drawing uid (`line-`, `poly-`, `circ-`) through the `nonContactPrefixes` early-return, so select/edit/delete never fired on the globe (2D already worked via hit-testing).

- New `openCesiumDrawingMenu(uid:at:)` in `MapViewController` parses the drawing uid, confirms the shape still exists in `drawingStore`, and opens the same `markerContext` radial menu the 2D path builds — passing `drawingId` + `drawingType`.
- Edit/Delete then route through the existing shared `RadialMenuActionExecutor` drawing handlers (no new action plumbing). Edit opens the existing `DrawingPropertiesView`; Delete removes the shape from the store.
- Wired into both the tap and long-press cases; `line-`/`poly-`/`circ-`/`dmark-` removed from the drop list (`ads-`/`rring-`/`meas-`/`trail-`/`route-` stay, since those have no editable model).

Note: this fixes selection/edit/delete and the move/vertex-edit gap noted in the issue is **not** addressed here — there is still no vertex-drag editor on either engine; the edit sheet remains name/color/radius. Called out so it isn't assumed closed.

## #61 — Cesium bridge: drawingStore.markers (MarkerDrawing) render 2D-only
`CesiumMainMap` had no parameter for drawing-tool markers and `buildEntityJSON` skipped them, so a drawing-tool pin was invisible on 3D.

- Added a `markerDrawings` input fed from `drawingStore.markers`.
- Each emits as a colored-dot billboard (reusing the existing `spot` dot path in the HTML, recolored to the drawing's tactical color to match the 2D disc) under a `dmark-<uuid>` uid — so it both renders and selects (via #60).

## #63 — 3D drawing is blind: no in-progress vertices/segments until Complete
Live drawing feedback was bridged only for measurements; the temp-drawing overlay was Mapbox-only, so multi-tap line/polygon on the globe read as non-functional.

- Added a `setTempDrawing` channel to the bridge (state map + upsert/clear) next to the measurement channel, painting a solid line + vertex dots in the active drawing color, closing the ring for polygons and previewing the disc for circles — parity with the 2D temp overlay.
- Fed from `DrawingToolsManager.temporaryPoints`/`currentMode` via new computed helpers; deduped per-frame and replayed on bridge-ready like the other snapshots.

## #64 — Rotate-compass under the status bar (2D)
The built-in Mapbox rotate-compass kept SDK defaults (`.topTrailing`, 8pt margins), so rotating the 2D map popped it directly under the full-width opaque status strip, occluded and unreachable.

- Pushed the ornament below the status bar via `ornaments.options.compass.margins` so the tap-to-reset affordance is visible; nudged x so it doesn't stack under OmniTAK's own `CompassOverlayView`.
- The 3D map-bearing compass — the other half of #64 — already landed in #76 (`CompassOverlayView` now takes `mapBearing` + tap-to-north and mounts on both engines), so it's not re-done here.

## Test plan
Build: `xcodebuild -project OmniTAK.xcodeproj -scheme OmniTAKMobile -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' build` → **BUILD SUCCEEDED**.

Manual (3D globe engine):
- Draw a line, polygon, and circle. Confirm vertices/segments appear **as you tap** (before Complete), in the active color.
- Tap and long-press each finished shape → radial menu opens → Edit opens the properties sheet, Delete removes it.
- Place a drawing-tool **marker** → it appears as a colored dot on the globe and is tap-selectable.
- Toggle 3D→2D→3D mid-draw and confirm the committed shapes persist and the temp preview clears on Complete/Cancel.

Manual (2D Mapbox engine):
- Rotate the map → the compass appears **below** the status strip (not under it) and tapping it resets to north.

These are rendering bugs; the logic/wiring is verified by build + code path, but the on-globe visuals (temp line styling, dot color match, compass placement) warrant a visual pass on a simulator/device.

Closes #60
Closes #61
Closes #63
Closes #64