### PR TITLE
feat(markers): self-pip tap/reposition, heading arrow, icon picker, CoT heading (#65-68)

### DIFF
--- a/OmniTAK.xcodeproj/project.pbxproj
+++ b/OmniTAK.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		62F0E99E6E6CC7D48A777176 /* RadialMenuActionExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C4AE7792EC101310F1483A /* RadialMenuActionExecutor.swift */; };
 		636ABF73E9E4AF843491777E /* SFGPEVC----.svg in Resources */ = {isa = PBXBuildFile; fileRef = EE2FC006021B8F5CE7D6554F /* SFGPEVC----.svg */; };
 		636B2050F7414B9F51ED24C1 /* CoordinateEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9EF53FB6EBD8EDF3F86897D /* CoordinateEntryView.swift */; };
+		AA65001BB2347C8D9E001234 /* SelfPositionEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA65001AB2347C8D9E001234 /* SelfPositionEditSheet.swift */; };
 		65F8AEA3C407443E418A537F /* MeshCoreFrameCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FD474B6A8250F778891C09 /* MeshCoreFrameCodec.swift */; };
 		664F8613B5F60B743FBF798E /* SUA---------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8D6AFD4385B2CB747A74C320 /* SUA---------.svg */; };
 		6671B330ED4920A501C466DB /* SHSPN------.svg in Resources */ = {isa = PBXBuildFile; fileRef = B1A726FDC5E3383C783799A5 /* SHSPN------.svg */; };
@@ -735,6 +736,7 @@
 		D9B49FD9370499A376CCF228 /* zh-Hant */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "OmniTAKMobile/Resources/zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		D9BD8FABAF37BB1D8BCFEBCB /* DataPackageImportView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DataPackageImportView.swift; path = OmniTAKMobile/Features/DataPackages/Views/DataPackageImportView.swift; sourceTree = "<group>"; };
 		D9EF53FB6EBD8EDF3F86897D /* CoordinateEntryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Map/Views/CoordinateEntryView.swift; sourceTree = "<group>"; };
+		AA65001AB2347C8D9E001234 /* SelfPositionEditSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfPositionEditSheet.swift; path = OmniTAKMobile/Features/Map/Views/SelfPositionEditSheet.swift; sourceTree = "<group>"; };
 		DAD02BBDBC955E7953E23B56 /* SFAPMHC----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFAPMHC----.svg"; sourceTree = "<group>"; };
 		DB52A8F022DBCC0F3709FDA2 /* ADSBTrafficService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ADSBTrafficService.swift; path = OmniTAKMobile/Features/ADSB/Services/ADSBTrafficService.swift; sourceTree = "<group>"; };
 		DB5771FBA69E70A6E4BD4764 /* MeasurementToolView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeasurementToolView.swift; path = OmniTAKMobile/Features/Measurement/Views/MeasurementToolView.swift; sourceTree = "<group>"; };
@@ -1298,6 +1300,7 @@
 				6A0A793E185CC30595DAB79B /* CoordinateDisplayView.swift */,
 				448D0EBEFF3E2A71669016D1 /* ScaleBarView.swift */,
 				D9EF53FB6EBD8EDF3F86897D /* CoordinateEntryView.swift */,
+				AA65001AB2347C8D9E001234 /* SelfPositionEditSheet.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -2934,6 +2937,7 @@
 				5D471A897ED1FBD0C5BEB754 /* GybDetectorView.swift in Sources */,
 				A0E27883B3902B6F2FF2FE1C /* TWD97Converter.swift in Sources */,
 				636B2050F7414B9F51ED24C1 /* CoordinateEntryView.swift in Sources */,
+				AA65001BB2347C8D9E001234 /* SelfPositionEditSheet.swift in Sources */,
 				617462BB009B1420CCADF5C6 /* ATAKMapChrome.swift in Sources */,
 				A94B9754063A94BA0CF96C37 /* LocationManager.swift in Sources */,
 				F16F23716C9A564FD3B17635 /* TacticalMapView.swift in Sources */,

--- a/OmniTAKMobile/CoT/Generators/MarkerCoTGenerator.swift
+++ b/OmniTAKMobile/CoT/Generators/MarkerCoTGenerator.swift
@@ -56,6 +56,11 @@ class MarkerCoTGenerator {
             detail += generateSALUTEElement(salute)
         }
 
+        // Issue #68 — emit track element when operator has set a heading on the marker.
+        if let heading = marker.heading {
+            detail += "\n        <track speed=\"0.0\" course=\"\(String(format: "%.2f", heading))\"/>"
+        }
+
         // Add marker metadata
         detail += """
 

--- a/OmniTAKMobile/Features/Drawing/Models/PointMarkerModels.swift
+++ b/OmniTAKMobile/Features/Drawing/Models/PointMarkerModels.swift
@@ -63,12 +63,17 @@ struct PointMarker: Identifiable, Codable, Equatable {
     // Sharing
     var isBroadcast: Bool
 
+    // Issue #68 — optional heading / course in degrees (0–360 CW from north).
+    // When non-nil the CoT generator emits <track speed="0.0" course="{heading}"/>.
+    var heading: Double?
+
     init(
         id: UUID = UUID(),
         name: String,
         affiliation: MarkerAffiliation,
         coordinate: CLLocationCoordinate2D,
         altitude: Double? = nil,
+        heading: Double? = nil,
         remarks: String? = nil,
         saluteReport: SALUTEReport? = nil,
         createdBy: String? = nil,
@@ -83,6 +88,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         self.affiliation = affiliation
         self.coordinate = coordinate
         self.altitude = altitude
+        self.heading = heading
         self.timestamp = Date()
         self.modifiedAt = Date()
         self.remarks = remarks
@@ -102,6 +108,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         self.takIcon = takIcon
         self.markersIcon = markersIcon
         self.googleIcon = googleIcon
+        self.heading = heading
         self.isBroadcast = isBroadcast
     }
 
@@ -111,7 +118,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         case id, name, affiliation, latitude, longitude, altitude
         case timestamp, modifiedAt, remarks, createdBy, saluteReport
         case uid, cotType, iconName, isBroadcast, femaIcon, takIcon
-        case markersIcon, googleIcon
+        case markersIcon, googleIcon, heading
     }
 
     init(from decoder: Decoder) throws {
@@ -138,6 +145,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         takIcon = try container.decodeIfPresent(TAKSpotIcon.self, forKey: .takIcon)
         markersIcon = try container.decodeIfPresent(TAKMarkersIcon.self, forKey: .markersIcon)
         googleIcon = try container.decodeIfPresent(TAKGoogleIcon.self, forKey: .googleIcon)
+        heading = try container.decodeIfPresent(Double.self, forKey: .heading)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -161,6 +169,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         try container.encodeIfPresent(takIcon, forKey: .takIcon)
         try container.encodeIfPresent(markersIcon, forKey: .markersIcon)
         try container.encodeIfPresent(googleIcon, forKey: .googleIcon)
+        try container.encodeIfPresent(heading, forKey: .heading)
     }
 
     // MARK: - Equatable

--- a/OmniTAKMobile/Features/Drawing/Views/PointMarkerEditView.swift
+++ b/OmniTAKMobile/Features/Drawing/Views/PointMarkerEditView.swift
@@ -17,7 +17,15 @@ struct PointMarkerEditView: View {
     @State private var editedAffiliation: MarkerAffiliation = .hostile
     @State private var editedRemarks: String = ""
     @State private var editedAltitude: String = ""
+    @State private var editedHeading: String = ""
     @State private var editedBroadcast: Bool = false
+
+    // Issue #67 — icon pack override fields, mirroring PointMarker.
+    @State private var editedTakIcon: TAKSpotIcon? = nil
+    @State private var editedMarkersIcon: TAKMarkersIcon? = nil
+    @State private var editedGoogleIcon: TAKGoogleIcon? = nil
+    @State private var editedFemaIcon: FemaIcon? = nil
+    @State private var showIconPicker: Bool = false
 
     var body: some View {
         NavigationView {
@@ -38,11 +46,57 @@ struct PointMarkerEditView: View {
                     }
                 }
 
+                // Issue #67 — icon picker row
+                Section("ICON") {
+                    Button(action: { showIconPicker = true }) {
+                        HStack {
+                            Text("Icon")
+                                .foregroundColor(.primary)
+                            Spacer()
+                            if let takIcon = editedTakIcon {
+                                Circle()
+                                    .fill(takIcon.color)
+                                    .frame(width: 18, height: 18)
+                                Text(takIcon.displayName)
+                                    .foregroundColor(.secondary)
+                            } else if let markersIcon = editedMarkersIcon {
+                                Text(markersIcon.displayName)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(1)
+                            } else if let googleIcon = editedGoogleIcon {
+                                Text(googleIcon.token)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(1)
+                            } else if let femaIcon = editedFemaIcon {
+                                Image(systemName: femaIcon.sfSymbolName)
+                                    .foregroundColor(femaIcon.tintColor)
+                            } else {
+                                Image(systemName: editedAffiliation.iconName)
+                                    .foregroundColor(editedAffiliation.color)
+                                Text("Affiliation default")
+                                    .foregroundColor(.secondary)
+                            }
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 13))
+                                .foregroundColor(.gray)
+                        }
+                    }
+                }
+
                 Section("DETAILS") {
                     HStack {
                         Text("Altitude (m)")
                         Spacer()
                         TextField("Optional", text: $editedAltitude)
+                            .keyboardType(.decimalPad)
+                            .multilineTextAlignment(.trailing)
+                    }
+
+                    // Issue #68 — heading field
+                    HStack {
+                        Text("Heading (°)")
+                        Spacer()
+                        TextField("0–360", text: $editedHeading)
                             .keyboardType(.decimalPad)
                             .multilineTextAlignment(.trailing)
                     }
@@ -87,6 +141,16 @@ struct PointMarkerEditView: View {
                 }
             }
             .onAppear(perform: load)
+            // Issue #67 — icon picker sheet
+            .sheet(isPresented: $showIconPicker) {
+                MarkerIconPickerSheet(
+                    affiliation: editedAffiliation,
+                    selectedTakIcon: $editedTakIcon,
+                    selectedMarkersIcon: $editedMarkersIcon,
+                    selectedGoogleIcon: $editedGoogleIcon,
+                    selectedFemaIcon: $editedFemaIcon
+                )
+            }
         }
     }
 
@@ -100,18 +164,272 @@ struct PointMarkerEditView: View {
         editedAffiliation = marker.affiliation
         editedRemarks = marker.remarks ?? ""
         editedAltitude = marker.altitude.map { String(format: "%.1f", $0) } ?? ""
+        editedHeading = marker.heading.map { String(format: "%.1f", $0) } ?? ""
         editedBroadcast = marker.isBroadcast
+        // Load icon pack override state
+        editedTakIcon = marker.takIcon
+        editedMarkersIcon = marker.markersIcon
+        editedGoogleIcon = marker.googleIcon
+        editedFemaIcon = marker.femaIcon
     }
 
     private func save() {
         guard var marker = currentMarker else { return }
         marker.name = editedName.trimmingCharacters(in: .whitespaces)
         marker.affiliation = editedAffiliation
-        marker.cotType = editedAffiliation.cotType
-        marker.iconName = editedAffiliation.iconName
         marker.remarks = editedRemarks.isEmpty ? nil : editedRemarks
         marker.altitude = Double(editedAltitude.trimmingCharacters(in: .whitespaces))
         marker.isBroadcast = editedBroadcast
+
+        // Issue #68 — persist heading (nil when field is empty or invalid)
+        let headingStr = editedHeading.trimmingCharacters(in: .whitespaces)
+        if let h = Double(headingStr), h >= 0, h <= 360 {
+            marker.heading = h
+        } else {
+            marker.heading = nil
+        }
+
+        // Issue #67 — apply icon pack override with same precedence as init().
+        marker.takIcon = editedTakIcon
+        marker.markersIcon = editedMarkersIcon
+        marker.googleIcon = editedGoogleIcon
+        marker.femaIcon = editedFemaIcon
+        // Recalculate cotType + iconName to mirror PointMarker.init precedence.
+        marker.cotType = editedTakIcon.map { _ in TAKSpotIcon.cotType }
+            ?? editedMarkersIcon?.cotType
+            ?? editedGoogleIcon?.cotType
+            ?? editedFemaIcon?.cotType
+            ?? editedAffiliation.cotType
+        marker.iconName = editedFemaIcon?.sfSymbolName
+            ?? editedGoogleIcon?.symbolName
+            ?? editedAffiliation.iconName
+
         pointDropperService.updateMarker(marker)
+    }
+}
+
+// MARK: - Icon Picker Sheet (Issue #67)
+
+/// Modal sheet that lets the user pick a new icon pack for an existing marker.
+/// Mirrors the icon selection UI in PointDropperView but presented as a sheet
+/// so the full-screen map is never compressed.
+private struct MarkerIconPickerSheet: View {
+    let affiliation: MarkerAffiliation
+    @Binding var selectedTakIcon: TAKSpotIcon?
+    @Binding var selectedMarkersIcon: TAKMarkersIcon?
+    @Binding var selectedGoogleIcon: TAKGoogleIcon?
+    @Binding var selectedFemaIcon: FemaIcon?
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedTab: IconPackTab = .spot
+
+    enum IconPackTab: String, CaseIterable, Identifiable {
+        case spot = "Spot"
+        case markers = "Markers"
+        case google = "Google"
+        case fema = "FEMA"
+        case affiliation = "Default"
+        var id: String { rawValue }
+    }
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                Picker("Icon Pack", selection: $selectedTab) {
+                    ForEach(IconPackTab.allCases) { tab in
+                        Text(tab.rawValue).tag(tab)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding()
+
+                ScrollView {
+                    switch selectedTab {
+                    case .spot:
+                        spotGrid
+                    case .markers:
+                        markersGrid
+                    case .google:
+                        googleGrid
+                    case .fema:
+                        femaGrid
+                    case .affiliation:
+                        affiliationDefault
+                    }
+                }
+            }
+            .navigationTitle("Choose Icon")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    // MARK: Spot Map grid
+
+    private var spotGrid: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 70))], spacing: 16) {
+            ForEach(TAKSpotIcon.allCases, id: \.self) { icon in
+                Button(action: {
+                    selectedTakIcon = icon
+                    selectedMarkersIcon = nil
+                    selectedGoogleIcon = nil
+                    selectedFemaIcon = nil
+                }) {
+                    VStack(spacing: 6) {
+                        Circle()
+                            .fill(icon.color)
+                            .frame(width: 36, height: 36)
+                            .overlay(
+                                selectedTakIcon == icon
+                                    ? Circle().stroke(Color.accentColor, lineWidth: 2)
+                                    : nil
+                            )
+                        Text(icon.displayName)
+                            .font(.caption2)
+                            .multilineTextAlignment(.center)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding()
+    }
+
+    // MARK: TAK Markers (2525C) grid
+
+    private var markersGrid: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 90))], spacing: 16) {
+            ForEach(TAKMarkersIcon.allCases, id: \.self) { icon in
+                Button(action: {
+                    selectedMarkersIcon = icon
+                    selectedTakIcon = nil
+                    selectedGoogleIcon = nil
+                    selectedFemaIcon = nil
+                }) {
+                    VStack(spacing: 6) {
+                        // TAKMarkersIcon wraps a 2525C CoT type — no SF symbol.
+                        // Show a shield badge with the short code as a stand-in.
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(selectedMarkersIcon == icon
+                                      ? Color.accentColor.opacity(0.2)
+                                      : Color.secondary.opacity(0.15))
+                                .frame(width: 36, height: 36)
+                            Text(icon.shortName)
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundColor(affiliation.color)
+                        }
+                        Text(icon.displayName)
+                            .font(.caption2)
+                            .multilineTextAlignment(.center)
+                            .lineLimit(2)
+                    }
+                    .frame(width: 80)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding()
+    }
+
+    // MARK: Google Place icon grid
+
+    private var googleGrid: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 90))], spacing: 16) {
+            ForEach(TAKGoogleIcon.allCases, id: \.self) { icon in
+                Button(action: {
+                    selectedGoogleIcon = icon
+                    selectedTakIcon = nil
+                    selectedMarkersIcon = nil
+                    selectedFemaIcon = nil
+                }) {
+                    VStack(spacing: 6) {
+                        Image(systemName: icon.symbolName)
+                            .font(.title2)
+                            .foregroundColor(affiliation.color)
+                            .frame(width: 36, height: 36)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill(selectedGoogleIcon == icon
+                                          ? Color.accentColor.opacity(0.2) : Color.clear)
+                            )
+                        Text(icon.token)
+                            .font(.caption2)
+                            .multilineTextAlignment(.center)
+                            .lineLimit(2)
+                    }
+                    .frame(width: 80)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding()
+    }
+
+    // MARK: FEMA icon grid
+
+    private var femaGrid: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 90))], spacing: 16) {
+            ForEach(FemaIcon.allCases, id: \.self) { icon in
+                Button(action: {
+                    selectedFemaIcon = icon
+                    selectedTakIcon = nil
+                    selectedMarkersIcon = nil
+                    selectedGoogleIcon = nil
+                }) {
+                    VStack(spacing: 6) {
+                        Image(systemName: icon.sfSymbolName)
+                            .font(.title2)
+                            .foregroundColor(icon.tintColor)
+                            .frame(width: 36, height: 36)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill(selectedFemaIcon == icon
+                                          ? Color.accentColor.opacity(0.2) : Color.clear)
+                            )
+                        Text(icon.displayName)
+                            .font(.caption2)
+                            .multilineTextAlignment(.center)
+                            .lineLimit(2)
+                    }
+                    .frame(width: 80)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding()
+    }
+
+    // MARK: Affiliation default (clear all overrides)
+
+    private var affiliationDefault: some View {
+        VStack(spacing: 20) {
+            Spacer().frame(height: 20)
+            Image(systemName: affiliation.iconName)
+                .font(.system(size: 48))
+                .foregroundColor(affiliation.color)
+            Text("Affiliation Default")
+                .font(.headline)
+            Text("The marker will use the standard \(affiliation.displayName) icon.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+            Button(action: {
+                selectedTakIcon = nil
+                selectedMarkersIcon = nil
+                selectedGoogleIcon = nil
+                selectedFemaIcon = nil
+                dismiss()
+            }) {
+                Label("Use Default", systemImage: "arrow.clockwise")
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
     }
 }

--- a/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
@@ -716,6 +716,14 @@ struct CesiumMainMap: UIViewRepresentable {
         var all: [BridgeEntity] = []
 
         if let loc = selfLocation {
+            // Issue #66 — supply GPS course as heading when the arrow style is
+            // active (non-negative course = valid heading from CoreLocation).
+            // The HTML billboard rotates the entity icon by `heading` degrees
+            // clockwise from north, same as aircraft entities.
+            let selfHeading: Double? = (selfMarkerStyle == "arrow" && loc.course >= 0)
+                ? loc.course
+                : nil
+
             all.append(BridgeEntity(
                 uid: "__self__",
                 lat: loc.coordinate.latitude,
@@ -724,13 +732,15 @@ struct CesiumMainMap: UIViewRepresentable {
                 callsign: selfCallsign,
                 affiliation: "f",
                 kind: "self",
-                heading: nil,
+                heading: selfHeading,
                 // Self renders as a friendly ground combat unit so milsymbol
                 // draws the standard friendly frame the operator expects.
                 // The "bullseye" Settings style suppresses the SIDC so the
                 // HTML falls back to the green disc + center-dot canvas
                 // billboard — the globe's bullseye analog.
-                sidc: selfMarkerStyle == "bullseye" ? nil : "SFGPUCI----",
+                // The "arrow" style also suppresses the SIDC in favour of
+                // the heading-rotated arrow billboard from the HTML side.
+                sidc: (selfMarkerStyle == "bullseye" || selfMarkerStyle == "arrow") ? nil : "SFGPUCI----",
                 spot: nil,
                 icon: nil,
                 leader: false

--- a/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
@@ -65,6 +65,8 @@ struct ATAKMapView: View {
     // Radial menu → Edit on a PointMarker posts .radialMenuEditMarker;
     // we hold the marker id here so a sheet can open the edit form.
     @State private var editingPointMarkerID: UUID?
+    // Issue #65 — self-position edit sheet (manual position override).
+    @State private var showSelfPositionEdit: Bool = false
     @State private var mapType: MKMapType = .standard
     @State private var showToolsMenu = false
     @State private var showLoadingScreen = true
@@ -1106,6 +1108,16 @@ struct ATAKMapView: View {
                 drawingManager.pendingRenameID = drawingId
             }
         }
+        // Issue #65 — self-position puck tapped from either engine.
+        .onReceive(NotificationCenter.default.publisher(for: .selfMarkerTapped)) { _ in
+            showSelfPositionEdit = true
+        }
+        .sheet(isPresented: $showSelfPositionEdit) {
+            SelfPositionEditSheet(
+                locationManager: locationManager,
+                isPresented: $showSelfPositionEdit
+            )
+        }
     }
 
     /// The bare 3D engine — the Cesium scene and nothing else. All shared
@@ -1708,7 +1720,12 @@ struct ATAKMapView: View {
             // `rring-…`, `meas-…`, `trail-…`, `:v<idx>` vertex labels)
             // for non-contact entities. None of those have a CoT event
             // behind them, so skip the marker-context menu for them.
-            if uid == "__self__" { return }
+            if uid == "__self__" {
+                // Issue #65 — tap on own Cesium pip opens the self-position
+                // edit sheet (same sheet the Mapbox puck tap triggers).
+                NotificationCenter.default.post(name: .selfMarkerTapped, object: nil)
+                return
+            }
             let nonContactPrefixes = ["ads-", "line-", "poly-", "circ-", "rring-", "meas-", "trail-", "route-"]
             if nonContactPrefixes.contains(where: { uid.hasPrefix($0) }) { return }
             if uid.contains(":v") { return }

--- a/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
@@ -18,6 +18,10 @@ import UIKit
 extension Notification.Name {
     /// Posted by ATAKMapView to snap the Mapbox camera heading to 0° (north).
     static let mapboxResetNorth = Notification.Name("mapboxResetNorth")
+    /// Issue #65 — posted when the operator taps their own self-position puck
+    /// (either the Mapbox 2D puck or the Cesium 3D `__self__` entity). The
+    /// MapViewController observes this and presents `SelfPositionEditSheet`.
+    static let selfMarkerTapped = Notification.Name("selfMarkerTapped")
 }
 
 // MARK: - Tactical Map View (Mapbox Maps SDK v3 — native)
@@ -86,6 +90,7 @@ struct TacticalMapView: UIViewRepresentable {
         // marker" picker (selfMarkerStyle). Previously the picker persisted
         // a value nothing read and the puck was always the default dot.
         mapView.location.options.puckType = TacticalMapView.selfPuckType()
+        TacticalMapView.applyPuckBearing(to: mapView)
         context.coordinator.lastSelfMarkerStyle =
             UserDefaults.standard.string(forKey: "selfMarkerStyle") ?? "milstd"
         if !showsUserLocation { mapView.location.options.puckType = nil }
@@ -235,6 +240,9 @@ struct TacticalMapView: UIViewRepresentable {
             if context.coordinator.lastSelfMarkerStyle != style {
                 context.coordinator.lastSelfMarkerStyle = style
                 mapView.location.options.puckType = TacticalMapView.selfPuckType()
+                // Issue #66 — also update the bearing mode so the arrow puck
+                // rotates with device heading when the user switches to it.
+                TacticalMapView.applyPuckBearing(to: mapView)
             }
         }
 
@@ -251,16 +259,35 @@ struct TacticalMapView: UIViewRepresentable {
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 
     /// User-location puck honoring the Settings "Self-position marker"
-    /// picker: "milstd" → MIL-STD-2525 friendly-combat frame, "bullseye" →
-    /// legacy tactical bullseye (both from `SelfPositionMarkerImage`).
+    /// picker:
+    ///   "milstd"   → MIL-STD-2525 friendly-combat frame (default)
+    ///   "bullseye" → legacy tactical bullseye
+    ///   "arrow"    → heading-indicating triangle (Issue #66). Puck bearing
+    ///                is set to .heading via `applyPuckBearing(_:)` after
+    ///                this returns.
     static func selfPuckType() -> PuckType {
         let style = UserDefaults.standard.string(forKey: "selfMarkerStyle") ?? "milstd"
-        let image = style == "bullseye"
-            ? SelfPositionMarkerImage.bullseye
-            : SelfPositionMarkerImage.milStdFriendlyCombat
+        let image: UIImage
+        switch style {
+        case "bullseye":
+            image = SelfPositionMarkerImage.bullseye
+        case "arrow":
+            image = SelfPositionMarkerImage.arrowMarker()
+        default:
+            image = SelfPositionMarkerImage.milStdFriendlyCombat
+        }
         var config = Puck2DConfiguration(topImage: image)
         config.showsAccuracyRing = true
         return .puck2D(config)
+    }
+
+    /// Apply the bearing-tracking option that pairs with the chosen puck style.
+    /// "arrow" uses .heading (north-relative, rotates with device heading);
+    /// other styles keep puckBearingEnabled false so the puck stays upright.
+    static func applyPuckBearing(to mapView: MapView) {
+        let style = UserDefaults.standard.string(forKey: "selfMarkerStyle") ?? "milstd"
+        mapView.location.options.puckBearing = .heading
+        mapView.location.options.puckBearingEnabled = (style == "arrow")
     }
 
     // MARK: - Style mapping
@@ -1350,6 +1377,22 @@ struct TacticalMapView: UIViewRepresentable {
             guard let mapView = mapView else { return }
             let point = gesture.location(in: mapView)
             let coordinate = mapView.mapboxMap.coordinate(for: point)
+
+            // Issue #65 — tap the self-position puck to open the manual
+            // position edit sheet. The puck center is the GPS coordinate
+            // projected to screen; we use a 28pt hit radius (larger than
+            // the smallest puck image so it's easy to tap).
+            if !parent.drawingManager.isDrawingActive && !parent.measurementManager.isActive {
+                if let gpsCoord = mapView.location.latestLocation?.coordinate {
+                    let puckScreenPoint = mapView.mapboxMap.point(for: gpsCoord)
+                    let dx = point.x - puckScreenPoint.x
+                    let dy = point.y - puckScreenPoint.y
+                    if sqrt(dx * dx + dy * dy) < 28 {
+                        NotificationCenter.default.post(name: .selfMarkerTapped, object: nil)
+                        return
+                    }
+                }
+            }
 
             // Bug #1: tap (not just long-press) on a marker / shape body or
             // its floating name label should open the radial context menu.

--- a/OmniTAKMobile/Features/Map/Markers/SelfPositionMarkerImage.swift
+++ b/OmniTAKMobile/Features/Map/Markers/SelfPositionMarkerImage.swift
@@ -52,6 +52,47 @@ enum SelfPositionMarkerImage {
         }
     }()
 
+    /// Issue #66 — 40×40 north-pointing equilateral arrow (triangle) for the
+    /// heading-aware puck style. The arrow points north in the image coordinate
+    /// system; Mapbox rotates the puck via `puckBearing = .heading` so it always
+    /// indicates the device's actual heading. The anchor is the geometric center
+    /// so Mapbox keeps the tip on the GPS coordinate regardless of rotation.
+    ///
+    /// Call `arrowMarker(heading:)` to get the image — the heading parameter is
+    /// ignored here (Mapbox rotates for us) but kept so callers can pass it for
+    /// potential future Cesium billboard use.
+    static func arrowMarker(heading: Double? = nil) -> UIImage {
+        let size = CGSize(width: 40, height: 40)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { _ in
+            // Equilateral-ish north-pointing triangle: tip at top center,
+            // base at ~70% down from top. Center of mass is at ~50% height
+            // so Mapbox's default center anchor keeps the tip above the coordinate.
+            let cx = size.width / 2
+            let tip = CGPoint(x: cx, y: 3)          // top tip
+            let baseLeft  = CGPoint(x: 5, y: 37)    // bottom-left
+            let baseRight = CGPoint(x: 35, y: 37)   // bottom-right
+
+            let path = UIBezierPath()
+            path.move(to: tip)
+            path.addLine(to: baseRight)
+            path.addLine(to: baseLeft)
+            path.close()
+
+            // Fill with tactical accent green, stroke with dark navy.
+            tacticalAccent.setFill()
+            path.fill()
+            tacticalDark.setStroke()
+            path.lineWidth = 2.0
+            path.stroke()
+
+            // Small center dot to anchor the GPS coordinate visually.
+            let centerDotRect = CGRect(x: cx - 3, y: 22, width: 6, height: 6)
+            tacticalDark.setFill()
+            UIBezierPath(ovalIn: centerDotRect).fill()
+        }
+    }
+
     /// 36×36 friendly-combat ground frame: cyan fill, saturated-blue
     /// stroke, simple rectangle (no echelon, no function modifier).
     /// Matches the SFGPUC------ family of MIL-STD-2525B symbols and

--- a/OmniTAKMobile/Features/Map/Views/SelfPositionEditSheet.swift
+++ b/OmniTAKMobile/Features/Map/Views/SelfPositionEditSheet.swift
@@ -1,0 +1,158 @@
+//
+//  SelfPositionEditSheet.swift
+//  OmniTAKMobile
+//
+//  Issue #65 — Modal sheet that lets the operator manually override their
+//  self-position (disabling GPS for CoT broadcast) or return to GPS tracking.
+//
+
+import SwiftUI
+import CoreLocation
+
+/// Sheet for manually repositioning the self-position marker.
+///
+/// When the operator enters a lat/lon and taps "Set Manual Position", the
+/// `PositionBroadcastService` stops reading from GPS and uses the entered
+/// coordinate for all subsequent CoT SA broadcasts (both auto-PPLI and user-
+/// triggered PLI). Tapping "Return to GPS" clears the override.
+struct SelfPositionEditSheet: View {
+    let locationManager: LocationManager
+    @Binding var isPresented: Bool
+
+    @ObservedObject private var pbs = PositionBroadcastService.shared
+
+    @State private var latText: String = ""
+    @State private var lonText: String = ""
+    @State private var validationError: String? = nil
+
+    private var currentGPS: CLLocationCoordinate2D? {
+        locationManager.location?.coordinate
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                // Status banner
+                Section {
+                    HStack(spacing: 12) {
+                        Image(systemName: pbs.isManualPositionActive
+                              ? "location.slash.fill"
+                              : "location.fill")
+                            .foregroundColor(pbs.isManualPositionActive ? .orange : .green)
+                            .font(.title2)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(pbs.isManualPositionActive
+                                 ? "Manual Position Active"
+                                 : "GPS Active")
+                                .font(.headline)
+
+                            if pbs.isManualPositionActive, let pos = pbs.manualPosition {
+                                Text(String(format: "%.6f, %.6f",
+                                            pos.latitude, pos.longitude))
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(.secondary)
+                            } else if let gps = currentGPS {
+                                Text(String(format: "%.6f, %.6f",
+                                            gps.latitude, gps.longitude))
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                // Manual coordinate entry
+                Section("SET MANUAL POSITION") {
+                    HStack {
+                        Text("Latitude")
+                        Spacer()
+                        TextField("e.g. 38.8951", text: $latText)
+                            .keyboardType(.decimalPad)
+                            .multilineTextAlignment(.trailing)
+                    }
+
+                    HStack {
+                        Text("Longitude")
+                        Spacer()
+                        TextField("e.g. -77.0364", text: $lonText)
+                            .keyboardType(.decimalPad)
+                            .multilineTextAlignment(.trailing)
+                    }
+
+                    if let error = validationError {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+
+                    Button(action: applyManualPosition) {
+                        Label("Set Manual Position", systemImage: "mappin.and.ellipse")
+                    }
+                    .disabled(latText.trimmingCharacters(in: .whitespaces).isEmpty ||
+                              lonText.trimmingCharacters(in: .whitespaces).isEmpty)
+
+                    // Prefill from current GPS to make editing the position easy.
+                    if let gps = currentGPS {
+                        Button(action: {
+                            latText = String(format: "%.6f", gps.latitude)
+                            lonText = String(format: "%.6f", gps.longitude)
+                        }) {
+                            Label("Prefill from GPS", systemImage: "location.circle")
+                        }
+                        .foregroundColor(.blue)
+                    }
+                }
+
+                // Return to GPS
+                if pbs.isManualPositionActive {
+                    Section {
+                        Button(action: returnToGPS) {
+                            Label("Return to GPS", systemImage: "location.fill")
+                                .foregroundColor(.green)
+                        }
+                    }
+                }
+
+                // Info footer
+                Section {
+                    Text("When a manual position is set, all CoT SA broadcasts use the entered coordinate instead of GPS. The puck on the map still shows your actual GPS position.")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .navigationTitle("Self Position")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { isPresented = false }
+                }
+            }
+        }
+    }
+
+    private func applyManualPosition() {
+        validationError = nil
+        let latStr = latText.trimmingCharacters(in: .whitespaces)
+        let lonStr = lonText.trimmingCharacters(in: .whitespaces)
+
+        guard let lat = Double(latStr), lat >= -90, lat <= 90 else {
+            validationError = "Latitude must be a number between -90 and 90."
+            return
+        }
+        guard let lon = Double(lonStr), lon >= -180, lon <= 180 else {
+            validationError = "Longitude must be a number between -180 and 180."
+            return
+        }
+
+        pbs.manualPosition = CLLocationCoordinate2D(latitude: lat, longitude: lon)
+        pbs.isManualPositionActive = true
+        isPresented = false
+    }
+
+    private func returnToGPS() {
+        pbs.isManualPositionActive = false
+        isPresented = false
+    }
+}

--- a/OmniTAKMobile/Features/Networking/Services/PositionBroadcastService.swift
+++ b/OmniTAKMobile/Features/Networking/Services/PositionBroadcastService.swift
@@ -89,6 +89,22 @@ class PositionBroadcastService: ObservableObject {
     // Not @Published — mutated on ppliQueue; expose internal for @testable access.
     internal var lastMeshPPLISend: Date?
 
+    // MARK: - Issue #65: Manual Position Override
+    //
+    // When the operator taps their self-pip and sets a manual coordinate,
+    // `manualPosition` becomes non-nil and CoT generation uses it instead of
+    // the GPS location. Cleared by toggling `isManualPositionActive = false`
+    // or by tapping "Return to GPS" in the SelfPositionEditSheet.
+
+    @Published var manualPosition: CLLocationCoordinate2D? = nil
+    @Published var isManualPositionActive: Bool = false {
+        didSet {
+            if !isManualPositionActive {
+                manualPosition = nil
+            }
+        }
+    }
+
     @Published var lastBroadcastTime: Date?
     @Published var broadcastCount: Int = 0
     @Published var lastError: String?
@@ -238,12 +254,20 @@ class PositionBroadcastService: ObservableObject {
 
     private func sendAutoPPLITick() {
         guard let takService = takService else { return }
-        guard let location = locationManager?.location else {
-            // No GPS fix yet — skip this tick rather than sending stale zeros.
-            return
+
+        // Issue #65 — manual position override takes priority over GPS.
+        let effectiveLocation: CLLocation
+        if isManualPositionActive, let manualCoord = manualPosition {
+            effectiveLocation = CLLocation(latitude: manualCoord.latitude, longitude: manualCoord.longitude)
+        } else {
+            guard let location = locationManager?.location else {
+                // No GPS fix yet — skip this tick rather than sending stale zeros.
+                return
+            }
+            effectiveLocation = location
         }
 
-        let cotXML = generateSelfSACoT(location: location)
+        let cotXML = generateSelfSACoT(location: effectiveLocation)
         let _ = takService.sendCoT(xml: cotXML)
 
         // --- Mesh off-grid PPLI ---
@@ -291,13 +315,20 @@ class PositionBroadcastService: ObservableObject {
             return
         }
 
-        guard let location = locationManager?.location else {
-            print("❌ broadcastPosition: No location available (locationManager: \(locationManager != nil ? "exists" : "nil"))")
-            lastError = "No location available"
-            return
+        // Issue #65 — manual position override takes priority over GPS.
+        let effectiveLocation: CLLocation
+        if isManualPositionActive, let manualCoord = manualPosition {
+            effectiveLocation = CLLocation(latitude: manualCoord.latitude, longitude: manualCoord.longitude)
+        } else {
+            guard let location = locationManager?.location else {
+                print("❌ broadcastPosition: No location available (locationManager: \(locationManager != nil ? "exists" : "nil"))")
+                lastError = "No location available"
+                return
+            }
+            effectiveLocation = location
         }
 
-        let cotXML = generateSelfSACoT(location: location)
+        let cotXML = generateSelfSACoT(location: effectiveLocation)
 
         #if DEBUG
         print("📡 Sending PLI CoT for UID: \(userUID), callsign: \(userCallsign)")
@@ -310,7 +341,7 @@ class PositionBroadcastService: ObservableObject {
             lastBroadcastTime = Date()
             broadcastCount += 1
             lastError = nil
-            print("Position broadcast #\(broadcastCount) at \(location.coordinate)")
+            print("Position broadcast #\(broadcastCount) at \(effectiveLocation.coordinate)")
         } else {
             lastError = "Failed to send position"
             print("Failed to broadcast position")

--- a/OmniTAKMobile/Features/Settings/Views/SettingsView.swift
+++ b/OmniTAKMobile/Features/Settings/Views/SettingsView.swift
@@ -213,6 +213,10 @@ struct SettingsView: View {
                     Picker(loc.t("settings.selfPositionMarker"), selection: $selfMarkerStyle) {
                         Text(loc.t("settings.marker.milstd")).tag("milstd")
                         Text(loc.t("settings.marker.bullseye")).tag("bullseye")
+                        // Issue #66 — heading-indicating arrow puck. Mapbox
+                        // rotates the puck via puckBearing = .heading so the
+                        // triangle always points in the device's heading direction.
+                        Text(loc.t("settings.marker.arrow")).tag("arrow")
                     }
                 }
 

--- a/OmniTAKMobile/Resources/de.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/de.lproj/Localizable.strings
@@ -103,6 +103,7 @@
 "settings.coord.bngHelp" = "BNG ist für Großbritannien/Irland optimiert (49°-61° N, 9° W - 2° O). Verwendet das OSGB36-Datum mit Gitterquadraten wie SU, TQ, NT.";
 "settings.marker.milstd" = "MIL-STD-Symbol";
 "settings.marker.bullseye" = "Zielscheibe (klassisch)";
+"settings.marker.arrow" = "Pfeil (Richtung)";
 "settings.color.cyan" = "Cyan";
 "settings.color.green" = "Grün";
 "settings.color.orange" = "Orange";

--- a/OmniTAKMobile/Resources/en.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/en.lproj/Localizable.strings
@@ -104,6 +104,7 @@
 "settings.coord.bngHelp" = "BNG is optimized for UK/Ireland (49°N-61°N, 9°W-2°E). Uses OSGB36 datum with grid squares like SU, TQ, NT.";
 "settings.marker.milstd" = "MIL-STD Symbol";
 "settings.marker.bullseye" = "Bullseye (Legacy)";
+"settings.marker.arrow" = "Arrow (Heading)";
 "settings.color.cyan" = "Cyan";
 "settings.color.green" = "Green";
 "settings.color.orange" = "Orange";

--- a/OmniTAKMobile/Resources/es.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/es.lproj/Localizable.strings
@@ -103,6 +103,7 @@
 "settings.coord.bngHelp" = "BNG está optimizada para el Reino Unido e Irlanda (49°-61° N, 9° O - 2° E). Usa el datum OSGB36 con cuadrados de cuadrícula como SU, TQ, NT.";
 "settings.marker.milstd" = "Símbolo MIL-STD";
 "settings.marker.bullseye" = "Diana (heredado)";
+"settings.marker.arrow" = "Flecha (rumbo)";
 "settings.color.cyan" = "Cian";
 "settings.color.green" = "Verde";
 "settings.color.orange" = "Naranja";

--- a/OmniTAKMobile/Resources/fr.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/fr.lproj/Localizable.strings
@@ -103,6 +103,7 @@
 "settings.coord.bngHelp" = "Le BNG est optimisé pour le Royaume-Uni et l'Irlande (49°-61° N, 9° O - 2° E). Utilise le datum OSGB36 avec des carrés de grille comme SU, TQ, NT.";
 "settings.marker.milstd" = "Symbole MIL-STD";
 "settings.marker.bullseye" = "Cible (ancien)";
+"settings.marker.arrow" = "Flèche (cap)";
 "settings.color.cyan" = "Cyan";
 "settings.color.green" = "Vert";
 "settings.color.orange" = "Orange";

--- a/OmniTAKMobile/Resources/pl.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/pl.lproj/Localizable.strings
@@ -103,6 +103,7 @@
 "settings.coord.bngHelp" = "BNG jest zoptymalizowana dla Wielkiej Brytanii i Irlandii (49°-61° N, 9° W - 2° E). Używa układu odniesienia OSGB36 z kwadratami siatki takimi jak SU, TQ, NT.";
 "settings.marker.milstd" = "Symbol MIL-STD";
 "settings.marker.bullseye" = "Tarcza (starszy)";
+"settings.marker.arrow" = "Strzałka (kierunek)";
 "settings.color.cyan" = "Cyjan";
 "settings.color.green" = "Zielony";
 "settings.color.orange" = "Pomarańczowy";

--- a/OmniTAKMobile/Resources/uk.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/uk.lproj/Localizable.strings
@@ -103,6 +103,7 @@
 "settings.coord.bngHelp" = "BNG оптимізовано для Великої Британії та Ірландії (49°-61° пн. ш., 9° зх. д. - 2° сх. д.). Використовує датум OSGB36 із квадратами сітки на кшталт SU, TQ, NT.";
 "settings.marker.milstd" = "Символ MIL-STD";
 "settings.marker.bullseye" = "Мішень (застарілий)";
+"settings.marker.arrow" = "Стрілка (напрям)";
 "settings.color.cyan" = "Блакитний";
 "settings.color.green" = "Зелений";
 "settings.color.orange" = "Помаранчевий";

--- a/OmniTAKMobile/Resources/zh-Hant.lproj/Localizable.strings
+++ b/OmniTAKMobile/Resources/zh-Hant.lproj/Localizable.strings
@@ -104,6 +104,7 @@
 "settings.coord.bngHelp" = "BNG 針對英國/愛爾蘭最佳化（49°N-61°N, 9°W-2°E）。使用 OSGB36 基準與 SU、TQ、NT 等網格方格。";
 "settings.marker.milstd" = "MIL-STD 符號";
 "settings.marker.bullseye" = "靶心（舊版）";
+"settings.marker.arrow" = "箭頭（方向）";
 "settings.color.cyan" = "青色";
 "settings.color.green" = "綠色";
 "settings.color.orange" = "橘色";


### PR DESCRIPTION
## Summary

- **#65** — Tap the self-marker to manually reposition it; GPS is suspended while a manual override is active. Tap restores GPS mode.
- **#66** — New \"Arrow\" self-marker style renders a heading-indicating triangle that rotates with device heading on Mapbox (puck bearing). Cesium receives the heading value via the entity bridge.
- **#67** — Post-placement icon picker in the marker edit sheet. All four icon packs (TAK Spot, TAK Markers 2525C, TAK Google, FEMA) are selectable; changing the icon recalculates `cotType` and `iconName` using the same precedence chain as placement.
- **#68** — `PointMarker` gains an optional `heading: Double?` field. The edit sheet exposes a \"Heading (°)\" field (0–360). `MarkerCoTGenerator` emits `<track speed=\"0.0\" course=\"{heading}\"/>` when set, so the heading round-trips to ATAK/iTAK.

## Files changed

| File | Change |
|------|--------|
| `PointMarkerModels.swift` | `heading: Double?` field + encode/decode |
| `MarkerCoTGenerator.swift` | Emit `<track>` element when heading set |
| `PointMarkerEditView.swift` | Heading field + MarkerIconPickerSheet |
| `SelfPositionMarkerImage.swift` | `arrowMarker()` static image |
| `TacticalMapView.swift` | Arrow puck + puck bearing + self-pip tap detection |
| `CesiumMainMap.swift` | Pass `selfHeading` to entity bridge for arrow style |
| `MapViewController.swift` | Observe `.selfMarkerTapped`, present `SelfPositionEditSheet` |
| `PositionBroadcastService.swift` | `manualPosition` + `isManualPositionActive` override |
| `SelfPositionEditSheet.swift` (new) | Manual position form sheet |
| `SettingsView.swift` | \"Arrow\" option in self-marker style picker |
| 7× `Localizable.strings` | `selfMarkerStyle.arrow` key |

## Test plan

- [ ] **#68**: Drop a marker, open Edit, set heading 45°, save. Broadcast it; confirm ATAK shows the marker with correct orientation. Clear heading, confirm `<track>` is absent.
- [ ] **#67**: Drop a marker, open Edit, tap the Icon row. Verify all four icon packs load in the picker. Pick a TAK Spot icon, save; confirm the marker re-renders with the new icon on both 2D and 3D map.
- [ ] **#66**: In Settings → Self-position marker, switch to \"Arrow\". Confirm the puck changes to a triangle and rotates as you physically rotate the device (Mapbox). Toggle to Cesium; heading value is bridged (JS rendering depends on bridge impl).
- [ ] **#65**: On Cesium, tap the self-pip (`__self__`). `SelfPositionEditSheet` opens. Enter a lat/lon, save. Confirm the PPLI CoT now broadcasts the manual coordinate. Tap \"Return to GPS\"; confirm live location resumes. On Mapbox, tap within 28pt of the GPS dot; sheet opens.

Closes #65
Closes #66
Closes #67
Closes #68