### PR TITLE
Drawing move: drag-to-reposition placed drawings on both engines

### DIFF
--- a/OmniTAK.xcodeproj/project.pbxproj
+++ b/OmniTAK.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		9D1E97C264F38CD9B0017F5A /* DrawingPropertiesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8A6851F2CB32B82BEA2817 /* DrawingPropertiesView.swift */; };
 		9D4DD979FA07D0D920CA576A /* MEDEVACRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C046FF14CC38A998A3C9C57A /* MEDEVACRequestView.swift */; };
 		9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */; };
+		D60D60D60D60D60D60D60D60 /* DrawingMoveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60F60F60F60F60F60F60F60 /* DrawingMoveTests.swift */; };
 		9F360AA41C05B15FC6B71F75 /* EchelonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D5A42ABFBE8EF268B187D8 /* EchelonModels.swift */; };
 		9F4D964068E0E91862AEE361 /* KMLOverlaysPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619B6C2A0B1A1C5237648ED5 /* KMLOverlaysPanel.swift */; };
 		9F975E18CC49BBAC535F8A0B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D9B49FD9370499A376CCF227 /* Localizable.strings */; };
@@ -764,6 +765,7 @@
 		EA4A86523E550E87AC1EE8A4 /* SALUTEReportView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SALUTEReportView.swift; path = OmniTAKMobile/Features/Military/Views/SALUTEReportView.swift; sourceTree = "<group>"; };
 		EA65513B351E6E8D864A945A /* RemoteIdAppBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RemoteIdAppBridge.swift; path = OmniTAKMobile/Features/RemoteID/Services/RemoteIdAppBridge.swift; sourceTree = "<group>"; };
 		EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoordinateFormatTests.swift; path = OmniTAKMobileTests/CoordinateFormatTests.swift; sourceTree = "<group>"; };
+		D60F60F60F60F60F60F60F60 /* DrawingMoveTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DrawingMoveTests.swift; path = OmniTAKMobileTests/DrawingMoveTests.swift; sourceTree = "<group>"; };
 		EC5FB4399952EB25310628E4 /* RangeBearingService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RangeBearingService.swift; path = OmniTAKMobile/Features/Measurement/Services/RangeBearingService.swift; sourceTree = "<group>"; };
 		ED51505084DDA26949BB854D /* EchelonHierarchyView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EchelonHierarchyView.swift; path = OmniTAKMobile/Features/Teams/Views/EchelonHierarchyView.swift; sourceTree = "<group>"; };
 		EE2FC006021B8F5CE7D6554F /* SFGPEVC----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPEVC----.svg"; sourceTree = "<group>"; };
@@ -1061,6 +1063,7 @@
 				0C8884B98F8B309825903DC6 /* ServerValidatorTests.swift */,
 				D34215C77B2CE923B04AF0F5 /* TAKPacketCodecTests.swift */,
 				EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */,
+				D60F60F60F60F60F60F60F60 /* DrawingMoveTests.swift */,
 				8D3A7C46FD7B29D70D019C18 /* TAKServiceTests.swift */,
 								CF000005A000000000000001 /* ConfigProfileTests.swift */,
 				A99C500AFB1B09E55ABEDBBF /* Info.plist */,
@@ -2709,6 +2712,7 @@
 				1412A35EC6121F54838D6CCA /* ServerValidatorTests.swift in Sources */,
 				B4862ADC1DD9D4427C0DB504 /* TAKPacketCodecTests.swift in Sources */,
 				9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */,
+				D60D60D60D60D60D60D60D60 /* DrawingMoveTests.swift in Sources */,
 				4DF8129B40825E01D7F5BA79 /* TAKServiceTests.swift in Sources */,
 				F831B10A1D135F2E88925F52 /* PluginSDKTests.swift in Sources */,
 				C5C06A972D151475A44BC316 /* MeshCoreFrameCodecTests.swift in Sources */,

--- a/OmniTAKMobile/Features/Drawing/Models/DrawingModels.swift
+++ b/OmniTAKMobile/Features/Drawing/Models/DrawingModels.swift
@@ -95,7 +95,10 @@ struct MarkerDrawing: DrawingObject {
     var label: String  // User-editable label for marker
     var color: DrawingColor
     let createdAt: Date
-    let coordinate: CLLocationCoordinate2D
+    // `var` so a placed marker can be repositioned (issue #60 move/reposition
+    // follow-up). The reposition flow rigidly translates the coordinate and
+    // persists it through DrawingStore.updateMarker(_:).
+    var coordinate: CLLocationCoordinate2D
 
     var coordinates: [CLLocationCoordinate2D] {
         [coordinate]
@@ -210,7 +213,9 @@ struct CircleDrawing: DrawingObject {
     var label: String  // User-editable label
     var color: DrawingColor
     let createdAt: Date
-    let center: CLLocationCoordinate2D
+    // `var` so a placed circle can be repositioned (issue #60 move/reposition
+    // follow-up) — move translates the center; radius is unchanged.
+    var center: CLLocationCoordinate2D
     var radius: CLLocationDistance
 
     var coordinates: [CLLocationCoordinate2D] {
@@ -326,5 +331,130 @@ extension CLLocationCoordinate2D {
         let from = CLLocation(latitude: self.latitude, longitude: self.longitude)
         let to = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
         return from.distance(from: to)
+    }
+
+    /// Offset this coordinate by a degree delta. Used by the drawing
+    /// reposition flow to rigidly translate a whole shape by the same
+    /// (latΔ, lonΔ) the operator dragged. Longitude wraps across the
+    /// antimeridian; latitude is clamped to the poles.
+    func offset(latDelta: CLLocationDegrees, lonDelta: CLLocationDegrees) -> CLLocationCoordinate2D {
+        var lon = longitude + lonDelta
+        if lon > 180 { lon -= 360 } else if lon < -180 { lon += 360 }
+        let lat = max(-90, min(90, latitude + latDelta))
+        return CLLocationCoordinate2D(latitude: lat, longitude: lon)
+    }
+}
+
+// MARK: - Rigid Translate (issue #60 — move/reposition follow-up)
+
+// Each drawing type can be rigidly translated by a degree delta — every
+// vertex (or the circle center / marker point) shifts by the same offset,
+// so the shape's geometry is preserved exactly and only its position moves.
+// Mirrors Android's DrawingMoveOverlay rigid-translate behavior.
+
+extension MarkerDrawing {
+    func translated(latDelta: CLLocationDegrees, lonDelta: CLLocationDegrees) -> MarkerDrawing {
+        var copy = self
+        copy.coordinate = coordinate.offset(latDelta: latDelta, lonDelta: lonDelta)
+        return copy
+    }
+}
+
+extension LineDrawing {
+    func translated(latDelta: CLLocationDegrees, lonDelta: CLLocationDegrees) -> LineDrawing {
+        var copy = self
+        copy.coordinates = coordinates.map { $0.offset(latDelta: latDelta, lonDelta: lonDelta) }
+        return copy
+    }
+}
+
+extension PolygonDrawing {
+    func translated(latDelta: CLLocationDegrees, lonDelta: CLLocationDegrees) -> PolygonDrawing {
+        var copy = self
+        copy.coordinates = coordinates.map { $0.offset(latDelta: latDelta, lonDelta: lonDelta) }
+        return copy
+    }
+}
+
+extension CircleDrawing {
+    func translated(latDelta: CLLocationDegrees, lonDelta: CLLocationDegrees) -> CircleDrawing {
+        var copy = self
+        copy.center = center.offset(latDelta: latDelta, lonDelta: lonDelta)
+        return copy
+    }
+}
+
+// Restore-from-snapshot helpers — used by the move Cancel path to put a
+// shape's geometry back exactly as it was when Move began (see
+// DrawingMoveSession.originalCoordinates), independent of any clamping or
+// antimeridian wrap the drag applied.
+
+extension MarkerDrawing {
+    func with(coordinate: CLLocationCoordinate2D) -> MarkerDrawing {
+        var copy = self; copy.coordinate = coordinate; return copy
+    }
+}
+
+extension LineDrawing {
+    func with(coordinates: [CLLocationCoordinate2D]) -> LineDrawing {
+        var copy = self; copy.coordinates = coordinates; return copy
+    }
+}
+
+extension PolygonDrawing {
+    func with(coordinates: [CLLocationCoordinate2D]) -> PolygonDrawing {
+        var copy = self; copy.coordinates = coordinates; return copy
+    }
+}
+
+extension CircleDrawing {
+    func with(center: CLLocationCoordinate2D) -> CircleDrawing {
+        var copy = self; copy.center = center; return copy
+    }
+}
+
+// MARK: - Drawing Move Session (issue #60 — move/reposition follow-up)
+
+/// Drives "reposition mode" for a single placed drawing, shared by both the
+/// 2D Mapbox and 3D Cesium engines so the move UX is identical on each. The
+/// operator enters it from the drawing radial menu's **Move** action; while
+/// active the map camera is locked and a single-finger drag rigidly
+/// translates the whole shape. A committed move persists the new geometry to
+/// the DrawingStore; cancel restores the original.
+final class DrawingMoveSession: ObservableObject {
+    /// True while the operator is repositioning a shape — engines lock the
+    /// camera and capture the drag, and the move HUD shows.
+    @Published private(set) var isActive: Bool = false
+    /// The shape being moved.
+    @Published private(set) var drawingId: UUID?
+    @Published private(set) var drawingType: RadialMenuContext.DrawingType?
+    /// Human-readable name for the move HUD ("Move <label>").
+    @Published private(set) var label: String = ""
+
+    /// The shape's exact geometry at the moment Move was entered. Cancel
+    /// restores this verbatim rather than reversing accumulated drag deltas —
+    /// so a move that clamped at a pole or crossed the antimeridian still
+    /// returns the shape precisely to where it started. For a circle this is
+    /// `[center]`; for a marker `[point]`; for a line/polygon every vertex.
+    private(set) var originalCoordinates: [CLLocationCoordinate2D] = []
+
+    /// Begin repositioning the given drawing, snapshotting its starting
+    /// geometry so Cancel can restore it exactly.
+    func begin(id: UUID, type: RadialMenuContext.DrawingType, label: String,
+               originalCoordinates: [CLLocationCoordinate2D]) {
+        drawingId = id
+        drawingType = type
+        self.label = label
+        self.originalCoordinates = originalCoordinates
+        isActive = true
+    }
+
+    /// End the session (commit or after the caller has reverted). Clears state.
+    func end() {
+        isActive = false
+        drawingId = nil
+        drawingType = nil
+        label = ""
+        originalCoordinates = []
     }
 }

--- a/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
@@ -27,8 +27,10 @@ import UIKit
 /// struct so the SwiftUI shell can drive the radial menu and contact
 /// edit flows the same way the 2D Mapbox path does.
 struct CesiumMapEvent {
-    enum Kind { case tap, longpress, cameraChanged, lasso }
+    enum Kind { case tap, longpress, cameraChanged, lasso, move }
     let kind: Kind
+    /// For `.move`, this is the drag's CURRENT globe point; `moveFromCoordinate`
+    /// is the previous one, so the delta is (coordinate − moveFromCoordinate).
     let coordinate: CLLocationCoordinate2D
     let screenPoint: CGPoint
     /// Cesium Entity id that was picked under the cursor, or nil for an
@@ -42,6 +44,10 @@ struct CesiumMapEvent {
     let centerCoordinate: CLLocationCoordinate2D?
     /// Freehand lasso polygon (lat/lon vertices) for a `.lasso` event.
     let polygon: [CLLocationCoordinate2D]?
+    /// Drag origin for a `.move` event (issue #60) — the globe point under the
+    /// finger on the PREVIOUS frame. `coordinate` holds the current frame, so
+    /// the rigid-translate delta is (coordinate − moveFromCoordinate).
+    let moveFromCoordinate: CLLocationCoordinate2D?
 
     struct CameraState {
         let height: Double      // metres above ellipsoid
@@ -108,6 +114,11 @@ struct CesiumMainMap: UIViewRepresentable {
     /// When true (lasso mode), lock the globe camera and capture a freehand
     /// drag for multi-select; the polygon is posted back as a `.lasso` event.
     var lassoActive: Bool = false
+    /// Issue #60 (move/reposition follow-up) — when true (drawing reposition
+    /// mode), lock the globe camera and capture a single-finger drag; each
+    /// step is posted back as a `.move` event carrying the previous→current
+    /// globe coordinates so the native side rigidly translates the shape.
+    var drawingMoveActive: Bool = false
     /// Base imagery layer for the globe ("satellite" | "hybrid" | "standard").
     var baseLayer: String = "satellite"
     /// Issue #72 — north-up lock. When true the globe is pinned north-up
@@ -311,6 +322,14 @@ struct CesiumMainMap: UIViewRepresentable {
                 webView.evaluateJavaScript("window.OmniBridge.setLassoMode({on:\(lassoActive)});", completionHandler: nil)
             }
 
+            // Issue #60 (move/reposition follow-up) — reposition mode toggle.
+            // Same transition-only pattern as lasso; the bridge locks the
+            // camera and captures the single-finger drag, posting `move` events.
+            if drawingMoveActive != context.coordinator.moveWasActive {
+                context.coordinator.moveWasActive = drawingMoveActive
+                webView.evaluateJavaScript("window.OmniBridge.setMoveMode({on:\(drawingMoveActive)});", completionHandler: nil)
+            }
+
             // Base layer (imagery) — swap the globe's imagery on change so the
             // layers panel's Satellite/Hybrid/Standard work on 3D too.
             if baseLayer != context.coordinator.lastBaseLayer {
@@ -345,6 +364,8 @@ struct CesiumMainMap: UIViewRepresentable {
         var wasFollowing = false
         /// Whether lasso mode was active last render (to toggle on transition).
         var lassoWasActive = false
+        /// Issue #60 — whether drawing reposition mode was active last render.
+        var moveWasActive = false
         /// Last base imagery layer pushed to the globe (swap on change).
         var lastBaseLayer = "satellite"
         /// Observer token for toolbar zoom commands forwarded to the bridge.
@@ -422,6 +443,13 @@ struct CesiumMainMap: UIViewRepresentable {
                 // so the globe comes back north-up and stays locked.
                 if northLocked {
                     webView?.evaluateJavaScript("window.OmniBridge.setNorthLock({on:true});", completionHandler: nil)
+                }
+                // Issue #60 — if reposition mode was active before this bridge
+                // (re)initialized (e.g. a WebGL process restart mid-move),
+                // re-engage it so the globe camera comes back locked and the
+                // drag capture is restored, mirroring the north-lock re-apply.
+                if moveWasActive {
+                    webView?.evaluateJavaScript("window.OmniBridge.setMoveMode({on:true});", completionHandler: nil)
                 }
                 // Drain the latest snapshots the moment the HTML signals it
                 // has the OmniBridge alive — anything queued during page
@@ -501,6 +529,7 @@ struct CesiumMainMap: UIViewRepresentable {
                 case "longpress": kind = .longpress
                 case "camerachanged": kind = .cameraChanged
                 case "lasso": kind = .lasso
+                case "move": kind = .move
                 default: return
                 }
                 let cameraState: CesiumMapEvent.CameraState?
@@ -520,6 +549,12 @@ struct CesiumMainMap: UIViewRepresentable {
                 let polygon: [CLLocationCoordinate2D]? = payload.polygon?.compactMap {
                     $0.count == 2 ? CLLocationCoordinate2D(latitude: $0[0], longitude: $0[1]) : nil
                 }
+                let moveFrom: CLLocationCoordinate2D?
+                if let fLat = payload.fromLat, let fLon = payload.fromLon {
+                    moveFrom = CLLocationCoordinate2D(latitude: fLat, longitude: fLon)
+                } else {
+                    moveFrom = nil
+                }
                 let event = CesiumMapEvent(
                     kind: kind,
                     coordinate: CLLocationCoordinate2D(latitude: payload.lat, longitude: payload.lon),
@@ -527,7 +562,8 @@ struct CesiumMainMap: UIViewRepresentable {
                     entityUid: payload.uid,
                     camera: cameraState,
                     centerCoordinate: centerCoord,
-                    polygon: polygon
+                    polygon: polygon,
+                    moveFromCoordinate: moveFrom
                 )
                 parent.onMapEvent?(event)
             default:
@@ -558,6 +594,10 @@ struct CesiumMainMap: UIViewRepresentable {
             let centerLon: Double?
             // Freehand lasso polygon as [[lat,lon],...] for a 'lasso' event.
             let polygon: [[Double]]?
+            // Drag origin (previous frame globe point) for a 'move' event
+            // (issue #60). `lat`/`lon` carry the current frame.
+            let fromLat: Double?
+            let fromLon: Double?
         }
     }
 

--- a/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
@@ -25,6 +25,9 @@ struct ATAKMapView: View {
     @StateObject private var locationManager = LocationManager()
     @StateObject private var drawingStore: DrawingStore
     @StateObject private var drawingManager: DrawingToolsManager
+    // Issue #60 (move/reposition follow-up) — drives drawing reposition mode,
+    // shared by both engines so the move UX is identical on Mapbox + Cesium.
+    @StateObject private var drawingMoveSession = DrawingMoveSession()
     @StateObject private var radialMenuCoordinator = RadialMenuMapCoordinator()
     @ObservedObject private var chatManager = ChatManager.shared
     @StateObject private var trackRecordingService = TrackRecordingService()
@@ -250,6 +253,12 @@ struct ATAKMapView: View {
             mapStateManager: mapStateManager,
             measurementManager: measurementManager,
             lassoService: lassoService,
+            // Issue #60 (move/reposition follow-up) — reposition session +
+            // the rigid-translate callback the 2D drag gesture drives.
+            drawingMoveSession: drawingMoveSession,
+            onDrawingMoveDragged: { latDelta, lonDelta in
+                applyDrawingMoveDelta(latDelta: latDelta, lonDelta: lonDelta)
+            },
             onMapTap: handleMapTap,
             // Issue #72 — forward the north-lock flag so TacticalMapView
             // can disable rotation gestures when engaged.
@@ -1108,6 +1117,22 @@ struct ATAKMapView: View {
                 drawingManager.pendingRenameID = drawingId
             }
         }
+        // Issue #60 (move/reposition follow-up) — Move from the drawing radial
+        // menu enters reposition mode for the selected shape on both engines.
+        .onReceive(NotificationCenter.default.publisher(for: .radialMenuMoveDrawing)) { notification in
+            guard let drawingId = notification.userInfo?["drawingId"] as? UUID,
+                  let drawingType = notification.userInfo?["drawingType"] as? RadialMenuContext.DrawingType
+            else { return }
+            beginDrawingMove(id: drawingId, type: drawingType)
+        }
+        // Issue #60 — bail out of reposition mode if the operator toggles the
+        // map engine mid-move. The session is a @StateObject that survives the
+        // engine swap, and the outgoing engine unmounts without a chance to
+        // release its camera lock; cancelling restores the shape and clears the
+        // HUD so the incoming engine starts clean.
+        .onChange(of: mapEngineRaw) { _ in
+            if drawingMoveSession.isActive { cancelDrawingMove() }
+        }
         // Issue #65 — self-position puck tapped from either engine.
         .onReceive(NotificationCenter.default.publisher(for: .selfMarkerTapped)) { _ in
             showSelfPositionEdit = true
@@ -1148,6 +1173,10 @@ struct ATAKMapView: View {
                 // Lasso multi-select — lock the globe camera and capture the
                 // freehand drag when the operator is in lasso mode.
                 lassoActive: drawingManager.currentMode == .lasso && drawingManager.isDrawingActive,
+                // Issue #60 (move/reposition follow-up) — lock the globe camera
+                // and capture a single-finger drag while a shape is being
+                // repositioned, mirroring the lasso capture pattern.
+                drawingMoveActive: drawingMoveSession.isActive,
                 // Base layer (satellite / hybrid / standard) so the layers
                 // panel switches the globe's imagery, not just the 2D style.
                 baseLayer: activeMapLayer,
@@ -1296,8 +1325,68 @@ struct ATAKMapView: View {
         radialMenu
         gpsFollowButton
         lassoSelectionPill
+        drawingMoveOverlay
         measurementChrome
         routeNavigationChrome
+    }
+
+    /// Issue #60 (move/reposition follow-up) — reposition HUD. A top banner
+    /// (never a side panel — the full-screen map stays uncovered) telling the
+    /// operator to drag the shape, with Cancel / Done. Shown on whichever
+    /// engine is active; the drag itself is handled inside each engine.
+    @ViewBuilder
+    private var drawingMoveOverlay: some View {
+        if drawingMoveSession.isActive {
+            VStack {
+                HStack(spacing: 12) {
+                    Image(systemName: "arrow.up.and.down.and.arrow.left.and.right")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(Color(hex: "#FFFC00"))
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Moving \(drawingMoveSession.label)")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(.white)
+                            .lineLimit(1)
+                        Text("Drag the shape to reposition")
+                            .font(.system(size: 11))
+                            .foregroundColor(Color(hex: "#BBBBBB"))
+                    }
+                    Spacer(minLength: 8)
+                    Button {
+                        cancelDrawingMove()
+                    } label: {
+                        Text("Cancel")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 7)
+                            .background(Color.white.opacity(0.15))
+                            .clipShape(Capsule())
+                    }
+                    Button {
+                        commitDrawingMove()
+                    } label: {
+                        Text("Done")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(.black)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 7)
+                            .background(Color(hex: "#FFFC00"))
+                            .clipShape(Capsule())
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(.ultraThinMaterial)
+                .background(Color.black.opacity(0.55))
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .padding(.horizontal, 16)
+                .padding(.top, 110) // clear the top status strip / toolbars
+                Spacer()
+            }
+            .zIndex(2600) // above lasso pill (2000), below radial menu (3000)
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
     }
 
     /// Plugin SDK map-overlay seam. Renders every overlay a plugin registered
@@ -1807,6 +1896,16 @@ struct ATAKMapView: View {
                 drawingStore.polygons.map { LassoDrawing(id: $0.id, coordinates: $0.coordinates) } +
                 drawingStore.circles.map { LassoDrawing(id: $0.id, coordinates: [$0.center]) }
             _ = lassoService.endLasso(markers: markers, drawings: drawings)
+        case .move:
+            // Issue #60 (move/reposition follow-up) — the globe reported a drag
+            // step in reposition mode. Translate the active shape by the
+            // previous→current globe-coordinate delta. The 2D engine drives the
+            // same applyDrawingMoveDelta via its onDrawingMoveDragged closure.
+            guard let from = event.moveFromCoordinate else { return }
+            let latDelta = event.coordinate.latitude - from.latitude
+            let lonDelta = event.coordinate.longitude - from.longitude
+            guard latDelta != 0 || lonDelta != 0 else { return }
+            applyDrawingMoveDelta(latDelta: latDelta, lonDelta: lonDelta)
         }
     }
 
@@ -1865,6 +1964,115 @@ struct ATAKMapView: View {
             drawingType: match.type
         )
         return true
+    }
+
+    // MARK: - Drawing Move (issue #60 — move/reposition follow-up)
+
+    /// Enter reposition mode for the given drawing. Resolves its label for the
+    /// move HUD and arms the shared `DrawingMoveSession`; both engines watch
+    /// that session, lock the camera, and translate the shape on drag.
+    private func beginDrawingMove(id: UUID, type: RadialMenuContext.DrawingType) {
+        // Resolve the shape's label + starting geometry so Cancel can restore
+        // it exactly. Bail if it vanished between menu-open and Move.
+        let label: String
+        let original: [CLLocationCoordinate2D]
+        switch type {
+        case .marker:
+            guard let m = drawingStore.markers.first(where: { $0.id == id }) else { return }
+            label = m.label; original = [m.coordinate]
+        case .line:
+            guard let l = drawingStore.lines.first(where: { $0.id == id }) else { return }
+            label = l.label; original = l.coordinates
+        case .circle:
+            guard let c = drawingStore.circles.first(where: { $0.id == id }) else { return }
+            label = c.label; original = [c.center]
+        case .polygon:
+            guard let p = drawingStore.polygons.first(where: { $0.id == id }) else { return }
+            label = p.label; original = p.coordinates
+        }
+        // A drawing tool / measurement shouldn't be mid-flight while moving.
+        drawingManager.cancelDrawing()
+        drawingMoveSession.begin(id: id, type: type, label: label, originalCoordinates: original)
+    }
+
+    /// Apply an incremental drag delta to the shape under move — rigidly
+    /// translates every vertex (or the circle center / marker point) and
+    /// persists it live, so the shape tracks the finger on both engines.
+    /// Called by the per-engine drag handlers via the `.drawingMoveDragged`
+    /// notification so the geometry update lives in one place.
+    private func applyDrawingMoveDelta(latDelta: CLLocationDegrees, lonDelta: CLLocationDegrees) {
+        guard drawingMoveSession.isActive,
+              let id = drawingMoveSession.drawingId,
+              let type = drawingMoveSession.drawingType else { return }
+        // Normalize the longitude step to the shortest path so a single drag
+        // frame that straddles the ±180° antimeridian (e.g. 179.9 → -179.9,
+        // a raw −359.8° step) translates the shape smoothly across the seam
+        // instead of teleporting it nearly all the way around the globe.
+        var lon = lonDelta
+        if lon > 180 { lon -= 360 } else if lon < -180 { lon += 360 }
+        switch type {
+        case .marker:
+            guard let m = drawingStore.markers.first(where: { $0.id == id }) else {
+                cancelDrawingMove(); return
+            }
+            drawingStore.updateMarker(m.translated(latDelta: latDelta, lonDelta: lon))
+        case .line:
+            guard let l = drawingStore.lines.first(where: { $0.id == id }) else {
+                cancelDrawingMove(); return
+            }
+            drawingStore.updateLine(l.translated(latDelta: latDelta, lonDelta: lon))
+        case .circle:
+            guard let c = drawingStore.circles.first(where: { $0.id == id }) else {
+                cancelDrawingMove(); return
+            }
+            drawingStore.updateCircle(c.translated(latDelta: latDelta, lonDelta: lon))
+        case .polygon:
+            guard let p = drawingStore.polygons.first(where: { $0.id == id }) else {
+                cancelDrawingMove(); return
+            }
+            drawingStore.updatePolygon(p.translated(latDelta: latDelta, lonDelta: lon))
+        }
+    }
+
+    /// Commit the reposition. The live drags already persisted each step, so
+    /// this just closes the session (and saves once more for good measure).
+    private func commitDrawingMove() {
+        guard drawingMoveSession.isActive else { return }
+        drawingStore.saveAllDrawings()
+        drawingMoveSession.end()
+    }
+
+    /// Cancel the reposition — restore the shape's geometry to the snapshot
+    /// taken when Move began (exact, so a drag that clamped at a pole or crossed
+    /// the antimeridian still lands precisely back where it started), then close
+    /// the session.
+    private func cancelDrawingMove() {
+        guard drawingMoveSession.isActive,
+              let id = drawingMoveSession.drawingId,
+              let type = drawingMoveSession.drawingType else {
+            drawingMoveSession.end()
+            return
+        }
+        let original = drawingMoveSession.originalCoordinates
+        switch type {
+        case .marker:
+            if let m = drawingStore.markers.first(where: { $0.id == id }), let first = original.first {
+                drawingStore.updateMarker(m.with(coordinate: first))
+            }
+        case .line:
+            if let l = drawingStore.lines.first(where: { $0.id == id }), !original.isEmpty {
+                drawingStore.updateLine(l.with(coordinates: original))
+            }
+        case .circle:
+            if let c = drawingStore.circles.first(where: { $0.id == id }), let first = original.first {
+                drawingStore.updateCircle(c.with(center: first))
+            }
+        case .polygon:
+            if let p = drawingStore.polygons.first(where: { $0.id == id }), !original.isEmpty {
+                drawingStore.updatePolygon(p.with(coordinates: original))
+            }
+        }
+        drawingMoveSession.end()
     }
 
     // MARK: - Marker Actions

--- a/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
@@ -51,6 +51,11 @@ struct TacticalMapView: UIViewRepresentable {
     @ObservedObject var mapStateManager: MapStateManager
     @ObservedObject var measurementManager: MeasurementManager
     @ObservedObject var lassoService: LassoSelectionService = LassoSelectionService.shared
+    // Issue #60 (move/reposition follow-up) — reposition session shared with
+    // the parent + Cesium engine. When active, a single-finger drag rigidly
+    // translates the shape via `onDrawingMoveDragged` (the parent persists it).
+    @ObservedObject var drawingMoveSession: DrawingMoveSession
+    var onDrawingMoveDragged: ((CLLocationDegrees, CLLocationDegrees) -> Void)? = nil
     @ObservedObject var kmlVectorStore: KMLVectorOverlayStore = KMLVectorOverlayStore.shared
     @ObservedObject var rasterStore: RasterOverlayStore = RasterOverlayStore.shared
     @ObservedObject var mbtilesStore: MBTilesOverlayStore = MBTilesOverlayStore.shared
@@ -157,6 +162,21 @@ struct TacticalMapView: UIViewRepresentable {
         mapView.addGestureRecognizer(lasso)
         context.coordinator.lassoGesture = lasso
 
+        // Issue #60 (move/reposition follow-up) — drag-to-reposition gesture,
+        // gated on DrawingMoveSession.isActive. When inactive it no-ops; when
+        // active it captures the single-finger pan and rigidly translates the
+        // selected shape. `updateUIView` also disables map pan while moving so
+        // the camera stays put under the dragged shape.
+        let movePan = UIPanGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleMovePanGesture(_:))
+        )
+        movePan.maximumNumberOfTouches = 1
+        movePan.cancelsTouchesInView = true
+        movePan.delegate = context.coordinator
+        mapView.addGestureRecognizer(movePan)
+        context.coordinator.movePanGesture = movePan
+
         // Lifecycle hooks — load terrain + atmosphere on style load
         // so the operator gets immediate 3D depth without a settings
         // detour, and mirror camera changes back into the SwiftUI
@@ -217,6 +237,11 @@ struct TacticalMapView: UIViewRepresentable {
         // re-enable when released. The Mapbox API exposes this cleanly on
         // gestures.options without tearing down the whole gesture stack.
         mapView.gestures.options.rotateEnabled = !isNorthLocked
+
+        // Issue #60 (move/reposition follow-up) — while repositioning a shape,
+        // disable the map's own pan so the single-finger drag moves the SHAPE
+        // (via the movePan recognizer), not the camera. Restore pan on exit.
+        mapView.gestures.options.panEnabled = !drawingMoveSession.isActive
 
         // Region sync — only push to Mapbox if the SwiftUI region
         // diverges from the camera state by more than a hair. This is
@@ -418,6 +443,12 @@ struct TacticalMapView: UIViewRepresentable {
         weak var lassoGesture: UILongPressGestureRecognizer?
         private var lassoPathLayer: CAShapeLayer?
         private var lassoViewPoints: [CGPoint] = []
+
+        // Issue #60 (move/reposition follow-up) — drag-to-reposition recognizer
+        // and the last screen point we translated from (to derive per-frame
+        // lat/lon deltas as the finger moves).
+        weak var movePanGesture: UIPanGestureRecognizer?
+        private var lastMovePanPoint: CGPoint?
 
         // MIL-STD-2525 symbol cache — UIHostingController snapshots
         // keyed by (cotType, callsign) so we don't rebuild the image
@@ -1643,6 +1674,11 @@ struct TacticalMapView: UIViewRepresentable {
                 return parent.drawingManager.isDrawingActive &&
                        parent.drawingManager.currentMode == .lasso
             }
+            // Issue #60 — the reposition pan only begins while a move session is
+            // active; otherwise it stands down so normal pan/tap work.
+            if gestureRecognizer === movePanGesture {
+                return parent.drawingMoveSession.isActive
+            }
             return true
         }
 
@@ -1673,6 +1709,36 @@ struct TacticalMapView: UIViewRepresentable {
                 _ = service.endLasso(markers: markers, drawings: drawings)
                 removeLassoOverlay(on: mapView)
                 parent.drawingManager.cancelDrawing()
+            default:
+                break
+            }
+        }
+
+        // MARK: - Drawing move gesture (issue #60 — move/reposition follow-up)
+
+        /// Single-finger drag in reposition mode → rigidly translate the
+        /// selected shape. We convert the previous and current screen points to
+        /// map coordinates and forward the (latΔ, lonΔ) to the parent, which
+        /// updates the store live. Using a coordinate delta (rather than a fixed
+        /// metres-per-pixel) keeps the shape under the finger at any zoom/pitch.
+        @objc func handleMovePanGesture(_ gesture: UIPanGestureRecognizer) {
+            guard let mapView = mapView, parent.drawingMoveSession.isActive else { return }
+            let point = gesture.location(in: mapView)
+            switch gesture.state {
+            case .began:
+                lastMovePanPoint = point
+            case .changed:
+                guard let last = lastMovePanPoint else { lastMovePanPoint = point; return }
+                let fromCoord = mapView.mapboxMap.coordinate(for: last)
+                let toCoord = mapView.mapboxMap.coordinate(for: point)
+                let latDelta = toCoord.latitude - fromCoord.latitude
+                let lonDelta = toCoord.longitude - fromCoord.longitude
+                if latDelta != 0 || lonDelta != 0 {
+                    parent.onDrawingMoveDragged?(latDelta, lonDelta)
+                }
+                lastMovePanPoint = point
+            case .ended, .cancelled, .failed:
+                lastMovePanPoint = nil
             default:
                 break
             }

--- a/OmniTAKMobile/Resources/cesium_scene.html
+++ b/OmniTAKMobile/Resources/cesium_scene.html
@@ -28,7 +28,7 @@
 <script src="https://unpkg.com/milsymbol@2.2.0/dist/milsymbol.js"></script>
 <script>
   Cesium.Ion.defaultAccessToken='__CESIUM_ION_TOKEN__';
-  const _state={ready:false,viewer:null,entities:new Map(),drawings:new Map(),measurements:new Map(),tempDrawings:new Map(),trails:new Map(),leaders:new Map(),photoreal:null,billboardCache:new Map(),lasso:{enabled:false,dragging:false,pts:[],handler:null},northLocked:false,northSnapping:false};
+  const _state={ready:false,viewer:null,entities:new Map(),drawings:new Map(),measurements:new Map(),tempDrawings:new Map(),trails:new Map(),leaders:new Map(),photoreal:null,billboardCache:new Map(),lasso:{enabled:false,dragging:false,pts:[],handler:null},move:{enabled:false,dragging:false,last:null},northLocked:false,northSnapping:false};
   // Lasso multi-select drag (issue #16, 3D parity). Camera pan is
   // disabled while the lasso is enabled; the freehand path is drawn on
   // a 2D overlay canvas and the screen points are picked to lat/lon on
@@ -42,6 +42,18 @@
   function _lassoTouchStart(e){if(!_state.lasso.enabled)return;e.preventDefault();const t=e.touches[0];if(!t)return;_state.lasso.dragging=true;_state.lasso.pts=[[t.clientX,t.clientY]];_drawLasso();}
   function _lassoTouchMove(e){if(!_state.lasso.enabled||!_state.lasso.dragging)return;e.preventDefault();const t=e.touches[0];if(!t)return;_state.lasso.pts.push([t.clientX,t.clientY]);_drawLasso();}
   function _lassoTouchEnd(e){if(!_state.lasso.enabled||!_state.lasso.dragging)return;e.preventDefault();_finishLasso();}
+  // Issue #60 (move/reposition follow-up) — single-finger drag in reposition
+  // mode. We translate each touch position to a globe coordinate and post a
+  // 'move' event carrying the previous→current point so the native side rigidly
+  // translates the whole shape (parity with the 2D Mapbox move gesture). Camera
+  // inputs are disabled while move mode is on (see setMoveMode), so the globe
+  // stays put under the dragged shape.
+  function _moveCarto(t){const v=_state.viewer;if(!v)return null;return _cartoFor(v,new Cesium.Cartesian2(t.clientX,t.clientY));}
+  function _moveTouchStart(e){if(!_state.move.enabled)return;e.preventDefault();const t=e.touches[0];if(!t)return;const c=_moveCarto(t);if(!c)return;_state.move.dragging=true;_state.move.last=c;}
+  function _moveTouchMove(e){if(!_state.move.enabled||!_state.move.dragging)return;e.preventDefault();const t=e.touches[0];if(!t)return;const c=_moveCarto(t);if(!c||!_state.move.last)return;
+    _postMapEvent({event:'move',lat:c.lat,lon:c.lon,hae:c.hae,fromLat:_state.move.last.lat,fromLon:_state.move.last.lon});
+    _state.move.last=c;}
+  function _moveTouchEnd(e){if(!_state.move.enabled)return;e.preventDefault();_state.move.dragging=false;_state.move.last=null;}
   function _drawColor(hex,a){try{const c=Cesium.Color.fromCssColorString(hex||'#4ADE80');return a!==undefined?c.withAlpha(a):c}catch(e){return Cesium.Color.CYAN}}
   function _havDist(a,b){const R=6371000,lat1=a[1]*Math.PI/180,lat2=b[1]*Math.PI/180,dLat=(b[1]-a[1])*Math.PI/180,dLon=(b[0]-a[0])*Math.PI/180;const s=Math.sin(dLat/2)**2+Math.cos(lat1)*Math.cos(lat2)*Math.sin(dLon/2)**2;return 2*R*Math.asin(Math.min(1,Math.sqrt(s)))}
   function _fitViewport(){
@@ -272,6 +284,32 @@
         cv.removeEventListener('touchmove',_lassoTouchMove);
         cv.removeEventListener('touchend',_lassoTouchEnd);
         cv.removeEventListener('touchcancel',_lassoTouchEnd);
+        const ctx=cv.getContext('2d');ctx&&ctx.clearRect(0,0,cv.width,cv.height);
+        cv.style.display='none';cv.style.pointerEvents='none';
+        if(v)v.scene.screenSpaceCameraController.enableInputs=true;
+      }
+    },
+    // Issue #60 (move/reposition follow-up) — drawing reposition mode. While
+    // on, the same overlay canvas the lasso uses captures the single-finger
+    // drag (so the globe camera stays put) and camera inputs are disabled as a
+    // backup; each drag step posts a 'move' event with the previous→current
+    // globe point. No marquee is drawn — the shape itself tracks the finger via
+    // the native store update + setDrawings re-render.
+    setMoveMode(arg){const e=_parse(arg);const on=!!(e&&e.on);const v=_state.viewer;const cv=document.getElementById('lassoCanvas');if(!cv)return;
+      if(on){
+        _state.move.enabled=true;_state.move.dragging=false;_state.move.last=null;
+        cv.width=window.innerWidth;cv.height=window.innerHeight;cv.style.display='block';cv.style.pointerEvents='auto';
+        cv.addEventListener('touchstart',_moveTouchStart,{passive:false});
+        cv.addEventListener('touchmove',_moveTouchMove,{passive:false});
+        cv.addEventListener('touchend',_moveTouchEnd,{passive:false});
+        cv.addEventListener('touchcancel',_moveTouchEnd,{passive:false});
+        if(v)v.scene.screenSpaceCameraController.enableInputs=false;
+      }else{
+        _state.move.enabled=false;_state.move.dragging=false;_state.move.last=null;
+        cv.removeEventListener('touchstart',_moveTouchStart);
+        cv.removeEventListener('touchmove',_moveTouchMove);
+        cv.removeEventListener('touchend',_moveTouchEnd);
+        cv.removeEventListener('touchcancel',_moveTouchEnd);
         const ctx=cv.getContext('2d');ctx&&ctx.clearRect(0,0,cv.width,cv.height);
         cv.style.display='none';cv.style.pointerEvents='none';
         if(v)v.scene.screenSpaceCameraController.enableInputs=true;

--- a/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuActionExecutor.swift
+++ b/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuActionExecutor.swift
@@ -65,6 +65,8 @@ class RadialMenuActionExecutor {
             return executeDrawPolygon(context: context)
         case .editDrawing:
             return executeEditDrawing(context: context, services: services)
+        case .moveDrawing:
+            return executeMoveDrawing(context: context, services: services)
         case .deleteDrawing:
             return executeDeleteDrawing(context: context, services: services)
         case .copyCoordinates:
@@ -493,6 +495,24 @@ class RadialMenuActionExecutor {
         return true
     }
 
+    /// Issue #60 (move/reposition follow-up) — enter reposition mode for the
+    /// pressed drawing. The map view observes `radialMenuMoveDrawing`, starts a
+    /// DrawingMoveSession, and locks the camera while the operator drags the
+    /// whole shape to a new position. Works for shapes selected from either
+    /// engine (the radial Move action routes through here identically).
+    private static func executeMoveDrawing(context: RadialMenuContext, services: RadialMenuServices) -> Bool {
+        guard let drawingId = context.pressedDrawingId,
+              let drawingType = context.pressedDrawingType else { return false }
+
+        NotificationCenter.default.post(
+            name: .radialMenuMoveDrawing,
+            object: nil,
+            userInfo: ["drawingId": drawingId, "drawingType": drawingType]
+        )
+
+        return true
+    }
+
     private static func executeDeleteDrawing(context: RadialMenuContext, services: RadialMenuServices) -> Bool {
         guard let drawingId = context.pressedDrawingId,
               let drawingType = context.pressedDrawingType,
@@ -767,6 +787,9 @@ extension Notification.Name {
     /// showToolsMenu state so the 5x4 grid presents.
     static let showFullTools = Notification.Name("showFullTools")
     static let radialMenuEditDrawing = Notification.Name("radialMenuEditDrawing")
+    /// Issue #60 (move/reposition follow-up) — posted by the drawing radial
+    /// menu's Move action; the map view enters reposition mode for the shape.
+    static let radialMenuMoveDrawing = Notification.Name("radialMenuMoveDrawing")
     // App mode & layers
     static let radialMenuShowAppModePicker = Notification.Name("radialMenuShowAppModePicker")
     static let radialMenuShowLayers = Notification.Name("radialMenuShowLayers")

--- a/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuMapCoordinator.swift
+++ b/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuMapCoordinator.swift
@@ -336,8 +336,13 @@ class RadialMenuMapCoordinator: ObservableObject {
                 pressedDrawingType: drawingType,
                 contextType: .drawing
             )
-            // Use marker context menu for drawn shapes
-            menuConfiguration = RadialMenuPresets.markerContextMenu
+            // Drawing shapes get the drawing menu (Edit / Move / Delete / Info).
+            // The Move action (issue #60) is drawing-only, so it never shows for
+            // point markers. Fall back to the marker menu if, defensively, this
+            // .markerContext call carried no drawing id.
+            menuConfiguration = (drawingId != nil)
+                ? RadialMenuPresets.drawingContextMenu
+                : RadialMenuPresets.markerContextMenu
         }
 
         currentContext = context

--- a/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuModels.swift
+++ b/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuModels.swift
@@ -74,6 +74,7 @@ enum RadialMenuAction: Equatable {
     case drawCircle
     case drawPolygon
     case editDrawing
+    case moveDrawing
     case deleteDrawing
 
     // Utility Actions
@@ -129,6 +130,8 @@ enum RadialMenuAction: Equatable {
             return "drawPolygon"
         case .editDrawing:
             return "editDrawing"
+        case .moveDrawing:
+            return "moveDrawing"
         case .deleteDrawing:
             return "deleteDrawing"
         case .copyCoordinates:
@@ -407,7 +410,8 @@ extension RadialMenuAction {
         switch self {
         case .measure, .measureDistance, .measureArea, .measureBearing:
             return "measure"
-        case .openDrawingTools, .openDrawingsList, .drawLine, .drawCircle, .drawPolygon:
+        case .openDrawingTools, .openDrawingsList, .drawLine, .drawCircle, .drawPolygon,
+             .moveDrawing:
             return "drawing"
         case .navigate, .navigateToMarker, .createRoute:
             return "routes"

--- a/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuPresets.swift
+++ b/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuPresets.swift
@@ -124,6 +124,50 @@ enum RadialMenuPresets {
         )
     }
 
+    // MARK: - Drawing Context Menu
+
+    /// Menu for a placed drawing shape (line / polygon / circle / drawing
+    /// marker). Adds **Move** between Edit and Delete — the reposition action
+    /// from issue #60. Edit / Delete reuse the shared `.editMarker` /
+    /// `.deleteMarker` actions, which already dispatch to the drawing handlers
+    /// when the context is a drawing (see RadialMenuActionExecutor). This is
+    /// shown instead of `markerContextMenu` whenever a drawing is selected, so
+    /// Move never appears for point markers (which can't be repositioned here).
+    static var drawingContextMenu: RadialMenuConfiguration {
+        RadialMenuConfiguration(
+            items: [
+                RadialMenuItem(
+                    icon: "pencil.circle.fill",
+                    label: "Edit",
+                    color: atakOrange,
+                    action: .editMarker
+                ),
+                RadialMenuItem(
+                    icon: "arrow.up.and.down.and.arrow.left.and.right",
+                    label: "Move",
+                    color: atakBlue,
+                    action: .moveDrawing
+                ),
+                RadialMenuItem(
+                    icon: "trash.fill",
+                    label: "Delete",
+                    color: atakRed,
+                    action: .deleteMarker
+                ),
+                RadialMenuItem(
+                    icon: "info.circle.fill",
+                    label: "Info",
+                    color: atakGray,
+                    action: .getInfo
+                )
+            ],
+            radius: 120,
+            itemSize: 56,
+            hapticFeedback: true,
+            showLabels: true
+        )
+    }
+
     // MARK: - Quick Actions Menu
 
     /// Menu for quick tactical actions
@@ -528,6 +572,8 @@ struct RadialMenuPresetsPreviewWrapper: View {
             return "Draw Polygon"
         case .editDrawing:
             return "Edit Drawing"
+        case .moveDrawing:
+            return "Move Drawing"
         case .deleteDrawing:
             return "Delete Drawing"
         case .openLayers:

--- a/OmniTAKMobileTests/DrawingMoveTests.swift
+++ b/OmniTAKMobileTests/DrawingMoveTests.swift
@@ -1,0 +1,200 @@
+//
+//  DrawingMoveTests.swift
+//  OmniTAKMobileTests
+//
+//  Regression tests for the drawing move/reposition geometry (issue #60
+//  follow-up). The reposition flow rigidly translates a placed shape by a
+//  (latΔ, lonΔ) degree delta — every vertex (or the circle center / marker
+//  point) shifts by the same offset, so the shape's geometry is preserved and
+//  only its position changes. These tests pin that math + the move-session
+//  bookkeeping that Cancel relies on.
+//
+
+import XCTest
+import CoreLocation
+@testable import OmniTAK
+
+final class DrawingMoveTests: XCTestCase {
+
+    private let eps = 1e-9
+
+    // MARK: - Coordinate offset
+
+    func testCoordinateOffsetAddsDelta() {
+        let c = CLLocationCoordinate2D(latitude: 40.0, longitude: -73.0)
+        let moved = c.offset(latDelta: 0.5, lonDelta: -0.25)
+        XCTAssertEqual(moved.latitude, 40.5, accuracy: eps)
+        XCTAssertEqual(moved.longitude, -73.25, accuracy: eps)
+    }
+
+    func testCoordinateOffsetClampsLatitudeToPole() {
+        let c = CLLocationCoordinate2D(latitude: 89.9, longitude: 10.0)
+        let moved = c.offset(latDelta: 5.0, lonDelta: 0)
+        XCTAssertEqual(moved.latitude, 90.0, accuracy: eps, "latitude must clamp at the pole")
+    }
+
+    func testCoordinateOffsetWrapsLongitudeAcrossAntimeridian() {
+        let c = CLLocationCoordinate2D(latitude: 0, longitude: 179.0)
+        let moved = c.offset(latDelta: 0, lonDelta: 3.0)   // 182 → wraps to -178
+        XCTAssertEqual(moved.longitude, -178.0, accuracy: 1e-6)
+    }
+
+    // MARK: - Rigid translate per shape
+
+    func testLineTranslateShiftsEveryVertexEqually() {
+        let line = LineDrawing(
+            name: "L", color: .red,
+            coordinates: [
+                CLLocationCoordinate2D(latitude: 1, longitude: 1),
+                CLLocationCoordinate2D(latitude: 2, longitude: 3),
+                CLLocationCoordinate2D(latitude: -4, longitude: 5)
+            ]
+        )
+        let moved = line.translated(latDelta: 0.1, lonDelta: -0.2)
+        XCTAssertEqual(moved.coordinates.count, line.coordinates.count)
+        for (orig, new) in zip(line.coordinates, moved.coordinates) {
+            XCTAssertEqual(new.latitude - orig.latitude, 0.1, accuracy: 1e-9)
+            XCTAssertEqual(new.longitude - orig.longitude, -0.2, accuracy: 1e-9)
+        }
+        // Identity preserved — same shape, new position.
+        XCTAssertEqual(moved.id, line.id)
+    }
+
+    func testPolygonTranslatePreservesShape() {
+        let poly = PolygonDrawing(
+            name: "P", color: .green,
+            coordinates: [
+                CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                CLLocationCoordinate2D(latitude: 0, longitude: 1),
+                CLLocationCoordinate2D(latitude: 1, longitude: 1)
+            ]
+        )
+        let moved = poly.translated(latDelta: 10, lonDelta: 20)
+        // Pairwise edge vectors are unchanged → rigid translation, not a warp.
+        for i in 0..<poly.coordinates.count {
+            let j = (i + 1) % poly.coordinates.count
+            let origEdgeLat = poly.coordinates[j].latitude - poly.coordinates[i].latitude
+            let newEdgeLat = moved.coordinates[j].latitude - moved.coordinates[i].latitude
+            XCTAssertEqual(origEdgeLat, newEdgeLat, accuracy: 1e-9)
+        }
+        XCTAssertEqual(moved.id, poly.id)
+    }
+
+    func testCircleTranslateMovesCenterKeepsRadius() {
+        let circle = CircleDrawing(
+            name: "C", color: .blue,
+            center: CLLocationCoordinate2D(latitude: 5, longitude: 5),
+            radius: 250
+        )
+        let moved = circle.translated(latDelta: -1, lonDelta: 2)
+        XCTAssertEqual(moved.center.latitude, 4, accuracy: 1e-9)
+        XCTAssertEqual(moved.center.longitude, 7, accuracy: 1e-9)
+        XCTAssertEqual(moved.radius, 250, accuracy: 1e-9, "radius must be unchanged by a move")
+        XCTAssertEqual(moved.id, circle.id)
+    }
+
+    func testMarkerTranslateMovesPoint() {
+        let marker = MarkerDrawing(
+            name: "M", color: .yellow,
+            coordinate: CLLocationCoordinate2D(latitude: 12, longitude: -8)
+        )
+        let moved = marker.translated(latDelta: 0.3, lonDelta: 0.4)
+        XCTAssertEqual(moved.coordinate.latitude, 12.3, accuracy: 1e-9)
+        XCTAssertEqual(moved.coordinate.longitude, -7.6, accuracy: 1e-9)
+        XCTAssertEqual(moved.id, marker.id)
+    }
+
+    func testTranslateThenReverseRestoresOriginal() {
+        // The Cancel path applies the negated net delta; it must land back
+        // exactly on the starting geometry.
+        let line = LineDrawing(
+            name: "L", color: .orange,
+            coordinates: [
+                CLLocationCoordinate2D(latitude: 47.61, longitude: -122.33),
+                CLLocationCoordinate2D(latitude: 47.62, longitude: -122.31)
+            ]
+        )
+        let moved = line.translated(latDelta: 0.05, lonDelta: -0.07)
+        let restored = moved.translated(latDelta: -0.05, lonDelta: 0.07)
+        for (orig, back) in zip(line.coordinates, restored.coordinates) {
+            XCTAssertEqual(back.latitude, orig.latitude, accuracy: 1e-9)
+            XCTAssertEqual(back.longitude, orig.longitude, accuracy: 1e-9)
+        }
+    }
+
+    func testWithCoordinatesRestoresSnapshotExactly() {
+        // The Cancel path writes the snapshot back verbatim via `with(...)`.
+        let original = [
+            CLLocationCoordinate2D(latitude: 47.61, longitude: -122.33),
+            CLLocationCoordinate2D(latitude: 47.62, longitude: -122.31)
+        ]
+        let line = LineDrawing(name: "L", color: .red, coordinates: original)
+        // Simulate a drag that moved it, then restore from the snapshot.
+        let moved = line.translated(latDelta: 0.5, lonDelta: 0.5)
+        let restored = moved.with(coordinates: original)
+        for (orig, back) in zip(original, restored.coordinates) {
+            XCTAssertEqual(back.latitude, orig.latitude, accuracy: eps)
+            XCTAssertEqual(back.longitude, orig.longitude, accuracy: eps)
+        }
+        XCTAssertEqual(restored.id, line.id)
+    }
+
+    func testCircleWithCenterKeepsRadius() {
+        let circle = CircleDrawing(
+            name: "C", color: .blue,
+            center: CLLocationCoordinate2D(latitude: 5, longitude: 5),
+            radius: 250
+        )
+        let restored = circle.with(center: CLLocationCoordinate2D(latitude: 1, longitude: 2))
+        XCTAssertEqual(restored.center.latitude, 1, accuracy: eps)
+        XCTAssertEqual(restored.radius, 250, accuracy: eps)
+    }
+
+    func testSnapshotCancelRestoresExactlyEvenAfterPoleClamp() {
+        // A move that clamps at the pole loses information for a delta-reverse,
+        // but the snapshot-based Cancel restores the exact original anyway.
+        let line = LineDrawing(
+            name: "L", color: .red,
+            coordinates: [
+                CLLocationCoordinate2D(latitude: 89.9, longitude: 10),
+                CLLocationCoordinate2D(latitude: 88.0, longitude: 11)
+            ]
+        )
+        let original = line.coordinates
+        let moved = line.translated(latDelta: 5, lonDelta: 0) // first vertex clamps at 90
+        XCTAssertEqual(moved.coordinates[0].latitude, 90, accuracy: eps)
+        let restored = moved.with(coordinates: original)
+        for (orig, back) in zip(original, restored.coordinates) {
+            XCTAssertEqual(back.latitude, orig.latitude, accuracy: eps)
+            XCTAssertEqual(back.longitude, orig.longitude, accuracy: eps)
+        }
+    }
+
+    // MARK: - Move session bookkeeping
+
+    @MainActor
+    func testMoveSessionLifecycle() {
+        let session = DrawingMoveSession()
+        XCTAssertFalse(session.isActive)
+        XCTAssertTrue(session.originalCoordinates.isEmpty)
+
+        let id = UUID()
+        let original = [
+            CLLocationCoordinate2D(latitude: 1, longitude: 2),
+            CLLocationCoordinate2D(latitude: 3, longitude: 4)
+        ]
+        session.begin(id: id, type: .line, label: "Line 1", originalCoordinates: original)
+        XCTAssertTrue(session.isActive)
+        XCTAssertEqual(session.drawingId, id)
+        XCTAssertEqual(session.drawingType, .line)
+        XCTAssertEqual(session.label, "Line 1")
+        XCTAssertEqual(session.originalCoordinates.count, 2)
+        XCTAssertEqual(session.originalCoordinates[0].latitude, 1, accuracy: eps)
+
+        session.end()
+        XCTAssertFalse(session.isActive)
+        XCTAssertNil(session.drawingId)
+        XCTAssertNil(session.drawingType)
+        XCTAssertTrue(session.originalCoordinates.isEmpty)
+    }
+}


### PR DESCRIPTION
Completes the move/reposition follow-up from #60. PR #79 added select / edit (rename, recolor, radius) / delete for placed drawings on both the Mapbox 2D and Cesium 3D engines; the one remaining gap from #60 was **MOVE** — there was no way to reposition a shape once placed. Android already has a rigid-translate move; this brings the same to iOS, wired consistently into both engines.

## What's added

**Move action in the drawing radial menu**
- Placed drawings now open a dedicated context menu — **Edit / Move / Delete / Info** — instead of the marker menu. Move only ever appears for drawings (lines, polygons, circles, drawing markers), never for point markers, which can't be repositioned this way. Edit/Delete keep routing through the existing shared executor handlers, so that behavior is unchanged.

**Reposition mode (shared across engines)**
- A shared `DrawingMoveSession` drives the mode so the UX is identical on 2D and 3D. While active, the map camera is locked and a top banner shows `Moving <name>` with **Cancel / Done**. Per the full-screen-map rule it's a top overlay, never a side panel.
- **Rigid translate**: dragging shifts every vertex (or the circle center / marker point) by the same lat/lon delta — geometry is preserved, only the position changes — and persists live to the drawing store as you drag.
- **Cancel** restores the exact starting geometry from a snapshot captured when Move began (so a drag that clamped at a pole or crossed the antimeridian still lands precisely back where it started).

**2D Mapbox**
- A single-finger `UIPanGestureRecognizer` gated to move mode; the map's own pan is disabled while moving so the drag moves the shape, not the camera. Deltas come from screen→coordinate conversions, so the shape tracks the finger at any zoom/pitch.

**3D Cesium**
- A `setMoveMode` bridge that locks the globe camera and captures the single-finger drag on the overlay canvas (same pattern as the lasso), posting per-frame previous→current globe points that the native side rigidly translates. Re-applied on `omniBridgeReady` so a WebGL process restart mid-move re-locks the camera.

**Robustness**
- Per-frame longitude steps are normalized to the shortest path, so a drag across the ±180° antimeridian slides smoothly instead of teleporting the shape across the globe.
- The session is cancelled if the operator toggles the map engine mid-move, and bails cleanly if the shape is deleted elsewhere while a move is active.

## Vertex editing (stretch goal — intentionally not included)

The stretch goal was per-vertex editing (drag individual vertices; drag a radius handle for circles). I did **not** implement it, on purpose:

- The drawing model is geometry-only (`coordinates: [CLLocationCoordinate2D]`, circle `center` + `radius`), with no notion of a "selected vertex," and neither engine currently renders draggable per-vertex handles. Mapbox would need a new draggable annotation layer with hit-testing per vertex; Cesium would need per-vertex billboard handles plus drag capture and index mapping back through the bridge. That's a materially larger surface than MOVE and would touch the render path on both engines.
- Radius-resize already exists for circles via the Edit sheet (#79), which covers the most common reshape need.

Rather than half-implement it, this PR ships a solid, tested MOVE. Vertex/handle editing is a clean follow-up if there's demand — it slots onto the same `DrawingMoveSession` + bridge plumbing.

## Test plan

**Automated** (`OmniTAKMobileTests/DrawingMoveTests.swift`, 12 tests, green):
- Rigid translate per shape (line / polygon / circle / marker) shifts every point by the same delta and preserves shape + identity.
- Coordinate offset: pole clamp, antimeridian wrap.
- Snapshot restore (`with(...)`) returns the exact original geometry, including after a pole-clamping move.
- `DrawingMoveSession` lifecycle (begin / snapshot / end).

```
xcodebuild test -project OmniTAK.xcodeproj -scheme OmniTAKMobile \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  -only-testing:OmniTAKTests/DrawingMoveTests
# Executed 12 tests, with 0 failures — ** TEST SUCCEEDED **
```

**Build**: `xcodebuild ... build` green (Debug, iPhone 17 Pro sim).

**Needs a human device/visual pass** (build-verified, not yet exercised on-device):
- The actual drag feel on both engines — single-finger drag moving the shape with the camera locked, and the shape tracking the finger at various zooms/pitches (especially the Cesium globe-pick path at grazing angles).
- The move HUD banner layout over the live map on both engines.
- Confirming the radial **Move → drag → Done/Cancel** round-trip end to end, plus engine-toggle-mid-move cancelling cleanly.

Recommend the usual iOS+Android side-by-side screenshot once it's on a device.

Completes the move/reposition follow-up from #60 (already closed — no auto-close keyword used).