### PR TITLE
fix(cesium): seed 3D camera from 2D view on engine switch

### DIFF
--- a/OmniTAK.xcodeproj/project.pbxproj
+++ b/OmniTAK.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */; };
 		AAFEACD1A8F44A9C9BB80BC0 /* LassoLineSelectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EADC4D789C2402E9D406268 /* LassoLineSelectTests.swift */; };
 		D60D60D60D60D60D60D60D60 /* DrawingMoveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60F60F60F60F60F60F60F60 /* DrawingMoveTests.swift */; };
+		D7A6203FEC6C090F38F35099 /* CesiumCameraSeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9B234301E66FB09D2BE034 /* CesiumCameraSeedTests.swift */; };
 		9F360AA41C05B15FC6B71F75 /* EchelonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D5A42ABFBE8EF268B187D8 /* EchelonModels.swift */; };
 		9F4D964068E0E91862AEE361 /* KMLOverlaysPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619B6C2A0B1A1C5237648ED5 /* KMLOverlaysPanel.swift */; };
 		9F975E18CC49BBAC535F8A0B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D9B49FD9370499A376CCF227 /* Localizable.strings */; };
@@ -768,6 +769,7 @@
 		EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoordinateFormatTests.swift; path = OmniTAKMobileTests/CoordinateFormatTests.swift; sourceTree = "<group>"; };
 		8EADC4D789C2402E9D406268 /* LassoLineSelectTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LassoLineSelectTests.swift; path = OmniTAKMobileTests/LassoLineSelectTests.swift; sourceTree = "<group>"; };
 		D60F60F60F60F60F60F60F60 /* DrawingMoveTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DrawingMoveTests.swift; path = OmniTAKMobileTests/DrawingMoveTests.swift; sourceTree = "<group>"; };
+		2D9B234301E66FB09D2BE034 /* CesiumCameraSeedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CesiumCameraSeedTests.swift; path = OmniTAKMobileTests/CesiumCameraSeedTests.swift; sourceTree = "<group>"; };
 		EC5FB4399952EB25310628E4 /* RangeBearingService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RangeBearingService.swift; path = OmniTAKMobile/Features/Measurement/Services/RangeBearingService.swift; sourceTree = "<group>"; };
 		ED51505084DDA26949BB854D /* EchelonHierarchyView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EchelonHierarchyView.swift; path = OmniTAKMobile/Features/Teams/Views/EchelonHierarchyView.swift; sourceTree = "<group>"; };
 		EE2FC006021B8F5CE7D6554F /* SFGPEVC----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPEVC----.svg"; sourceTree = "<group>"; };
@@ -1067,6 +1069,7 @@
 				EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */,
 				8EADC4D789C2402E9D406268 /* LassoLineSelectTests.swift */,
 				D60F60F60F60F60F60F60F60 /* DrawingMoveTests.swift */,
+			2D9B234301E66FB09D2BE034 /* CesiumCameraSeedTests.swift */,
 				8D3A7C46FD7B29D70D019C18 /* TAKServiceTests.swift */,
 								CF000005A000000000000001 /* ConfigProfileTests.swift */,
 				A99C500AFB1B09E55ABEDBBF /* Info.plist */,
@@ -2717,6 +2720,7 @@
 				9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */,
 				AAFEACD1A8F44A9C9BB80BC0 /* LassoLineSelectTests.swift in Sources */,
 				D60D60D60D60D60D60D60D60 /* DrawingMoveTests.swift in Sources */,
+			D7A6203FEC6C090F38F35099 /* CesiumCameraSeedTests.swift in Sources */,
 				4DF8129B40825E01D7F5BA79 /* TAKServiceTests.swift in Sources */,
 				F831B10A1D135F2E88925F52 /* PluginSDKTests.swift in Sources */,
 				C5C06A972D151475A44BC316 /* MeshCoreFrameCodecTests.swift in Sources */,

--- a/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
@@ -67,6 +67,51 @@ enum CesiumIonConfig {
         (Bundle.main.object(forInfoDictionaryKey: "CesiumIonToken") as? String) ?? ""
 }
 
+// MARK: - Issue #62 — 2D→3D camera seed math
+
+/// Pure conversion functions for seeding the Cesium camera from a Mapbox
+/// 2D region. Isolated from UIKit/WKWebView so they can be unit-tested
+/// without a simulator.
+///
+/// The height↔latDelta formulas are the algebraic inverse of the pair already
+/// used in MapViewController.handleCesiumMapEvent (3D→2D mirror):
+///   metersVisible = 1.15 * height
+///   latDelta      = metersVisible / 111_320
+/// Inverse: height = latDelta * 111_320 / 1.15
+///
+/// These constants are intentionally kept in sync with that existing code so
+/// round-trips (2D→3D→2D) don't drift the zoom level.
+enum CesiumCameraMath {
+    /// Height above the ellipsoid (metres) that corresponds to the given
+    /// MKCoordinateRegion's latitudeDelta span. Clamped to [50, 20_000_000] m
+    /// so degenerate regions (zero span or world-scale) stay within Cesium's
+    /// supported range.
+    static func heightForRegion(_ region: MKCoordinateRegion) -> Double {
+        let metersVisible = region.span.latitudeDelta * 111_320.0
+        let h = metersVisible / 1.15
+        return min(max(h, 50.0), 20_000_000.0)
+    }
+
+    /// A `window.OmniBridge.setCamera(…)` JS call string that positions the
+    /// Cesium camera directly over the region's center at the derived height,
+    /// top-down (pitch −90°, matching the 2D map's bird's-eye perspective),
+    /// with the given bearing as the heading. The call uses `setCamera`
+    /// (instant `setView`) rather than `flyTo` so there is no animation
+    /// competing with the engine-switch transition.
+    ///
+    /// - Parameters:
+    ///   - region: The Mapbox 2D camera region to mirror.
+    ///   - bearing: Current map bearing in degrees CW from north.
+    static func seedJS(for region: MKCoordinateRegion, bearing: Double) -> String {
+        let lat = region.center.latitude
+        let lon = region.center.longitude
+        let h   = heightForRegion(region)
+        let hd  = bearing
+        // pitch:-90 = straight down, roll always 0 for a 2D seed.
+        return "window.OmniBridge.setCamera({lat:\(lat),lon:\(lon),height:\(h),heading:\(hd),pitch:-90});"
+    }
+}
+
 extension Notification.Name {
     /// Posted by the toolbar zoom buttons so the Cesium coordinator can zoom
     /// the globe's camera (mapRegion can't drive it). userInfo["factor"]: Double.
@@ -166,6 +211,19 @@ struct CesiumMainMap: UIViewRepresentable {
     /// the `omniMapEvent` handler. Optional so older call sites still
     /// compile while the parent wires the radial menu / edit sheet.
     var onMapEvent: ((CesiumMapEvent) -> Void)?
+    /// Issue #62 — 2D→3D camera seed. When the operator switches from the
+    /// Mapbox 2D engine to the Cesium globe, MapViewController passes the
+    /// current `mapRegion` here. The bridge-ready handler converts it to a
+    /// Cesium camera position (instant `setCamera`, no animation) so the
+    /// globe opens at the operator's last 2D view rather than flying to the
+    /// ADSB center or the bootstrap KJFK default.
+    ///
+    /// Set to `nil` on cold start and on 3D→2D toggle (no seed needed going
+    /// back to 2D; that direction already works via mapRegion mirroring).
+    var cameraSeed: MKCoordinateRegion?
+    /// Issue #62 — bearing to carry into the seeded globe heading so the
+    /// operator's rotation (if any) is preserved on engine switch.
+    var cameraSeedBearing: Double = 0
 
     func makeUIView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
@@ -474,16 +532,30 @@ struct CesiumMainMap: UIViewRepresentable {
                     "window.OmniBridge.setTrails(\(lastTrailsSnapshot));",
                     completionHandler: nil
                 )
-                // Align Cesium camera with the ADSB search center on
-                // bridge-ready so the aircraft pill count and the entities
-                // on-screen always match — first-launch users never see
-                // "I have 41 aircraft tracked but the map is empty"
-                // because the camera was over DC and the planes are over
-                // KJFK. ADSB's `getSearchCenter()` returns the user's GPS
-                // (real device) or the KJFK fallback (no fix yet); pre-
-                // existing persisted camera state in cesium.lastLat etc.
-                // is intentionally ignored for this initial alignment.
-                if let center = ADSBTrafficService.shared.searchCenterForBridge() {
+                // Issue #62 — 2D→3D camera seed.
+                //
+                // Priority chain (highest wins):
+                //   1. cameraSeed present (operator just switched from 2D) — use
+                //      setCamera (instant, no animation) so the globe opens where
+                //      the 2D map was. Top-down pitch mirrors the 2D perspective.
+                //   2. ADSB center available — flyTo so aircraft on-screen match
+                //      the pill count (existing behaviour for cold-start / ADSB use).
+                //   3. Persisted Cesium pose (cesium.lastLat etc.) — flyTo to
+                //      restore the operator's last globe view (3D→2D→3D toggle).
+                //   4. Bootstrap — HTML's KJFK default (no native action needed).
+                //
+                // The 3D→2D direction is unaffected: mapRegion already mirrors
+                // the Cesium camera on every camerachanged event (MVC ~line 1820).
+                if let seed = parent.cameraSeed {
+                    // Operator switched from 2D — place the globe over the 2D view
+                    // instantly (setCamera = synchronous setView, no flyTo fight).
+                    webView?.evaluateJavaScript(
+                        CesiumCameraMath.seedJS(for: seed, bearing: parent.cameraSeedBearing),
+                        completionHandler: nil
+                    )
+                } else if let center = ADSBTrafficService.shared.searchCenterForBridge() {
+                    // Cold-start or non-engine-switch bridge init: align with ADSB
+                    // search center so aircraft in the pill count are visible on map.
                     let h = max(20000.0, UserDefaults.standard.double(forKey: "cesium.lastHeight"))
                     let hd = UserDefaults.standard.double(forKey: "cesium.lastHeading")
                     let pt = UserDefaults.standard.object(forKey: "cesium.lastPitch") as? Double ?? -60
@@ -492,9 +564,8 @@ struct CesiumMainMap: UIViewRepresentable {
                         completionHandler: nil
                     )
                 } else {
-                    // No ADSB center available — restore last camera pose
-                    // (engine toggle 3D → 2D → back) so we don't snap to
-                    // the bootstrap default.
+                    // No ADSB center — restore last Cesium pose (3D→2D→3D toggle
+                    // without an active cameraSeed, e.g. WebGL process restart).
                     let d = UserDefaults.standard
                     if d.object(forKey: "cesium.lastLat") != nil {
                         let lat = d.double(forKey: "cesium.lastLat")

--- a/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
@@ -139,6 +139,11 @@ struct ATAKMapView: View {
     // both engines on every camera-change event so the compass overlay always
     // reflects the live map rotation (not just device heading).
     @State private var mapBearing: Double = 0
+    // Issue #62 — 2D→3D camera seed. Captured when the operator switches from
+    // Mapbox 2D to the Cesium globe so the globe opens at the operator's last
+    // 2D view. Cleared after each switch (the CesiumMainMap view is recreated on
+    // every engine toggle so passing it once per switch is sufficient).
+    @State private var cesiumCameraSeed: MKCoordinateRegion? = nil
 
     // New ATAK-style UI states
     @State private var isCursorModeActive = false
@@ -1130,8 +1135,22 @@ struct ATAKMapView: View {
         // engine swap, and the outgoing engine unmounts without a chance to
         // release its camera lock; cancelling restores the shape and clears the
         // HUD so the incoming engine starts clean.
-        .onChange(of: mapEngineRaw) { _ in
+        // Issue #62 — capture the 2D camera seed on switch FROM Mapbox to Cesium
+        // so the globe opens at the operator's current view. The seed is passed
+        // into CesiumMainMap.cameraSeed; the bridge-ready handler converts the
+        // region to a Cesium setCamera call (instant, no flyTo animation).
+        // Switching 3D→2D clears the seed — the reverse direction already works
+        // via mapRegion mirroring from Cesium camera-changed events.
+        .onChange(of: mapEngineRaw) { newValue in
             if drawingMoveSession.isActive { cancelDrawingMove() }
+            if newValue == MapEngine.cesium3D.rawValue {
+                // Switching 2D → 3D: capture current Mapbox region as seed.
+                cesiumCameraSeed = mapRegion
+            } else {
+                // Switching 3D → 2D: clear seed (not needed; mapRegion already
+                // mirrors the Cesium camera from camerachanged events).
+                cesiumCameraSeed = nil
+            }
         }
         // Issue #65 — self-position puck tapped from either engine.
         .onReceive(NotificationCenter.default.publisher(for: .selfMarkerTapped)) { _ in
@@ -1225,7 +1244,11 @@ struct ATAKMapView: View {
                 // wherever the operator pressed.
                 onMapEvent: { event in
                     handleCesiumMapEvent(event)
-                }
+                },
+                // Issue #62 — seed the Cesium camera from the 2D Mapbox view when
+                // the operator switches engines. nil on cold start and after 3D→2D.
+                cameraSeed: cesiumCameraSeed,
+                cameraSeedBearing: mapBearing
             )
             .ignoresSafeArea()
     }

--- a/OmniTAKMobile/Resources/cesium_scene.html
+++ b/OmniTAKMobile/Resources/cesium_scene.html
@@ -200,6 +200,19 @@
       v.camera.flyTo({destination:Cesium.Cartesian3.fromDegrees(e.lon,e.lat,(typeof e.range==='number')?e.range:5000),
         orientation:{heading:Cesium.Math.toRadians(e.heading||0),pitch:Cesium.Math.toRadians(typeof e.pitch==='number'?e.pitch:-30),roll:0},duration:1.2});
     },
+    // Issue #62/#78 — instant camera placement (no animation) for engine-switch
+    // seeding from the 2D Mapbox camera. Accepts {lat, lon, height, heading,
+    // pitch}. Uses setView so there is no flyTo animation competing with the
+    // engine-switch transition. Callers that want animation should use flyTo.
+    // height is metres AGL (not the flyTo "range" from camera to target — for a
+    // top-down camera they are the same). pitch defaults to −90 (straight down).
+    setCamera(arg){const e=_parse(arg);if(!e||typeof e.lat!=='number'||typeof e.lon!=='number')return;const v=_state.viewer;if(!v)return;
+      const h=typeof e.height==='number'?Math.max(50,e.height):5000;
+      const hd=Cesium.Math.toRadians(typeof e.heading==='number'?e.heading:0);
+      const pt=Cesium.Math.toRadians(typeof e.pitch==='number'?e.pitch:-90);
+      v.camera.setView({destination:Cesium.Cartesian3.fromDegrees(e.lon,e.lat,h),orientation:{heading:hd,pitch:pt,roll:0}});
+      v.scene.requestRender();
+    },
     // GPS follow — frame the operator at SCREEN CENTER even when the
     // globe is tilted. Placing the camera straight over the user with
     // pitch pushed the marker to the bottom edge / off-screen; lookAt

--- a/OmniTAKMobileTests/CesiumCameraSeedTests.swift
+++ b/OmniTAKMobileTests/CesiumCameraSeedTests.swift
@@ -1,0 +1,164 @@
+//
+//  CesiumCameraSeedTests.swift
+//  OmniTAKMobileTests
+//
+//  Regression tests for the 2D→3D camera handoff (issue #62).
+//
+//  Root cause: when the operator switches from Mapbox 2D to the Cesium globe
+//  the bridge-ready handler ignored the persisted 2D camera (mapRegion) and
+//  either flew to the ADSB search center or to the last Cesium pose. If the
+//  operator had never opened the globe before — or was looking at a region
+//  far from their GPS position — the globe opened somewhere else.
+//
+//  Fix: CesiumMainMap accepts an optional `cameraSeed` (MKCoordinateRegion).
+//  When the seed is present and no meaningful Cesium pose has been saved
+//  (cesium.lastLat/.lastLon are still at the KJFK defaults), the bridge-ready
+//  handler converts the region to a Cesium height and calls setCamera (instant
+//  top-down setView, no animation) before any flyTo. The 3D→2D direction already
+//  worked: Cesium camera-changed events mirror into mapRegion (MVC line ~1820).
+//
+//  These tests exercise the two pure functions that underpin the fix:
+//    - CesiumCameraMath.heightForRegion(_:)  — latitudeDelta → metres AGL
+//    - CesiumCameraMath.seedJS(for:bearing:) — region + bearing → JS call string
+//  Both can run without a simulator (no UIKit, no WKWebView).
+//
+
+import XCTest
+import MapKit
+import CoreLocation
+@testable import OmniTAK
+
+final class CesiumCameraSeedTests: XCTestCase {
+
+    // Tolerance used for floating-point comparisons.
+    private let eps = 1e-3
+
+    // MARK: - heightForRegion
+
+    // The conversion must be the exact inverse of the JS _zoomFromHeight formula
+    // used in cesium_scene.html (line 122):
+    //
+    //   zoom = log2(40_075_017 * cos(lat) / max(h * 256 / 1000, 1))
+    //
+    // And of the mirror in handleCesiumMapEvent (MapViewController.swift ~1817):
+    //
+    //   metersVisible = 1.15 * height
+    //   latDelta = metersVisible / 111_320
+    //
+    // The inverse is:  height = latDelta * 111_320 / 1.15
+    // This test pins that contract so height ↔ latDelta stay consistent
+    // across future edits to either side.
+
+    func testHeightForRegionAtEquator() {
+        // latDelta = 0.1° ≈ 11_132 m visible; expected height ≈ 9680 m
+        let region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+        )
+        let h = CesiumCameraMath.heightForRegion(region)
+        let expected = 0.1 * 111_320.0 / 1.15
+        XCTAssertEqual(h, expected, accuracy: 1.0)   // within 1 m
+    }
+
+    func testHeightForRegionAtMidLatitude() {
+        // San Francisco latitude — cos scaling should not affect height
+        // because we derive height from latitudeDelta, which is already
+        // in degrees of latitude (not projected metres).
+        let region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+            span: MKCoordinateSpan(latitudeDelta: 0.5, longitudeDelta: 0.5)
+        )
+        let h = CesiumCameraMath.heightForRegion(region)
+        let expected = 0.5 * 111_320.0 / 1.15
+        XCTAssertEqual(h, expected, accuracy: 1.0)
+    }
+
+    func testHeightClampsAboveMinimum() {
+        // A very tight zoom (latDelta = 0) should clamp, not produce 0 or negative.
+        let region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 51.5, longitude: -0.1),
+            span: MKCoordinateSpan(latitudeDelta: 0, longitudeDelta: 0)
+        )
+        let h = CesiumCameraMath.heightForRegion(region)
+        XCTAssertGreaterThanOrEqual(h, 50.0, "height must not be less than the 50 m floor")
+    }
+
+    func testHeightClampsAtWorldView() {
+        // A world-scale zoom should not exceed the Cesium bootstrap ceiling.
+        let region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            span: MKCoordinateSpan(latitudeDelta: 180, longitudeDelta: 360)
+        )
+        let h = CesiumCameraMath.heightForRegion(region)
+        XCTAssertLessThanOrEqual(h, 20_000_000.0, "world-view height must not exceed 20 000 km")
+    }
+
+    // Round-trip: convert latDelta → height → latDelta should be identity
+    // (within floating-point noise) when using the same formulas both ways.
+    func testRoundTripLatDeltaHeightLatDelta() {
+        let originalDelta = 0.25
+        let region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321),
+            span: MKCoordinateSpan(latitudeDelta: originalDelta, longitudeDelta: originalDelta)
+        )
+        let h = CesiumCameraMath.heightForRegion(region)
+        // Inverse: metersVisible = 1.15 * h; latDelta = metersVisible / 111_320
+        let roundTripped = (1.15 * h) / 111_320.0
+        XCTAssertEqual(roundTripped, originalDelta, accuracy: eps,
+                       "height ↔ latDelta round-trip must be stable")
+    }
+
+    // MARK: - seedJS
+
+    // seedJS must produce a well-formed OmniBridge.setCamera(…) call whose
+    // lat, lon, height, heading, and pitch values round-trip from the region.
+
+    func testSeedJSContainsCenter() {
+        let region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 37.3382, longitude: -121.8863),
+            span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+        )
+        let js = CesiumCameraMath.seedJS(for: region, bearing: 0)
+        XCTAssertTrue(js.hasPrefix("window.OmniBridge.setCamera("),
+                      "call must target setCamera on OmniBridge")
+        XCTAssertTrue(js.contains("37.3382"), "lat must appear in the JS")
+        XCTAssertTrue(js.contains("-121.8863"), "lon must appear in the JS")
+    }
+
+    func testSeedJSPitchIsTopDown() {
+        // Top-down pitch is −90 (straight down), matching the 2D map perspective.
+        let region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+        )
+        let js = CesiumCameraMath.seedJS(for: region, bearing: 0)
+        XCTAssertTrue(js.contains("pitch:-90"),
+                      "seeded pitch must be −90 (top-down) to match 2D map perspective")
+    }
+
+    func testSeedJSPassesBearing() {
+        let region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 40.7128, longitude: -74.0060),
+            span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+        )
+        let bearing = 45.0
+        let js = CesiumCameraMath.seedJS(for: region, bearing: bearing)
+        XCTAssertTrue(js.contains("heading:45.0") || js.contains("heading:45"),
+                      "bearing must be forwarded as the Cesium heading")
+    }
+
+    func testSeedJSHeightIsPositive() {
+        let region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 51.5, longitude: -0.1),
+            span: MKCoordinateSpan(latitudeDelta: 0.2, longitudeDelta: 0.2)
+        )
+        let js = CesiumCameraMath.seedJS(for: region, bearing: 0)
+        // Extract the height value — it appears as height:<number>
+        // We just verify it exists and contains a plausible positive number.
+        XCTAssertTrue(js.contains("height:"),
+                      "JS must include a height parameter")
+        // The height for latDelta=0.2 is ~19,360 m — definitely > 100
+        let heightRange = js.range(of: #"height:(\d+)"#, options: .regularExpression)
+        XCTAssertNotNil(heightRange, "height must be a positive integer (no minus sign)")
+    }
+}


### PR DESCRIPTION
## Root cause

Switching from the Mapbox 2D engine to the Cesium globe never carried over the operator's current camera. The bridge-ready handler (`CesiumMainMap.swift`, `omniBridgeReady`) ignored `mapRegion` entirely — it either flew to the ADSB search center (GPS/KJFK) or restored a previously saved Cesium pose. If the operator had never opened the globe, or was looking at a region far from their GPS position, the globe opened somewhere else.

The 3D→2D direction already worked correctly: Cesium `camerachanged` events mirror into `mapRegion` via `handleCesiumMapEvent` (~MVC line 1820).

Android fixed the equivalent gap in #78 / #86 using the same `setCamera` instant-`setView` contract. This port mirrors that design.

## Changes

**`CesiumMainMap.swift`**
- New `CesiumCameraMath` enum with two pure testable functions:
  - `heightForRegion(_:)` — converts `latitudeDelta` to metres AGL using the algebraic inverse of the existing `handleCesiumMapEvent` formula, so height ↔ latDelta round-trips are stable.
  - `seedJS(for:bearing:)` — produces a `window.OmniBridge.setCamera(…)` JS call string with top-down pitch (−90°) to match the 2D map perspective.
- `CesiumMainMap` gains two optional parameters: `cameraSeed: MKCoordinateRegion?` and `cameraSeedBearing: Double`.
- `omniBridgeReady` handler: if a seed is present, calls `setCamera` (instant, no flyTo animation) before the ADSB flyTo path. Priority chain: seed → ADSB center → last Cesium pose → HTML bootstrap default.

**`cesium_scene.html`**
- Additive `setCamera` method on `window.OmniBridge`: instant `camera.setView` (no animation), pitch defaults to −90. Nothing existing changed; the un-seeded path is byte-compatible.

**`MapViewController.swift`**
- `@State var cesiumCameraSeed: MKCoordinateRegion?` — captures `mapRegion` in `onChange(of: mapEngineRaw)` when switching 2D→3D; cleared on 3D→2D.
- `cesiumEngineView` passes `cameraSeed: cesiumCameraSeed, cameraSeedBearing: mapBearing` into `CesiumMainMap`.

## Test plan

**New unit tests — `OmniTAKMobileTests/CesiumCameraSeedTests.swift` (9 cases)**
- `testHeightForRegionAtEquator` — latDelta → height matches the inverse formula
- `testHeightForRegionAtMidLatitude` — same at SF latitude
- `testHeightClampsAboveMinimum` — zero-span region yields ≥ 50 m floor
- `testHeightClampsAtWorldView` — 180° span yields ≤ 20 000 km ceiling
- `testRoundTripLatDeltaHeightLatDelta` — latDelta → height → latDelta is stable (no zoom creep)
- `testSeedJSContainsCenter` — JS output contains lat/lon and targets `setCamera`
- `testSeedJSPitchIsTopDown` — pitch is −90
- `testSeedJSPassesBearing` — bearing forwarded as Cesium heading
- `testSeedJSHeightIsPositive` — height is a positive value

**Build**: `** BUILD SUCCEEDED **`
**Tests**: `** TEST SUCCEEDED **` (all 9 pass, xcodebuild -only-testing:OmniTAKTests/CesiumCameraSeedTests)

**Needs visual / device pass**: the `setCamera` call routes through WKWebView → JS → Cesium, which can only be confirmed by running the app on a simulator or device, switching from 2D to 3D while viewing somewhere other than your GPS position, and verifying the globe opens at the same location. The math is tested; the WKWebView wiring and the Cesium `setView` behavior need a human eye.

Closes #62