### PR TITLE
fix(lasso): select lines the lasso crosses/overlaps, not just centroid-inside

### DIFF
--- a/OmniTAK.xcodeproj/project.pbxproj
+++ b/OmniTAK.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		9D1E97C264F38CD9B0017F5A /* DrawingPropertiesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8A6851F2CB32B82BEA2817 /* DrawingPropertiesView.swift */; };
 		9D4DD979FA07D0D920CA576A /* MEDEVACRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C046FF14CC38A998A3C9C57A /* MEDEVACRequestView.swift */; };
 		9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */; };
+		AAFEACD1A8F44A9C9BB80BC0 /* LassoLineSelectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EADC4D789C2402E9D406268 /* LassoLineSelectTests.swift */; };
 		9F360AA41C05B15FC6B71F75 /* EchelonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D5A42ABFBE8EF268B187D8 /* EchelonModels.swift */; };
 		9F4D964068E0E91862AEE361 /* KMLOverlaysPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619B6C2A0B1A1C5237648ED5 /* KMLOverlaysPanel.swift */; };
 		9F975E18CC49BBAC535F8A0B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D9B49FD9370499A376CCF227 /* Localizable.strings */; };
@@ -764,6 +765,7 @@
 		EA4A86523E550E87AC1EE8A4 /* SALUTEReportView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SALUTEReportView.swift; path = OmniTAKMobile/Features/Military/Views/SALUTEReportView.swift; sourceTree = "<group>"; };
 		EA65513B351E6E8D864A945A /* RemoteIdAppBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RemoteIdAppBridge.swift; path = OmniTAKMobile/Features/RemoteID/Services/RemoteIdAppBridge.swift; sourceTree = "<group>"; };
 		EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoordinateFormatTests.swift; path = OmniTAKMobileTests/CoordinateFormatTests.swift; sourceTree = "<group>"; };
+		8EADC4D789C2402E9D406268 /* LassoLineSelectTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LassoLineSelectTests.swift; path = OmniTAKMobileTests/LassoLineSelectTests.swift; sourceTree = "<group>"; };
 		EC5FB4399952EB25310628E4 /* RangeBearingService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RangeBearingService.swift; path = OmniTAKMobile/Features/Measurement/Services/RangeBearingService.swift; sourceTree = "<group>"; };
 		ED51505084DDA26949BB854D /* EchelonHierarchyView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EchelonHierarchyView.swift; path = OmniTAKMobile/Features/Teams/Views/EchelonHierarchyView.swift; sourceTree = "<group>"; };
 		EE2FC006021B8F5CE7D6554F /* SFGPEVC----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPEVC----.svg"; sourceTree = "<group>"; };
@@ -1061,6 +1063,7 @@
 				0C8884B98F8B309825903DC6 /* ServerValidatorTests.swift */,
 				D34215C77B2CE923B04AF0F5 /* TAKPacketCodecTests.swift */,
 				EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */,
+				8EADC4D789C2402E9D406268 /* LassoLineSelectTests.swift */,
 				8D3A7C46FD7B29D70D019C18 /* TAKServiceTests.swift */,
 								CF000005A000000000000001 /* ConfigProfileTests.swift */,
 				A99C500AFB1B09E55ABEDBBF /* Info.plist */,
@@ -2709,6 +2712,7 @@
 				1412A35EC6121F54838D6CCA /* ServerValidatorTests.swift in Sources */,
 				B4862ADC1DD9D4427C0DB504 /* TAKPacketCodecTests.swift in Sources */,
 				9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */,
+				AAFEACD1A8F44A9C9BB80BC0 /* LassoLineSelectTests.swift in Sources */,
 				4DF8129B40825E01D7F5BA79 /* TAKServiceTests.swift in Sources */,
 				F831B10A1D135F2E88925F52 /* PluginSDKTests.swift in Sources */,
 				C5C06A972D151475A44BC316 /* MeshCoreFrameCodecTests.swift in Sources */,

--- a/OmniTAKMobile/Features/Drawing/Services/LassoSelectionService.swift
+++ b/OmniTAKMobile/Features/Drawing/Services/LassoSelectionService.swift
@@ -183,14 +183,69 @@ public final class LassoSelectionService: ObservableObject {
         }
 
         var drawingIDs: Set<UUID> = []
-        for d in drawings {
-            guard let centroid = centroid(of: d.coordinates) else { continue }
-            if pointInPolygon(centroid, polygon: polygon) {
-                drawingIDs.insert(d.id)
-            }
+        for d in drawings where drawingHit(d.coordinates, polygon: polygon) {
+            drawingIDs.insert(d.id)
         }
 
         return SelectionContext(markerIDs: markerIDs, drawingIDs: drawingIDs)
+    }
+
+    /// Does a drawing count as lassoed? A drawing is hit if it is
+    /// contained, overlapped, OR crossed by the lasso — not just when
+    /// its centroid lands inside. The old centroid-only test silently
+    /// missed lines: a line drawn across the map was never selected when
+    /// the lasso enclosed only part of it, looped around one endpoint, or
+    /// sliced through it without containing the midpoint. Select if ANY
+    /// vertex is inside, the centroid is inside, or ANY of the drawing's
+    /// segments intersects a lasso edge.
+    public static func drawingHit(
+        _ coords: [CLLocationCoordinate2D],
+        polygon: [CLLocationCoordinate2D]
+    ) -> Bool {
+        guard !coords.isEmpty, polygon.count >= 3 else { return false }
+        // 1. Any vertex inside the lasso (catches a partially-enclosed line
+        //    and any shape with a corner inside the squiggle).
+        for c in coords where pointInPolygon(c, polygon: polygon) { return true }
+        // 2. Centroid inside (a large shape lassoed around its middle with
+        //    no vertex inside).
+        if let mid = centroid(of: coords), pointInPolygon(mid, polygon: polygon) {
+            return true
+        }
+        // 3. Any drawing segment crosses any lasso edge (a line the lasso
+        //    slices through without containing an endpoint, or a shape that
+        //    only partially overlaps the lasso).
+        guard coords.count >= 2 else { return false }
+        let n = polygon.count
+        for i in 0..<(coords.count - 1) {
+            let a = coords[i], b = coords[i + 1]
+            for j in 0..<n where segmentsIntersect(a, b, polygon[j], polygon[(j + 1) % n]) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Proper segment intersection via orientation signs (general
+    /// crossing case; collinear-overlap isn't needed for lasso
+    /// hit-testing). Planar lon=x / lat=y, same convention as
+    /// `pointInPolygon`.
+    public static func segmentsIntersect(
+        _ p1: CLLocationCoordinate2D, _ p2: CLLocationCoordinate2D,
+        _ p3: CLLocationCoordinate2D, _ p4: CLLocationCoordinate2D
+    ) -> Bool {
+        func orient(
+            _ a: CLLocationCoordinate2D,
+            _ b: CLLocationCoordinate2D,
+            _ c: CLLocationCoordinate2D
+        ) -> Double {
+            (b.longitude - a.longitude) * (c.latitude - a.latitude) -
+                (b.latitude - a.latitude) * (c.longitude - a.longitude)
+        }
+        let d1 = orient(p3, p4, p1)
+        let d2 = orient(p3, p4, p2)
+        let d3 = orient(p1, p2, p3)
+        let d4 = orient(p1, p2, p4)
+        return ((d1 > 0) != (d2 > 0)) && ((d3 > 0) != (d4 > 0))
     }
 
     /// Ray-casting point-in-polygon (Franklin's PNPOLY). Treats

--- a/OmniTAKMobileTests/LassoLineSelectTests.swift
+++ b/OmniTAKMobileTests/LassoLineSelectTests.swift
@@ -1,0 +1,69 @@
+//
+//  LassoLineSelectTests.swift
+//  OmniTAKMobileTests
+//
+//  Regression coverage for lasso-selecting line/polygon drawings. The
+//  original selection test only included a drawing when its arithmetic
+//  centroid fell inside the lasso, which silently missed lines: a line
+//  drawn across the map was never selected unless the lasso happened to
+//  enclose its midpoint. These tests pin the "contained, overlapped, or
+//  crossed" behavior.
+//
+
+import XCTest
+import CoreLocation
+@testable import OmniTAK
+
+final class LassoLineSelectTests: XCTestCase {
+
+    private func c(_ lat: Double, _ lon: Double) -> CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: lat, longitude: lon)
+    }
+
+    /// THE BUG: a long horizontal line, lassoed by a small box over its
+    /// left portion. Both endpoints (lon ±10) are outside the box and the
+    /// centroid (0,0) is outside too — the old centroid-only test missed
+    /// it. The line still crosses the box, so it must be selected now.
+    func testLineCrossingLassoSelectedEvenWhenCentroidOutside() {
+        let line = LassoDrawing(id: UUID(), coordinates: [c(0, -10), c(0, 10)])
+        let box = [c(-1, -8), c(1, -8), c(1, -6), c(-1, -6)] // lat[-1,1] lon[-8,-6]
+        let result = LassoSelectionService.performLasso(polygon: box, markers: [], drawings: [line])
+        XCTAssertTrue(
+            result.drawingIDs.contains(line.id),
+            "A line crossing the lasso must be selected even when its centroid is outside")
+    }
+
+    /// Regression guard: the original centroid-inside heuristic still works.
+    func testLineSelectedWhenCentroidInside() {
+        let line = LassoDrawing(id: UUID(), coordinates: [c(0, -2), c(0, 2)])
+        let box = [c(-1, -3), c(1, -3), c(1, 3), c(-1, 3)]
+        let result = LassoSelectionService.performLasso(polygon: box, markers: [], drawings: [line])
+        XCTAssertTrue(result.drawingIDs.contains(line.id))
+    }
+
+    /// A single endpoint inside the lasso is enough to select.
+    func testLineSelectedWhenEndpointInside() {
+        let line = LassoDrawing(id: UUID(), coordinates: [c(0, -10), c(0, 10)])
+        let box = [c(-1, 8), c(1, 8), c(1, 12), c(-1, 12)] // contains the +10 end
+        let result = LassoSelectionService.performLasso(polygon: box, markers: [], drawings: [line])
+        XCTAssertTrue(result.drawingIDs.contains(line.id))
+    }
+
+    /// No false positives: a line well clear of the lasso is not selected.
+    func testLineFarFromLassoNotSelected() {
+        let line = LassoDrawing(id: UUID(), coordinates: [c(0, -10), c(0, -8)])
+        let box = [c(20, 20), c(21, 20), c(21, 21), c(20, 21)]
+        let result = LassoSelectionService.performLasso(polygon: box, markers: [], drawings: [line])
+        XCTAssertFalse(result.drawingIDs.contains(line.id))
+    }
+
+    /// Direct check of the segment-intersection primitive.
+    func testSegmentsIntersect() {
+        // A vertical and a horizontal segment that cross at the origin.
+        XCTAssertTrue(LassoSelectionService.segmentsIntersect(
+            c(-1, 0), c(1, 0), c(0, -1), c(0, 1)))
+        // Two far-apart segments do not cross.
+        XCTAssertFalse(LassoSelectionService.segmentsIntersect(
+            c(0, -1), c(0, 1), c(5, 5), c(6, 6)))
+    }
+}


### PR DESCRIPTION
## Problem
Reported in the field (iOS): the lasso select tool would not select a **line** drawn on the map.

## Root cause
`LassoSelectionService.performLasso` included a drawing only when its arithmetic **centroid** landed inside the lasso polygon. For a line, lassoing across it, around one endpoint, or over part of it leaves the centroid outside — so it was never selected.

## Fix
A drawing is now selected if it is **contained, overlapped, or crossed**:
1. any vertex inside the lasso, OR
2. the centroid inside (prior behavior), OR
3. any drawing segment intersects any lasso edge (new `segmentsIntersect` primitive).

## Tests
`LassoLineSelectTests` (5, all passing): the crossed-but-centroid-outside case (the reported bug), endpoint-inside, centroid-inside regression, a no-false-positive case, and the segment-intersection primitive. Wired into the OmniTAKTests target.

Build green; tests green.