### PR TITLE
Drawing vertex editing: drag individual vertices / circle radius on both engines

### DIFF
--- a/OmniTAK.xcodeproj/project.pbxproj
+++ b/OmniTAK.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */; };
 		AAFEACD1A8F44A9C9BB80BC0 /* LassoLineSelectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EADC4D789C2402E9D406268 /* LassoLineSelectTests.swift */; };
 		D60D60D60D60D60D60D60D60 /* DrawingMoveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60F60F60F60F60F60F60F60 /* DrawingMoveTests.swift */; };
+		0B3D84FD5B2E90470EDD3D15 /* DrawingVertexEditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C7049C308AC89CA5B0B79F /* DrawingVertexEditTests.swift */; };
 		D7A6203FEC6C090F38F35099 /* CesiumCameraSeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9B234301E66FB09D2BE034 /* CesiumCameraSeedTests.swift */; };
 		9F360AA41C05B15FC6B71F75 /* EchelonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D5A42ABFBE8EF268B187D8 /* EchelonModels.swift */; };
 		9F4D964068E0E91862AEE361 /* KMLOverlaysPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619B6C2A0B1A1C5237648ED5 /* KMLOverlaysPanel.swift */; };
@@ -769,6 +770,7 @@
 		EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoordinateFormatTests.swift; path = OmniTAKMobileTests/CoordinateFormatTests.swift; sourceTree = "<group>"; };
 		8EADC4D789C2402E9D406268 /* LassoLineSelectTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LassoLineSelectTests.swift; path = OmniTAKMobileTests/LassoLineSelectTests.swift; sourceTree = "<group>"; };
 		D60F60F60F60F60F60F60F60 /* DrawingMoveTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DrawingMoveTests.swift; path = OmniTAKMobileTests/DrawingMoveTests.swift; sourceTree = "<group>"; };
+		64C7049C308AC89CA5B0B79F /* DrawingVertexEditTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DrawingVertexEditTests.swift; path = OmniTAKMobileTests/DrawingVertexEditTests.swift; sourceTree = "<group>"; };
 		2D9B234301E66FB09D2BE034 /* CesiumCameraSeedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CesiumCameraSeedTests.swift; path = OmniTAKMobileTests/CesiumCameraSeedTests.swift; sourceTree = "<group>"; };
 		EC5FB4399952EB25310628E4 /* RangeBearingService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RangeBearingService.swift; path = OmniTAKMobile/Features/Measurement/Services/RangeBearingService.swift; sourceTree = "<group>"; };
 		ED51505084DDA26949BB854D /* EchelonHierarchyView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EchelonHierarchyView.swift; path = OmniTAKMobile/Features/Teams/Views/EchelonHierarchyView.swift; sourceTree = "<group>"; };
@@ -1069,6 +1071,7 @@
 				EC23A9361C594E04810857B2 /* CoordinateFormatTests.swift */,
 				8EADC4D789C2402E9D406268 /* LassoLineSelectTests.swift */,
 				D60F60F60F60F60F60F60F60 /* DrawingMoveTests.swift */,
+				64C7049C308AC89CA5B0B79F /* DrawingVertexEditTests.swift */,
 			2D9B234301E66FB09D2BE034 /* CesiumCameraSeedTests.swift */,
 				8D3A7C46FD7B29D70D019C18 /* TAKServiceTests.swift */,
 								CF000005A000000000000001 /* ConfigProfileTests.swift */,
@@ -2720,6 +2723,7 @@
 				9D878C1238B9495B89C1D5D8 /* CoordinateFormatTests.swift in Sources */,
 				AAFEACD1A8F44A9C9BB80BC0 /* LassoLineSelectTests.swift in Sources */,
 				D60D60D60D60D60D60D60D60 /* DrawingMoveTests.swift in Sources */,
+				0B3D84FD5B2E90470EDD3D15 /* DrawingVertexEditTests.swift in Sources */,
 			D7A6203FEC6C090F38F35099 /* CesiumCameraSeedTests.swift in Sources */,
 				4DF8129B40825E01D7F5BA79 /* TAKServiceTests.swift in Sources */,
 				F831B10A1D135F2E88925F52 /* PluginSDKTests.swift in Sources */,

--- a/OmniTAKMobile/Features/Drawing/Models/DrawingModels.swift
+++ b/OmniTAKMobile/Features/Drawing/Models/DrawingModels.swift
@@ -458,3 +458,134 @@ final class DrawingMoveSession: ObservableObject {
         originalCoordinates = []
     }
 }
+
+// MARK: - Vertex Edit (issue #84 — drag individual vertices / circle radius)
+
+// Where the move flow (#81) rigidly translates the WHOLE shape, vertex editing
+// moves a single point. Each helper replaces one vertex (line / polygon) or
+// resizes a circle from a dragged edge point, preserving identity. The math is
+// engine-agnostic so the 2D Mapbox and 3D Cesium drag paths share it exactly.
+
+extension LineDrawing {
+    /// Return a copy with vertex `index` replaced by `coordinate`. Out-of-range
+    /// indices are a no-op (defensive against a vertex deleted mid-drag).
+    func replacingVertex(at index: Int, with coordinate: CLLocationCoordinate2D) -> LineDrawing {
+        guard coordinates.indices.contains(index) else { return self }
+        var copy = self
+        copy.coordinates[index] = coordinate
+        return copy
+    }
+}
+
+extension PolygonDrawing {
+    /// Return a copy with vertex `index` replaced by `coordinate`. Out-of-range
+    /// indices are a no-op (defensive against a vertex deleted mid-drag).
+    func replacingVertex(at index: Int, with coordinate: CLLocationCoordinate2D) -> PolygonDrawing {
+        guard coordinates.indices.contains(index) else { return self }
+        var copy = self
+        copy.coordinates[index] = coordinate
+        return copy
+    }
+}
+
+extension CircleDrawing {
+    /// Smallest radius a resize drag can collapse a circle to, so dragging the
+    /// handle onto the center never yields a zero/degenerate shape.
+    static let minRadiusMeters: CLLocationDistance = 1
+
+    /// The draggable radius handle — a point exactly `radius` metres due-east
+    /// of the center. The engines render this as a second handle so the
+    /// operator can drag it to resize the circle, and Cancel snapshots it so
+    /// the original radius can be restored exactly.
+    var radiusHandleCoordinate: CLLocationCoordinate2D {
+        // Metres-per-degree-longitude shrinks with latitude (cos φ). Guard the
+        // poles where it collapses to zero by falling back to a tiny epsilon so
+        // the handle stays a hair east instead of landing on the center.
+        let metersPerDegLon = 111_320.0 * cos(center.latitude * .pi / 180)
+        let lonDelta = metersPerDegLon > 1 ? radius / metersPerDegLon : 0.0001
+        return CLLocationCoordinate2D(latitude: center.latitude,
+                                      longitude: center.longitude + lonDelta)
+    }
+
+    /// Return a copy resized so its radius is the distance from the (unchanged)
+    /// center to the dragged edge point, clamped to a positive floor.
+    func resized(toEdgePoint edge: CLLocationCoordinate2D) -> CircleDrawing {
+        var copy = self
+        copy.radius = max(Self.minRadiusMeters, center.distance(to: edge))
+        return copy
+    }
+}
+
+/// Nearest-vertex hit test, shared by both engines so picking a vertex behaves
+/// identically on 2D and 3D. Returns the index of the vertex closest to a
+/// touch coordinate, or nil if none is within `withinMeters`.
+enum DrawingVertexHitTest {
+    static func nearestVertexIndex(
+        in vertices: [CLLocationCoordinate2D],
+        to touch: CLLocationCoordinate2D,
+        withinMeters: CLLocationDistance
+    ) -> Int? {
+        var best: (index: Int, distance: CLLocationDistance)?
+        for (i, v) in vertices.enumerated() {
+            let d = v.distance(to: touch)
+            if d <= withinMeters, best == nil || d < best!.distance {
+                best = (i, d)
+            }
+        }
+        return best?.index
+    }
+}
+
+// MARK: - Drawing Vertex Edit Session (issue #84)
+
+/// Drives "edit vertices" mode for a single placed drawing, shared by both the
+/// 2D Mapbox and 3D Cesium engines so the UX is identical. Entered from the
+/// drawing radial menu's **Edit Vertices** action, alongside Move/Edit/Delete.
+/// While active the map camera is locked, draggable vertex handles render on
+/// the shape, and a single-finger drag moves the grabbed vertex (or a circle's
+/// radius handle). A committed edit persists the new geometry to the
+/// DrawingStore; Cancel restores the snapshot taken when the mode was entered.
+///
+/// Mirrors `DrawingMoveSession`, with one addition: `activeVertexIndex` tracks
+/// which handle the current drag grabbed (set on touch-down, cleared on
+/// release) so successive drag frames move the same point.
+final class DrawingVertexEditSession: ObservableObject {
+    @Published private(set) var isActive: Bool = false
+    @Published private(set) var drawingId: UUID?
+    @Published private(set) var drawingType: RadialMenuContext.DrawingType?
+    @Published private(set) var label: String = ""
+
+    /// The shape's exact geometry at the moment edit mode was entered, so
+    /// Cancel restores it verbatim. For a line/polygon this is every vertex;
+    /// for a circle it's `[center, radiusHandle]` (the two draggable handles).
+    private(set) var originalCoordinates: [CLLocationCoordinate2D] = []
+
+    /// The vertex index the in-flight drag grabbed, or nil between drags. For a
+    /// circle, index 0 = center (whole-circle move is out of scope here, so the
+    /// center isn't draggable), index 1 = radius handle.
+    @Published private(set) var activeVertexIndex: Int?
+
+    func begin(id: UUID, type: RadialMenuContext.DrawingType, label: String,
+               originalCoordinates: [CLLocationCoordinate2D]) {
+        drawingId = id
+        drawingType = type
+        self.label = label
+        self.originalCoordinates = originalCoordinates
+        activeVertexIndex = nil
+        isActive = true
+    }
+
+    /// Grab (or release, with nil) the vertex a drag is moving.
+    func setActiveVertex(_ index: Int?) {
+        activeVertexIndex = index
+    }
+
+    func end() {
+        isActive = false
+        drawingId = nil
+        drawingType = nil
+        label = ""
+        originalCoordinates = []
+        activeVertexIndex = nil
+    }
+}

--- a/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/CesiumMainMap.swift
@@ -27,10 +27,17 @@ import UIKit
 /// struct so the SwiftUI shell can drive the radial menu and contact
 /// edit flows the same way the 2D Mapbox path does.
 struct CesiumMapEvent {
-    enum Kind { case tap, longpress, cameraChanged, lasso, move }
+    enum Kind {
+        case tap, longpress, cameraChanged, lasso, move
+        // Issue #84 — vertex edit. `vertexDragStart` carries the touched globe
+        // point (native hit-tests the grabbed handle); `vertexDrag` carries the
+        // dragged point (native moves that vertex); `vertexDragEnd` releases it.
+        case vertexDragStart, vertexDrag, vertexDragEnd
+    }
     let kind: Kind
     /// For `.move`, this is the drag's CURRENT globe point; `moveFromCoordinate`
     /// is the previous one, so the delta is (coordinate − moveFromCoordinate).
+    /// For `.vertexDragStart` / `.vertexDrag` it's the touched / dragged point.
     let coordinate: CLLocationCoordinate2D
     let screenPoint: CGPoint
     /// Cesium Entity id that was picked under the cursor, or nil for an
@@ -164,6 +171,15 @@ struct CesiumMainMap: UIViewRepresentable {
     /// step is posted back as a `.move` event carrying the previous→current
     /// globe coordinates so the native side rigidly translates the shape.
     var drawingMoveActive: Bool = false
+    /// Issue #84 — when true (vertex-edit mode), lock the globe camera, render
+    /// `vertexEditHandles` as draggable points, and capture a single-finger
+    /// drag posted back as `.vertexDragStart` / `.vertexDrag` / `.vertexDragEnd`
+    /// events (native hit-tests + moves the grabbed vertex).
+    var drawingVertexEditActive: Bool = false
+    /// Issue #84 — the current draggable vertex handles for the shape under
+    /// edit (lat/lon). Rendered as bright points on the globe; updated live as
+    /// the operator drags so a handle tracks the finger.
+    var vertexEditHandles: [CLLocationCoordinate2D] = []
     /// Base imagery layer for the globe ("satellite" | "hybrid" | "standard").
     var baseLayer: String = "satellite"
     /// Issue #72 — north-up lock. When true the globe is pinned north-up
@@ -388,6 +404,22 @@ struct CesiumMainMap: UIViewRepresentable {
                 webView.evaluateJavaScript("window.OmniBridge.setMoveMode({on:\(drawingMoveActive)});", completionHandler: nil)
             }
 
+            // Issue #84 — vertex-edit mode toggle. Same transition-only pattern;
+            // the bridge locks the camera and captures the single-finger drag,
+            // posting vertexdragstart/vertexdrag/vertexdragend events.
+            if drawingVertexEditActive != context.coordinator.vertexEditWasActive {
+                context.coordinator.vertexEditWasActive = drawingVertexEditActive
+                webView.evaluateJavaScript("window.OmniBridge.setVertexEditMode({on:\(drawingVertexEditActive)});", completionHandler: nil)
+            }
+            // Push the draggable handle set whenever it changes (and while
+            // editing) so a handle tracks the finger as the operator drags.
+            if drawingVertexEditActive {
+                let handlesJSON = buildVertexHandlesJSON()
+                if context.coordinator.shouldPublishBridge(call: "setVertexHandles", signature: handlesJSON.hashValue) {
+                    webView.evaluateJavaScript("window.OmniBridge.setVertexHandles(\(handlesJSON));", completionHandler: nil)
+                }
+            }
+
             // Base layer (imagery) — swap the globe's imagery on change so the
             // layers panel's Satellite/Hybrid/Standard work on 3D too.
             if baseLayer != context.coordinator.lastBaseLayer {
@@ -424,6 +456,8 @@ struct CesiumMainMap: UIViewRepresentable {
         var lassoWasActive = false
         /// Issue #60 — whether drawing reposition mode was active last render.
         var moveWasActive = false
+        /// Issue #84 — whether vertex-edit mode was active last render.
+        var vertexEditWasActive = false
         /// Last base imagery layer pushed to the globe (swap on change).
         var lastBaseLayer = "satellite"
         /// Observer token for toolbar zoom commands forwarded to the bridge.
@@ -508,6 +542,12 @@ struct CesiumMainMap: UIViewRepresentable {
                 // drag capture is restored, mirroring the north-lock re-apply.
                 if moveWasActive {
                     webView?.evaluateJavaScript("window.OmniBridge.setMoveMode({on:true});", completionHandler: nil)
+                }
+                // Issue #84 — same re-apply for vertex-edit mode, including
+                // re-pushing the current handles so they reappear on the globe.
+                if vertexEditWasActive {
+                    webView?.evaluateJavaScript("window.OmniBridge.setVertexEditMode({on:true});", completionHandler: nil)
+                    webView?.evaluateJavaScript("window.OmniBridge.setVertexHandles(\(parent.buildVertexHandlesJSON()));", completionHandler: nil)
                 }
                 // Drain the latest snapshots the moment the HTML signals it
                 // has the OmniBridge alive — anything queued during page
@@ -601,6 +641,9 @@ struct CesiumMainMap: UIViewRepresentable {
                 case "camerachanged": kind = .cameraChanged
                 case "lasso": kind = .lasso
                 case "move": kind = .move
+                case "vertexdragstart": kind = .vertexDragStart
+                case "vertexdrag": kind = .vertexDrag
+                case "vertexdragend": kind = .vertexDragEnd
                 default: return
                 }
                 let cameraState: CesiumMapEvent.CameraState?
@@ -764,6 +807,17 @@ struct CesiumMainMap: UIViewRepresentable {
         }
 
         guard let data = try? JSONEncoder().encode(all),
+              let str = String(data: data, encoding: .utf8) else { return "[]" }
+        return str
+    }
+
+    /// Issue #84 — the draggable vertex handles for the shape under edit, as a
+    /// JSON array of `[lon, lat]` pairs (the bridge's coordinate order). The
+    /// globe renders each as a bright point; the native side owns hit-testing
+    /// and applying the drag, so this is purely the render payload.
+    fileprivate func buildVertexHandlesJSON() -> String {
+        let pairs = vertexEditHandles.map { [$0.longitude, $0.latitude] }
+        guard let data = try? JSONSerialization.data(withJSONObject: pairs),
               let str = String(data: data, encoding: .utf8) else { return "[]" }
         return str
     }

--- a/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
@@ -28,6 +28,9 @@ struct ATAKMapView: View {
     // Issue #60 (move/reposition follow-up) — drives drawing reposition mode,
     // shared by both engines so the move UX is identical on Mapbox + Cesium.
     @StateObject private var drawingMoveSession = DrawingMoveSession()
+    // Issue #84 — drives drawing vertex-edit mode (drag individual vertices /
+    // a circle's radius handle), shared by both engines like the move session.
+    @StateObject private var drawingVertexEditSession = DrawingVertexEditSession()
     @StateObject private var radialMenuCoordinator = RadialMenuMapCoordinator()
     @ObservedObject private var chatManager = ChatManager.shared
     @StateObject private var trackRecordingService = TrackRecordingService()
@@ -263,6 +266,21 @@ struct ATAKMapView: View {
             drawingMoveSession: drawingMoveSession,
             onDrawingMoveDragged: { latDelta, lonDelta in
                 applyDrawingMoveDelta(latDelta: latDelta, lonDelta: lonDelta)
+            },
+            // Issue #84 — vertex-edit session + the drag callbacks the 2D
+            // gesture drives. On touch-down it hit-tests the grabbed vertex at a
+            // map coordinate (returns true if one was grabbed); each frame moves
+            // that vertex to the dragged coordinate. The parent owns the
+            // hit-test + persist so the geometry update lives in one place.
+            drawingVertexEditSession: drawingVertexEditSession,
+            onVertexDragBegan: { coordinate in
+                beginVertexDrag(at: coordinate)
+            },
+            onVertexDragMoved: { coordinate in
+                applyVertexDrag(to: coordinate)
+            },
+            onVertexDragEnded: {
+                endVertexDrag()
             },
             onMapTap: handleMapTap,
             // Issue #72 — forward the north-lock flag so TacticalMapView
@@ -1130,6 +1148,14 @@ struct ATAKMapView: View {
             else { return }
             beginDrawingMove(id: drawingId, type: drawingType)
         }
+        // Issue #84 — Edit Vertices from the drawing radial menu enters
+        // vertex-edit mode for the selected shape on whichever engine is active.
+        .onReceive(NotificationCenter.default.publisher(for: .radialMenuEditVertices)) { notification in
+            guard let drawingId = notification.userInfo?["drawingId"] as? UUID,
+                  let drawingType = notification.userInfo?["drawingType"] as? RadialMenuContext.DrawingType
+            else { return }
+            beginVertexEdit(id: drawingId, type: drawingType)
+        }
         // Issue #60 — bail out of reposition mode if the operator toggles the
         // map engine mid-move. The session is a @StateObject that survives the
         // engine swap, and the outgoing engine unmounts without a chance to
@@ -1143,6 +1169,8 @@ struct ATAKMapView: View {
         // via mapRegion mirroring from Cesium camera-changed events.
         .onChange(of: mapEngineRaw) { newValue in
             if drawingMoveSession.isActive { cancelDrawingMove() }
+            // Issue #84 — same bail-out for vertex-edit mode on engine toggle.
+            if drawingVertexEditSession.isActive { cancelVertexEdit() }
             if newValue == MapEngine.cesium3D.rawValue {
                 // Switching 2D → 3D: capture current Mapbox region as seed.
                 cesiumCameraSeed = mapRegion
@@ -1196,6 +1224,13 @@ struct ATAKMapView: View {
                 // and capture a single-finger drag while a shape is being
                 // repositioned, mirroring the lasso capture pattern.
                 drawingMoveActive: drawingMoveSession.isActive,
+                // Issue #84 — vertex-edit mode: lock the globe camera, render
+                // draggable vertex handles for the active shape, and capture a
+                // single-finger drag (the bridge hit-tests the grabbed vertex
+                // native-side, same logic the 2D path uses). `vertexEditHandles`
+                // are the current draggable points so the globe shows them.
+                drawingVertexEditActive: drawingVertexEditSession.isActive,
+                vertexEditHandles: currentVertexEditHandles,
                 // Base layer (satellite / hybrid / standard) so the layers
                 // panel switches the globe's imagery, not just the 2D style.
                 baseLayer: activeMapLayer,
@@ -1349,6 +1384,7 @@ struct ATAKMapView: View {
         gpsFollowButton
         lassoSelectionPill
         drawingMoveOverlay
+        drawingVertexEditOverlay
         measurementChrome
         routeNavigationChrome
     }
@@ -1388,6 +1424,64 @@ struct ATAKMapView: View {
                     }
                     Button {
                         commitDrawingMove()
+                    } label: {
+                        Text("Done")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(.black)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 7)
+                            .background(Color(hex: "#FFFC00"))
+                            .clipShape(Capsule())
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(.ultraThinMaterial)
+                .background(Color.black.opacity(0.55))
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .padding(.horizontal, 16)
+                .padding(.top, 110) // clear the top status strip / toolbars
+                Spacer()
+            }
+            .zIndex(2600) // above lasso pill (2000), below radial menu (3000)
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+
+    /// Issue #84 — vertex-edit HUD. A top banner (never a side panel) telling
+    /// the operator to drag the handles, with Cancel / Done. Shown on whichever
+    /// engine is active; the per-vertex drag is handled inside each engine.
+    @ViewBuilder
+    private var drawingVertexEditOverlay: some View {
+        if drawingVertexEditSession.isActive {
+            VStack {
+                HStack(spacing: 12) {
+                    Image(systemName: "point.topleft.down.curvedto.point.bottomright.up.fill")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(Color(hex: "#FFFC00"))
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Editing \(drawingVertexEditSession.label)")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(.white)
+                            .lineLimit(1)
+                        Text("Drag a vertex to reshape")
+                            .font(.system(size: 11))
+                            .foregroundColor(Color(hex: "#BBBBBB"))
+                    }
+                    Spacer(minLength: 8)
+                    Button {
+                        cancelVertexEdit()
+                    } label: {
+                        Text("Cancel")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 7)
+                            .background(Color.white.opacity(0.15))
+                            .clipShape(Capsule())
+                    }
+                    Button {
+                        commitVertexEdit()
                     } label: {
                         Text("Done")
                             .font(.system(size: 13, weight: .semibold))
@@ -1929,6 +2023,18 @@ struct ATAKMapView: View {
             let lonDelta = event.coordinate.longitude - from.longitude
             guard latDelta != 0 || lonDelta != 0 else { return }
             applyDrawingMoveDelta(latDelta: latDelta, lonDelta: lonDelta)
+        case .vertexDragStart:
+            // Issue #84 — touch-down in vertex-edit mode. Hit-test the grabbed
+            // vertex at the touched globe coordinate; the same native logic the
+            // 2D path uses, so picking behaves identically on both engines.
+            beginVertexDrag(at: event.coordinate)
+        case .vertexDrag:
+            // Issue #84 — drag step in vertex-edit mode. Move the grabbed vertex
+            // (or circle radius handle) to the current globe coordinate.
+            applyVertexDrag(to: event.coordinate)
+        case .vertexDragEnd:
+            // Issue #84 — touch-up; release the grabbed vertex.
+            endVertexDrag()
         }
     }
 
@@ -2096,6 +2202,184 @@ struct ATAKMapView: View {
             }
         }
         drawingMoveSession.end()
+    }
+
+    // MARK: - Drawing Vertex Edit (issue #84)
+
+    /// The current set of draggable handles for the shape under vertex edit, or
+    /// empty when not editing. Both engines render these as handles: every
+    /// vertex of a line/polygon, the single point of a marker, or
+    /// `[center, radiusHandle]` for a circle (the radius handle is the draggable
+    /// one). Read live from the store so handles track in-progress drags.
+    private var currentVertexEditHandles: [CLLocationCoordinate2D] {
+        guard drawingVertexEditSession.isActive,
+              let id = drawingVertexEditSession.drawingId,
+              let type = drawingVertexEditSession.drawingType else { return [] }
+        switch type {
+        case .marker:
+            return drawingStore.markers.first(where: { $0.id == id }).map { [$0.coordinate] } ?? []
+        case .line:
+            return drawingStore.lines.first(where: { $0.id == id })?.coordinates ?? []
+        case .circle:
+            guard let c = drawingStore.circles.first(where: { $0.id == id }) else { return [] }
+            return [c.center, c.radiusHandleCoordinate]
+        case .polygon:
+            return drawingStore.polygons.first(where: { $0.id == id })?.coordinates ?? []
+        }
+    }
+
+    /// Zoom-aware grab radius (metres) for picking a vertex — a fixed on-screen
+    /// target translated to ground distance via the current 2D region span, so
+    /// a vertex is equally easy to grab at any zoom. Used by both engines'
+    /// touch-down hit-test.
+    private var vertexGrabRadiusMeters: CLLocationDistance {
+        // ~44 pt finger target. metresPerDegLat ≈ 111_320; the region's latitude
+        // span across the viewport height gives metres-per-point.
+        let metersPerDegLat = 111_320.0
+        let spanMeters = mapRegion.span.latitudeDelta * metersPerDegLat
+        // Assume a ~700 pt tall map; 44 pt of that is the grab target. Clamp so
+        // it never gets uselessly tiny (deep zoom) or huge (whole-globe view).
+        let perPoint = spanMeters / 700.0
+        return min(max(perPoint * 44.0, 5.0), 500_000.0)
+    }
+
+    /// Enter vertex-edit mode for the given drawing. Snapshots the editable
+    /// handles so Cancel can restore them exactly, then arms the shared
+    /// `DrawingVertexEditSession`; both engines lock the camera, render the
+    /// handles, and move the grabbed vertex on drag.
+    private func beginVertexEdit(id: UUID, type: RadialMenuContext.DrawingType) {
+        let label: String
+        let original: [CLLocationCoordinate2D]
+        switch type {
+        case .marker:
+            guard let m = drawingStore.markers.first(where: { $0.id == id }) else { return }
+            label = m.label; original = [m.coordinate]
+        case .line:
+            guard let l = drawingStore.lines.first(where: { $0.id == id }) else { return }
+            label = l.label; original = l.coordinates
+        case .circle:
+            guard let c = drawingStore.circles.first(where: { $0.id == id }) else { return }
+            label = c.label; original = [c.center, c.radiusHandleCoordinate]
+        case .polygon:
+            guard let p = drawingStore.polygons.first(where: { $0.id == id }) else { return }
+            label = p.label; original = p.coordinates
+        }
+        // A drawing tool / measurement shouldn't be mid-flight while editing.
+        drawingManager.cancelDrawing()
+        drawingVertexEditSession.begin(id: id, type: type, label: label, originalCoordinates: original)
+    }
+
+    /// Touch-down in vertex-edit mode — hit-test the nearest handle to the
+    /// touched coordinate and grab it for the drag. Shared by both engines so
+    /// picking is identical. For a circle only the radius handle (index 1) is
+    /// grabbable; the center isn't moved by vertex edit (use Move for that).
+    private func beginVertexDrag(at coordinate: CLLocationCoordinate2D) {
+        guard drawingVertexEditSession.isActive,
+              let id = drawingVertexEditSession.drawingId,
+              let type = drawingVertexEditSession.drawingType else { return }
+        let handles: [CLLocationCoordinate2D]
+        switch type {
+        case .marker:
+            handles = drawingStore.markers.first(where: { $0.id == id }).map { [$0.coordinate] } ?? []
+        case .line:
+            handles = drawingStore.lines.first(where: { $0.id == id })?.coordinates ?? []
+        case .polygon:
+            handles = drawingStore.polygons.first(where: { $0.id == id })?.coordinates ?? []
+        case .circle:
+            // Only the radius handle is draggable in vertex mode.
+            handles = drawingStore.circles.first(where: { $0.id == id }).map { [$0.radiusHandleCoordinate] } ?? []
+        }
+        guard let hit = DrawingVertexHitTest.nearestVertexIndex(
+            in: handles, to: coordinate, withinMeters: vertexGrabRadiusMeters
+        ) else {
+            drawingVertexEditSession.setActiveVertex(nil)
+            return
+        }
+        // For a circle the grabbable handle list held only the radius handle, so
+        // map its index 0 back to the session's handle index 1 (center is 0).
+        drawingVertexEditSession.setActiveVertex(type == .circle ? 1 : hit)
+    }
+
+    /// Drag step in vertex-edit mode — move the grabbed handle to `coordinate`
+    /// and persist live so the shape reshapes under the finger on both engines.
+    private func applyVertexDrag(to coordinate: CLLocationCoordinate2D) {
+        guard drawingVertexEditSession.isActive,
+              let id = drawingVertexEditSession.drawingId,
+              let type = drawingVertexEditSession.drawingType,
+              let vertexIndex = drawingVertexEditSession.activeVertexIndex else { return }
+        switch type {
+        case .marker:
+            guard let m = drawingStore.markers.first(where: { $0.id == id }) else {
+                cancelVertexEdit(); return
+            }
+            drawingStore.updateMarker(m.with(coordinate: coordinate))
+        case .line:
+            guard let l = drawingStore.lines.first(where: { $0.id == id }) else {
+                cancelVertexEdit(); return
+            }
+            drawingStore.updateLine(l.replacingVertex(at: vertexIndex, with: coordinate))
+        case .polygon:
+            guard let p = drawingStore.polygons.first(where: { $0.id == id }) else {
+                cancelVertexEdit(); return
+            }
+            drawingStore.updatePolygon(p.replacingVertex(at: vertexIndex, with: coordinate))
+        case .circle:
+            // Dragging the radius handle (index 1) resizes; center stays put.
+            guard vertexIndex == 1,
+                  let c = drawingStore.circles.first(where: { $0.id == id }) else {
+                if drawingStore.circles.first(where: { $0.id == id }) == nil { cancelVertexEdit() }
+                return
+            }
+            drawingStore.updateCircle(c.resized(toEdgePoint: coordinate))
+        }
+    }
+
+    /// Touch-up — release the grabbed vertex (the next touch-down re-picks).
+    private func endVertexDrag() {
+        guard drawingVertexEditSession.isActive else { return }
+        drawingVertexEditSession.setActiveVertex(nil)
+    }
+
+    /// Commit the vertex edit. Live drags already persisted each step, so this
+    /// just saves once more and closes the session.
+    private func commitVertexEdit() {
+        guard drawingVertexEditSession.isActive else { return }
+        drawingStore.saveAllDrawings()
+        drawingVertexEditSession.end()
+    }
+
+    /// Cancel the vertex edit — restore the shape's geometry to the snapshot
+    /// taken when the mode was entered, then close the session.
+    private func cancelVertexEdit() {
+        guard drawingVertexEditSession.isActive,
+              let id = drawingVertexEditSession.drawingId,
+              let type = drawingVertexEditSession.drawingType else {
+            drawingVertexEditSession.end()
+            return
+        }
+        let original = drawingVertexEditSession.originalCoordinates
+        switch type {
+        case .marker:
+            if let m = drawingStore.markers.first(where: { $0.id == id }), let first = original.first {
+                drawingStore.updateMarker(m.with(coordinate: first))
+            }
+        case .line:
+            if let l = drawingStore.lines.first(where: { $0.id == id }), !original.isEmpty {
+                drawingStore.updateLine(l.with(coordinates: original))
+            }
+        case .polygon:
+            if let p = drawingStore.polygons.first(where: { $0.id == id }), !original.isEmpty {
+                drawingStore.updatePolygon(p.with(coordinates: original))
+            }
+        case .circle:
+            // Snapshot was [center, radiusHandle]; restore both center and the
+            // radius implied by the original handle distance.
+            if let c = drawingStore.circles.first(where: { $0.id == id }),
+               original.count >= 2 {
+                drawingStore.updateCircle(c.with(center: original[0]).resized(toEdgePoint: original[1]))
+            }
+        }
+        drawingVertexEditSession.end()
     }
 
     // MARK: - Marker Actions

--- a/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/TacticalMapView.swift
@@ -56,6 +56,14 @@ struct TacticalMapView: UIViewRepresentable {
     // translates the shape via `onDrawingMoveDragged` (the parent persists it).
     @ObservedObject var drawingMoveSession: DrawingMoveSession
     var onDrawingMoveDragged: ((CLLocationDegrees, CLLocationDegrees) -> Void)? = nil
+    // Issue #84 — vertex-edit session shared with the parent + Cesium engine.
+    // When active, a single-finger drag grabs the nearest handle on touch-down
+    // (`onVertexDragBegan` with the touched coordinate) and moves it each frame
+    // (`onVertexDragMoved`); the parent owns the hit-test + persist.
+    @ObservedObject var drawingVertexEditSession: DrawingVertexEditSession
+    var onVertexDragBegan: ((CLLocationCoordinate2D) -> Void)? = nil
+    var onVertexDragMoved: ((CLLocationCoordinate2D) -> Void)? = nil
+    var onVertexDragEnded: (() -> Void)? = nil
     @ObservedObject var kmlVectorStore: KMLVectorOverlayStore = KMLVectorOverlayStore.shared
     @ObservedObject var rasterStore: RasterOverlayStore = RasterOverlayStore.shared
     @ObservedObject var mbtilesStore: MBTilesOverlayStore = MBTilesOverlayStore.shared
@@ -177,6 +185,23 @@ struct TacticalMapView: UIViewRepresentable {
         mapView.addGestureRecognizer(movePan)
         context.coordinator.movePanGesture = movePan
 
+        // Issue #84 — vertex-edit drag gesture, gated on
+        // DrawingVertexEditSession.isActive. On touch-down it forwards the
+        // touched map coordinate so the parent hit-tests the grabbed handle;
+        // each frame forwards the dragged coordinate so the parent moves that
+        // vertex (or the circle radius handle). Like move, `updateUIView`
+        // disables map pan while active so the drag moves the vertex, not the
+        // camera.
+        let vertexPan = UIPanGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleVertexEditPanGesture(_:))
+        )
+        vertexPan.maximumNumberOfTouches = 1
+        vertexPan.cancelsTouchesInView = true
+        vertexPan.delegate = context.coordinator
+        mapView.addGestureRecognizer(vertexPan)
+        context.coordinator.vertexEditPanGesture = vertexPan
+
         // Lifecycle hooks — load terrain + atmosphere on style load
         // so the operator gets immediate 3D depth without a settings
         // detour, and mirror camera changes back into the SwiftUI
@@ -241,7 +266,9 @@ struct TacticalMapView: UIViewRepresentable {
         // Issue #60 (move/reposition follow-up) — while repositioning a shape,
         // disable the map's own pan so the single-finger drag moves the SHAPE
         // (via the movePan recognizer), not the camera. Restore pan on exit.
-        mapView.gestures.options.panEnabled = !drawingMoveSession.isActive
+        // Issue #84 — same while vertex-editing (the vertexPan owns the drag).
+        mapView.gestures.options.panEnabled =
+            !drawingMoveSession.isActive && !drawingVertexEditSession.isActive
 
         // Region sync — only push to Mapbox if the SwiftUI region
         // diverges from the camera state by more than a hair. This is
@@ -411,6 +438,8 @@ struct TacticalMapView: UIViewRepresentable {
         private var drawingMarkerManager: PointAnnotationManager?
         private var drawingLabelManager: PointAnnotationManager?
         private var measurementVertexManager: PointAnnotationManager?
+        // Issue #84 — draggable vertex handles for the shape under vertex edit.
+        private var vertexHandleManager: PointAnnotationManager?
         private var drawingLineManager: PolylineAnnotationManager?
         private var drawingPolygonManager: PolygonAnnotationManager?
         private var drawingTempLineManager: PolylineAnnotationManager?
@@ -449,6 +478,11 @@ struct TacticalMapView: UIViewRepresentable {
         // lat/lon deltas as the finger moves).
         weak var movePanGesture: UIPanGestureRecognizer?
         private var lastMovePanPoint: CGPoint?
+
+        // Issue #84 — vertex-edit drag recognizer. Unlike move (which tracks a
+        // delta), this forwards absolute coordinates: the grabbed vertex on
+        // touch-down, then the dragged coordinate each frame.
+        weak var vertexEditPanGesture: UIPanGestureRecognizer?
 
         // MIL-STD-2525 symbol cache — UIHostingController snapshots
         // keyed by (cotType, callsign) so we don't rebuild the image
@@ -574,6 +608,7 @@ struct TacticalMapView: UIViewRepresentable {
             refreshDrawingPolygons()
             refreshDrawingCircles()
             refreshDrawingTempOverlay()
+            refreshVertexHandles()
             refreshMeasurementOverlay()
             refreshRangeBearing()
             refreshBreadcrumbTrail()
@@ -1316,6 +1351,65 @@ struct TacticalMapView: UIViewRepresentable {
             measurementVertexManager = m
             return m
         }
+
+        // MARK: - Vertex-edit handles (issue #84)
+
+        /// Render draggable handles for the shape under vertex edit (or clear
+        /// them when not editing). Every vertex of a line/polygon, the single
+        /// point of a marker, or `[center, radiusHandle]` for a circle. Read
+        /// live from the store so handles follow the shape as the operator drags.
+        private func refreshVertexHandles() {
+            let session = parent.drawingVertexEditSession
+            guard session.isActive, let id = session.drawingId, let type = session.drawingType else {
+                // Not editing — clear handles only if some are still shown, so we
+                // don't churn an already-empty manager on every camera tick.
+                if vertexHandlesShown {
+                    vertexHandleManager?.annotations = []
+                    vertexHandlesShown = false
+                    annotationSignatures["vertexHandles"] = nil
+                }
+                return
+            }
+            guard let manager = ensureVertexHandleManager() else { return }
+            let handles: [CLLocationCoordinate2D]
+            switch type {
+            case .marker:
+                handles = parent.drawingStore.markers.first(where: { $0.id == id }).map { [$0.coordinate] } ?? []
+            case .line:
+                handles = parent.drawingStore.lines.first(where: { $0.id == id })?.coordinates ?? []
+            case .polygon:
+                handles = parent.drawingStore.polygons.first(where: { $0.id == id })?.coordinates ?? []
+            case .circle:
+                guard let c = parent.drawingStore.circles.first(where: { $0.id == id }) else { handles = []; break }
+                handles = [c.center, c.radiusHandleCoordinate]
+            }
+            // Dedup vs camera ticks: only re-publish when the handle set changes.
+            var sigHasher = Hasher()
+            sigHasher.combine("vertexHandles"); sigHasher.combine(id)
+            for h in handles { sigHasher.combine(h.latitude); sigHasher.combine(h.longitude) }
+            guard shouldPublish(layer: "vertexHandles", signature: sigHasher.finalize()) else { return }
+            manager.annotations = handles.enumerated().map { (i, c) in
+                var ann = PointAnnotation(id: "vh-\(i)", coordinate: c)
+                ann.image = .init(image: Self.tempVertexImage, name: "temp-vertex")
+                ann.iconAnchor = .center
+                return ann
+            }
+            vertexHandlesShown = true
+        }
+
+        /// Whether vertex handles are currently displayed (to avoid clearing an
+        /// already-empty manager every camera tick once editing ends).
+        private var vertexHandlesShown = false
+
+        private func ensureVertexHandleManager() -> PointAnnotationManager? {
+            if let m = vertexHandleManager { return m }
+            guard let mapView = mapView else { return nil }
+            // Make this the topmost annotation manager so handles sit above the
+            // shape outlines the operator is editing.
+            let m = mapView.annotations.makePointAnnotationManager(id: "vertex-handles")
+            vertexHandleManager = m
+            return m
+        }
         private func ensureRangeRingManager() -> PolygonAnnotationManager? {
             if let m = rangeRingManager { return m }
             guard let mapView = mapView else { return nil }
@@ -1679,6 +1773,11 @@ struct TacticalMapView: UIViewRepresentable {
             if gestureRecognizer === movePanGesture {
                 return parent.drawingMoveSession.isActive
             }
+            // Issue #84 — the vertex-edit pan only begins while a vertex-edit
+            // session is active; otherwise it stands down.
+            if gestureRecognizer === vertexEditPanGesture {
+                return parent.drawingVertexEditSession.isActive
+            }
             return true
         }
 
@@ -1739,6 +1838,32 @@ struct TacticalMapView: UIViewRepresentable {
                 lastMovePanPoint = point
             case .ended, .cancelled, .failed:
                 lastMovePanPoint = nil
+            default:
+                break
+            }
+        }
+
+        // MARK: - Drawing vertex-edit gesture (issue #84)
+
+        /// Single-finger drag in vertex-edit mode → move one vertex. On
+        /// touch-down we forward the touched map coordinate so the parent
+        /// hit-tests the nearest handle and grabs it; each frame we forward the
+        /// dragged coordinate so the parent sets that vertex to it (the parent
+        /// owns the geometry so both engines share the same logic). Using the
+        /// absolute coordinate under the finger keeps the vertex pinned to the
+        /// touch at any zoom/pitch.
+        @objc func handleVertexEditPanGesture(_ gesture: UIPanGestureRecognizer) {
+            guard let mapView = mapView, parent.drawingVertexEditSession.isActive else { return }
+            let point = gesture.location(in: mapView)
+            let coord = mapView.mapboxMap.coordinate(for: point)
+            switch gesture.state {
+            case .began:
+                parent.onVertexDragBegan?(coord)
+                parent.onVertexDragMoved?(coord)
+            case .changed:
+                parent.onVertexDragMoved?(coord)
+            case .ended, .cancelled, .failed:
+                parent.onVertexDragEnded?()
             default:
                 break
             }

--- a/OmniTAKMobile/Resources/cesium_scene.html
+++ b/OmniTAKMobile/Resources/cesium_scene.html
@@ -28,7 +28,7 @@
 <script src="https://unpkg.com/milsymbol@2.2.0/dist/milsymbol.js"></script>
 <script>
   Cesium.Ion.defaultAccessToken='__CESIUM_ION_TOKEN__';
-  const _state={ready:false,viewer:null,entities:new Map(),drawings:new Map(),measurements:new Map(),tempDrawings:new Map(),trails:new Map(),leaders:new Map(),photoreal:null,billboardCache:new Map(),lasso:{enabled:false,dragging:false,pts:[],handler:null},move:{enabled:false,dragging:false,last:null},northLocked:false,northSnapping:false};
+  const _state={ready:false,viewer:null,entities:new Map(),drawings:new Map(),measurements:new Map(),tempDrawings:new Map(),trails:new Map(),leaders:new Map(),photoreal:null,billboardCache:new Map(),lasso:{enabled:false,dragging:false,pts:[],handler:null},move:{enabled:false,dragging:false,last:null},vertexEdit:{enabled:false,dragging:false,handles:[]},northLocked:false,northSnapping:false};
   // Lasso multi-select drag (issue #16, 3D parity). Camera pan is
   // disabled while the lasso is enabled; the freehand path is drawn on
   // a 2D overlay canvas and the screen points are picked to lat/lon on
@@ -54,6 +54,17 @@
     _postMapEvent({event:'move',lat:c.lat,lon:c.lon,hae:c.hae,fromLat:_state.move.last.lat,fromLon:_state.move.last.lon});
     _state.move.last=c;}
   function _moveTouchEnd(e){if(!_state.move.enabled)return;e.preventDefault();_state.move.dragging=false;_state.move.last=null;}
+  // Issue #84 — single-finger drag in vertex-edit mode. touchstart posts a
+  // 'vertexdragstart' with the touched globe point so the native side hit-tests
+  // the grabbed handle; touchmove posts 'vertexdrag' with the current point so
+  // native moves that one vertex (or the circle radius handle); touchend posts
+  // 'vertexdragend'. Same overlay-canvas + camera-lock pattern as move/lasso.
+  function _vertexCarto(t){const v=_state.viewer;if(!v)return null;return _cartoFor(v,new Cesium.Cartesian2(t.clientX,t.clientY));}
+  function _vertexTouchStart(e){if(!_state.vertexEdit.enabled)return;e.preventDefault();const t=e.touches[0];if(!t)return;const c=_vertexCarto(t);if(!c)return;_state.vertexEdit.dragging=true;
+    _postMapEvent({event:'vertexdragstart',lat:c.lat,lon:c.lon,hae:c.hae});}
+  function _vertexTouchMove(e){if(!_state.vertexEdit.enabled||!_state.vertexEdit.dragging)return;e.preventDefault();const t=e.touches[0];if(!t)return;const c=_vertexCarto(t);if(!c)return;
+    _postMapEvent({event:'vertexdrag',lat:c.lat,lon:c.lon,hae:c.hae});}
+  function _vertexTouchEnd(e){if(!_state.vertexEdit.enabled)return;e.preventDefault();_state.vertexEdit.dragging=false;_postMapEvent({event:'vertexdragend',lat:0,lon:0});}
   function _drawColor(hex,a){try{const c=Cesium.Color.fromCssColorString(hex||'#4ADE80');return a!==undefined?c.withAlpha(a):c}catch(e){return Cesium.Color.CYAN}}
   function _havDist(a,b){const R=6371000,lat1=a[1]*Math.PI/180,lat2=b[1]*Math.PI/180,dLat=(b[1]-a[1])*Math.PI/180,dLon=(b[0]-a[0])*Math.PI/180;const s=Math.sin(dLat/2)**2+Math.cos(lat1)*Math.cos(lat2)*Math.sin(dLon/2)**2;return 2*R*Math.asin(Math.min(1,Math.sqrt(s)))}
   function _fitViewport(){
@@ -327,6 +338,48 @@
         cv.style.display='none';cv.style.pointerEvents='none';
         if(v)v.scene.screenSpaceCameraController.enableInputs=true;
       }
+    },
+    // Issue #84 — drawing vertex-edit mode. Same overlay-canvas + camera-lock
+    // pattern as move; the single-finger drag posts vertexdragstart/vertexdrag/
+    // vertexdragend events the native side uses to hit-test + move one vertex.
+    // The draggable handles are rendered as bright points by setVertexHandles.
+    setVertexEditMode(arg){const e=_parse(arg);const on=!!(e&&e.on);const v=_state.viewer;const cv=document.getElementById('lassoCanvas');if(!cv)return;
+      if(on){
+        _state.vertexEdit.enabled=true;_state.vertexEdit.dragging=false;
+        cv.width=window.innerWidth;cv.height=window.innerHeight;cv.style.display='block';cv.style.pointerEvents='auto';
+        cv.addEventListener('touchstart',_vertexTouchStart,{passive:false});
+        cv.addEventListener('touchmove',_vertexTouchMove,{passive:false});
+        cv.addEventListener('touchend',_vertexTouchEnd,{passive:false});
+        cv.addEventListener('touchcancel',_vertexTouchEnd,{passive:false});
+        if(v)v.scene.screenSpaceCameraController.enableInputs=false;
+      }else{
+        _state.vertexEdit.enabled=false;_state.vertexEdit.dragging=false;
+        cv.removeEventListener('touchstart',_vertexTouchStart);
+        cv.removeEventListener('touchmove',_vertexTouchMove);
+        cv.removeEventListener('touchend',_vertexTouchEnd);
+        cv.removeEventListener('touchcancel',_vertexTouchEnd);
+        const ctx=cv.getContext('2d');ctx&&ctx.clearRect(0,0,cv.width,cv.height);
+        cv.style.display='none';cv.style.pointerEvents='none';
+        if(v)v.scene.screenSpaceCameraController.enableInputs=true;
+        // Clear any rendered handles when leaving the mode.
+        window.OmniBridge.setVertexHandles('[]');
+      }
+    },
+    // Issue #84 — render the draggable vertex handles for the shape under edit.
+    // `arg` is a JSON array of [lon,lat] pairs. Each becomes a bright point
+    // (same style as the in-progress drawing vertices) clamped to the ground,
+    // depth-test disabled so it reads above the shape. Re-pushed live during a
+    // drag so the grabbed handle visibly tracks the finger.
+    setVertexHandles(arg){const list=_parse(arg);const v=_state.viewer;if(!v)return;
+      // Remove the previous handle entities.
+      for(const e of (_state.vertexEdit.handles||[])){try{v.entities.remove(e);}catch(err){}}
+      _state.vertexEdit.handles=[];
+      if(!Array.isArray(list))return;
+      list.forEach(function(c,i){if(!Array.isArray(c)||c.length<2)return;
+        const ent=v.entities.add({id:'vhandle-'+i,position:Cesium.Cartesian3.fromDegrees(c[0],c[1],0),
+          point:{pixelSize:13,color:Cesium.Color.fromCssColorString('#FFFC00'),outlineColor:Cesium.Color.WHITE,outlineWidth:2,heightReference:Cesium.HeightReference.CLAMP_TO_GROUND,disableDepthTestDistance:Number.POSITIVE_INFINITY}});
+        _state.vertexEdit.handles.push(ent);});
+      v.scene.requestRender();
     },
     // Base imagery swap so the layers panel works on the globe:
     // satellite = Cesium World Imagery (aerial), standard = OSM streets,

--- a/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuActionExecutor.swift
+++ b/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuActionExecutor.swift
@@ -67,6 +67,8 @@ class RadialMenuActionExecutor {
             return executeEditDrawing(context: context, services: services)
         case .moveDrawing:
             return executeMoveDrawing(context: context, services: services)
+        case .editVertices:
+            return executeEditVertices(context: context, services: services)
         case .deleteDrawing:
             return executeDeleteDrawing(context: context, services: services)
         case .copyCoordinates:
@@ -513,6 +515,24 @@ class RadialMenuActionExecutor {
         return true
     }
 
+    /// Issue #84 — enter vertex-edit mode for the pressed drawing. The map view
+    /// observes `radialMenuEditVertices`, starts a DrawingVertexEditSession,
+    /// locks the camera, and renders draggable per-vertex handles (plus a
+    /// radius handle for a circle) the operator drags to reshape. Routes through
+    /// here identically for shapes selected from either engine.
+    private static func executeEditVertices(context: RadialMenuContext, services: RadialMenuServices) -> Bool {
+        guard let drawingId = context.pressedDrawingId,
+              let drawingType = context.pressedDrawingType else { return false }
+
+        NotificationCenter.default.post(
+            name: .radialMenuEditVertices,
+            object: nil,
+            userInfo: ["drawingId": drawingId, "drawingType": drawingType]
+        )
+
+        return true
+    }
+
     private static func executeDeleteDrawing(context: RadialMenuContext, services: RadialMenuServices) -> Bool {
         guard let drawingId = context.pressedDrawingId,
               let drawingType = context.pressedDrawingType,
@@ -790,6 +810,9 @@ extension Notification.Name {
     /// Issue #60 (move/reposition follow-up) — posted by the drawing radial
     /// menu's Move action; the map view enters reposition mode for the shape.
     static let radialMenuMoveDrawing = Notification.Name("radialMenuMoveDrawing")
+    /// Issue #84 — posted by the drawing radial menu's Edit Vertices action;
+    /// the map view enters vertex-edit mode for the shape.
+    static let radialMenuEditVertices = Notification.Name("radialMenuEditVertices")
     // App mode & layers
     static let radialMenuShowAppModePicker = Notification.Name("radialMenuShowAppModePicker")
     static let radialMenuShowLayers = Notification.Name("radialMenuShowLayers")

--- a/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuModels.swift
+++ b/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuModels.swift
@@ -75,6 +75,7 @@ enum RadialMenuAction: Equatable {
     case drawPolygon
     case editDrawing
     case moveDrawing
+    case editVertices
     case deleteDrawing
 
     // Utility Actions
@@ -132,6 +133,8 @@ enum RadialMenuAction: Equatable {
             return "editDrawing"
         case .moveDrawing:
             return "moveDrawing"
+        case .editVertices:
+            return "editVertices"
         case .deleteDrawing:
             return "deleteDrawing"
         case .copyCoordinates:
@@ -411,7 +414,7 @@ extension RadialMenuAction {
         case .measure, .measureDistance, .measureArea, .measureBearing:
             return "measure"
         case .openDrawingTools, .openDrawingsList, .drawLine, .drawCircle, .drawPolygon,
-             .moveDrawing:
+             .moveDrawing, .editVertices:
             return "drawing"
         case .navigate, .navigateToMarker, .createRoute:
             return "routes"

--- a/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuPresets.swift
+++ b/OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuPresets.swift
@@ -127,12 +127,13 @@ enum RadialMenuPresets {
     // MARK: - Drawing Context Menu
 
     /// Menu for a placed drawing shape (line / polygon / circle / drawing
-    /// marker). Adds **Move** between Edit and Delete — the reposition action
-    /// from issue #60. Edit / Delete reuse the shared `.editMarker` /
+    /// marker). Adds **Move** (whole-shape reposition, issue #60) and **Vertices**
+    /// (drag individual vertices / a circle's radius handle, issue #84) between
+    /// Edit and Delete. Edit / Delete reuse the shared `.editMarker` /
     /// `.deleteMarker` actions, which already dispatch to the drawing handlers
     /// when the context is a drawing (see RadialMenuActionExecutor). This is
     /// shown instead of `markerContextMenu` whenever a drawing is selected, so
-    /// Move never appears for point markers (which can't be repositioned here).
+    /// these shape-only actions never appear for point markers.
     static var drawingContextMenu: RadialMenuConfiguration {
         RadialMenuConfiguration(
             items: [
@@ -147,6 +148,12 @@ enum RadialMenuPresets {
                     label: "Move",
                     color: atakBlue,
                     action: .moveDrawing
+                ),
+                RadialMenuItem(
+                    icon: "point.topleft.down.curvedto.point.bottomright.up.fill",
+                    label: "Vertices",
+                    color: atakGreen,
+                    action: .editVertices
                 ),
                 RadialMenuItem(
                     icon: "trash.fill",
@@ -574,6 +581,8 @@ struct RadialMenuPresetsPreviewWrapper: View {
             return "Edit Drawing"
         case .moveDrawing:
             return "Move Drawing"
+        case .editVertices:
+            return "Edit Vertices"
         case .deleteDrawing:
             return "Delete Drawing"
         case .openLayers:

--- a/OmniTAKMobileTests/DrawingVertexEditTests.swift
+++ b/OmniTAKMobileTests/DrawingVertexEditTests.swift
@@ -1,0 +1,233 @@
+//
+//  DrawingVertexEditTests.swift
+//  OmniTAKMobileTests
+//
+//  Regression tests for the drawing vertex-edit geometry (issue #84 —
+//  follow-up to the move/reposition work in #81). Where move rigidly
+//  translates the whole shape, vertex editing moves a single point: replacing
+//  vertex `i` of a line/polygon with a dragged coordinate, or resizing a circle
+//  by dragging its radius handle. These tests pin that math plus the
+//  nearest-vertex hit-test and the edit-session bookkeeping that Cancel relies
+//  on. All geometry is engine-agnostic, so both the 2D Mapbox and 3D Cesium
+//  drag paths share exactly this logic.
+//
+
+import XCTest
+import CoreLocation
+@testable import OmniTAK
+
+final class DrawingVertexEditTests: XCTestCase {
+
+    private let eps = 1e-9
+
+    // MARK: - Replace a single vertex (line / polygon)
+
+    func testLineReplacingVertexMovesOnlyThatVertex() {
+        let line = LineDrawing(
+            name: "L", color: .red,
+            coordinates: [
+                CLLocationCoordinate2D(latitude: 1, longitude: 1),
+                CLLocationCoordinate2D(latitude: 2, longitude: 3),
+                CLLocationCoordinate2D(latitude: -4, longitude: 5)
+            ]
+        )
+        let newPoint = CLLocationCoordinate2D(latitude: 9, longitude: 9)
+        let edited = line.replacingVertex(at: 1, with: newPoint)
+        // Same count, identity preserved.
+        XCTAssertEqual(edited.coordinates.count, 3)
+        XCTAssertEqual(edited.id, line.id)
+        // Only vertex 1 changed.
+        XCTAssertEqual(edited.coordinates[0].latitude, 1, accuracy: eps)
+        XCTAssertEqual(edited.coordinates[0].longitude, 1, accuracy: eps)
+        XCTAssertEqual(edited.coordinates[1].latitude, 9, accuracy: eps)
+        XCTAssertEqual(edited.coordinates[1].longitude, 9, accuracy: eps)
+        XCTAssertEqual(edited.coordinates[2].latitude, -4, accuracy: eps)
+        XCTAssertEqual(edited.coordinates[2].longitude, 5, accuracy: eps)
+    }
+
+    func testPolygonReplacingVertexMovesOnlyThatVertex() {
+        let poly = PolygonDrawing(
+            name: "P", color: .green,
+            coordinates: [
+                CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                CLLocationCoordinate2D(latitude: 0, longitude: 1),
+                CLLocationCoordinate2D(latitude: 1, longitude: 1)
+            ]
+        )
+        let newPoint = CLLocationCoordinate2D(latitude: 5, longitude: 6)
+        let edited = poly.replacingVertex(at: 2, with: newPoint)
+        XCTAssertEqual(edited.coordinates.count, 3)
+        XCTAssertEqual(edited.id, poly.id)
+        XCTAssertEqual(edited.coordinates[0].latitude, 0, accuracy: eps)
+        XCTAssertEqual(edited.coordinates[1].longitude, 1, accuracy: eps)
+        XCTAssertEqual(edited.coordinates[2].latitude, 5, accuracy: eps)
+        XCTAssertEqual(edited.coordinates[2].longitude, 6, accuracy: eps)
+    }
+
+    func testReplacingVertexOutOfRangeIsNoOp() {
+        // Defensive: an index that vanished (e.g. a concurrent edit) must not
+        // crash — it returns the shape unchanged.
+        let line = LineDrawing(
+            name: "L", color: .red,
+            coordinates: [
+                CLLocationCoordinate2D(latitude: 1, longitude: 1),
+                CLLocationCoordinate2D(latitude: 2, longitude: 2)
+            ]
+        )
+        let p = CLLocationCoordinate2D(latitude: 9, longitude: 9)
+        let editedHigh = line.replacingVertex(at: 5, with: p)
+        let editedNeg = line.replacingVertex(at: -1, with: p)
+        for edited in [editedHigh, editedNeg] {
+            XCTAssertEqual(edited.coordinates.count, 2)
+            XCTAssertEqual(edited.coordinates[0].latitude, 1, accuracy: eps)
+            XCTAssertEqual(edited.coordinates[1].latitude, 2, accuracy: eps)
+        }
+    }
+
+    // MARK: - Circle radius handle
+
+    func testCircleRadiusHandleCoordinateIsRadiusMetersDueEast() {
+        // The radius handle sits due-east of the center at exactly `radius`
+        // metres, so dragging it resizes the circle. Round-tripping the handle
+        // back to a radius must recover the original distance.
+        let circle = CircleDrawing(
+            name: "C", color: .blue,
+            center: CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3),
+            radius: 500
+        )
+        let handle = circle.radiusHandleCoordinate
+        // Handle is east of center (greater longitude, same-ish latitude).
+        XCTAssertGreaterThan(handle.longitude, circle.center.longitude)
+        XCTAssertEqual(handle.latitude, circle.center.latitude, accuracy: 1e-6,
+                       "due-east handle stays on the same parallel")
+        // Distance from center to handle ≈ radius.
+        XCTAssertEqual(circle.center.distance(to: handle), 500, accuracy: 1.0)
+    }
+
+    func testCircleResizingFromEdgePointUpdatesRadius() {
+        let center = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let circle = CircleDrawing(name: "C", color: .blue, center: center, radius: 100)
+        // Drag the handle to a point ~1000 m away; radius should follow.
+        let dragged = center.offset(latDelta: 0, lonDelta: 0.01) // ~1.11 km east at equator
+        let resized = circle.resized(toEdgePoint: dragged)
+        XCTAssertEqual(resized.center.latitude, center.latitude, accuracy: eps,
+                       "resize keeps the center fixed")
+        XCTAssertEqual(resized.center.longitude, center.longitude, accuracy: eps)
+        XCTAssertEqual(resized.radius, center.distance(to: dragged), accuracy: 1.0)
+        XCTAssertGreaterThan(resized.radius, 1000)
+        XCTAssertEqual(resized.id, circle.id)
+    }
+
+    func testCircleResizeClampsToMinimumRadius() {
+        // Dragging the handle onto the center must not collapse the circle to a
+        // zero/degenerate radius — it clamps to a small positive floor.
+        let center = CLLocationCoordinate2D(latitude: 10, longitude: 10)
+        let circle = CircleDrawing(name: "C", color: .blue, center: center, radius: 250)
+        let resized = circle.resized(toEdgePoint: center)
+        XCTAssertGreaterThan(resized.radius, 0, "radius must stay positive")
+    }
+
+    // MARK: - Nearest-vertex hit test (shared by both engines)
+
+    func testNearestVertexPicksTheClosestWithinThreshold() {
+        let verts = [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 0, longitude: 1),
+            CLLocationCoordinate2D(latitude: 1, longitude: 1)
+        ]
+        // A touch right next to vertex 1.
+        let touch = CLLocationCoordinate2D(latitude: 0.0001, longitude: 1.0001)
+        let idx = DrawingVertexHitTest.nearestVertexIndex(
+            in: verts, to: touch, withinMeters: 10_000
+        )
+        XCTAssertEqual(idx, 1)
+    }
+
+    func testNearestVertexReturnsNilWhenNoneWithinThreshold() {
+        let verts = [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 0, longitude: 1)
+        ]
+        // A touch far from every vertex with a tight threshold.
+        let touch = CLLocationCoordinate2D(latitude: 50, longitude: 50)
+        let idx = DrawingVertexHitTest.nearestVertexIndex(
+            in: verts, to: touch, withinMeters: 100
+        )
+        XCTAssertNil(idx)
+    }
+
+    func testNearestVertexBreaksTiesToTheNearer() {
+        let verts = [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),   // far
+            CLLocationCoordinate2D(latitude: 0, longitude: 0.5), // nearer
+            CLLocationCoordinate2D(latitude: 0, longitude: 0.6)  // nearest
+        ]
+        let touch = CLLocationCoordinate2D(latitude: 0, longitude: 0.59)
+        let idx = DrawingVertexHitTest.nearestVertexIndex(
+            in: verts, to: touch, withinMeters: 1_000_000
+        )
+        XCTAssertEqual(idx, 2)
+    }
+
+    func testNearestVertexEmptyIsNil() {
+        let idx = DrawingVertexHitTest.nearestVertexIndex(
+            in: [], to: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            withinMeters: 1000
+        )
+        XCTAssertNil(idx)
+    }
+
+    // MARK: - Vertex-edit session bookkeeping
+
+    @MainActor
+    func testVertexEditSessionLifecycle() {
+        let session = DrawingVertexEditSession()
+        XCTAssertFalse(session.isActive)
+        XCTAssertTrue(session.originalCoordinates.isEmpty)
+        XCTAssertNil(session.activeVertexIndex)
+
+        let id = UUID()
+        let original = [
+            CLLocationCoordinate2D(latitude: 1, longitude: 2),
+            CLLocationCoordinate2D(latitude: 3, longitude: 4),
+            CLLocationCoordinate2D(latitude: 5, longitude: 6)
+        ]
+        session.begin(id: id, type: .polygon, label: "Poly 1", originalCoordinates: original)
+        XCTAssertTrue(session.isActive)
+        XCTAssertEqual(session.drawingId, id)
+        XCTAssertEqual(session.drawingType, .polygon)
+        XCTAssertEqual(session.label, "Poly 1")
+        XCTAssertEqual(session.originalCoordinates.count, 3)
+
+        // A drag grabs a specific vertex, then releases it.
+        session.setActiveVertex(1)
+        XCTAssertEqual(session.activeVertexIndex, 1)
+        session.setActiveVertex(nil)
+        XCTAssertNil(session.activeVertexIndex)
+
+        session.end()
+        XCTAssertFalse(session.isActive)
+        XCTAssertNil(session.drawingId)
+        XCTAssertNil(session.drawingType)
+        XCTAssertTrue(session.originalCoordinates.isEmpty)
+        XCTAssertNil(session.activeVertexIndex)
+    }
+
+    @MainActor
+    func testVertexEditSessionCircleHandleVertex() {
+        // For a circle the editable "vertices" are [center, radiusHandle]; the
+        // session carries that pair so the engines can render both handles and
+        // Cancel can restore the exact original radius.
+        let session = DrawingVertexEditSession()
+        let id = UUID()
+        let center = CLLocationCoordinate2D(latitude: 47.6, longitude: -122.3)
+        let circle = CircleDrawing(name: "C", color: .blue, center: center, radius: 400)
+        session.begin(id: id, type: .circle, label: "Circle 1",
+                      originalCoordinates: [circle.center, circle.radiusHandleCoordinate])
+        XCTAssertEqual(session.originalCoordinates.count, 2)
+        XCTAssertEqual(session.originalCoordinates[0].latitude, center.latitude, accuracy: eps)
+        // The second handle is the radius point, ~400 m east.
+        XCTAssertEqual(center.distance(to: session.originalCoordinates[1]), 400, accuracy: 1.0)
+        session.end()
+    }
+}


### PR DESCRIPTION
Follow-up to #60/#81. Whole-shape **move** shipped in #81 (drag to reposition); this adds the remaining piece from #84 — editing a placed drawing's individual geometry: **drag a line/polygon vertex, or drag a circle's radius handle** — on both the Mapbox 2D and Cesium 3D engines. It slots onto the same `DrawingMoveSession` + bridge plumbing #81 left in place.

## What's added

**"Edit Vertices" action in the drawing radial menu**
- Placed drawings now offer **Edit / Move / Vertices / Delete / Info**. Like Move, **Vertices** is drawing-only — it never shows for point markers. It posts `.radialMenuEditVertices`; the map view enters vertex-edit mode for the selected shape on whichever engine is active.

**Vertex-edit mode (shared across engines)**
- A shared `DrawingVertexEditSession` drives the mode so the UX is identical on 2D and 3D. While active the camera is locked, draggable handles render on the shape, and a top banner shows `Editing <name>` with **Cancel / Done**. Per the full-screen-map rule it's a top overlay, never a side panel. The session also tracks which handle the in-flight drag grabbed (`activeVertexIndex`), so successive frames move the same point.
- **Single-vertex edit** (vs move's rigid translate): `replacingVertex(at:with:)` for a line/polygon; a circle **radius handle** — a point `radius` m due-east of the center — that resizes the circle via `resized(toEdgePoint:)`, clamped to a positive floor so it can't collapse. Persists live to the `DrawingStore` each frame.
- **Cancel** restores the geometry snapshot taken when the mode was entered (for a circle, both the center and the original radius), so a drag that clamped or wrapped still lands back exactly where it started.

**2D Mapbox**
- A single-finger `UIPanGestureRecognizer` gated to the session. Touch-down hit-tests the nearest handle at the touched map coordinate and grabs it; each frame moves it to the dragged coordinate (absolute, so the vertex stays pinned to the finger at any zoom/pitch). The map's own pan is disabled while editing so the drag moves the vertex, not the camera. Handles render as bright points on a dedicated annotation manager.

**3D Cesium**
- A `setVertexEditMode` bridge that locks the globe camera and captures the single-finger drag on the overlay canvas (same pattern as the lasso/move), posting `vertexdragstart` / `vertexdrag` / `vertexdragend` events. The **native side does the hit-test** on the drag-origin globe point and moves the vertex — so picking shares exactly the same engine-agnostic logic the 2D path uses, rather than per-vertex entity picking. `setVertexHandles` renders the draggable handles as points and re-pushes them live so a grabbed handle visibly tracks the finger. Re-applied on `omniBridgeReady` so a WebGL process restart mid-edit re-locks the camera and restores the handles.

**Robustness**
- The nearest-vertex hit-test (`DrawingVertexHitTest`) is engine-agnostic and zoom-aware — a fixed on-screen grab target translated to ground distance — so a vertex is equally easy to grab at any zoom on both engines. The session is cancelled if the operator toggles the map engine mid-edit (mirroring the move bail-out), and each apply bails cleanly if the shape was deleted elsewhere.

## Test plan

**Automated** (`OmniTAKMobileTests/DrawingVertexEditTests.swift`, 12 tests, green):
- Per-vertex replace for line/polygon (only the targeted vertex moves; identity + count preserved); out-of-range index is a no-op.
- Circle radius handle is `radius` m due-east of center and round-trips; `resized(toEdgePoint:)` updates radius / keeps the center; min-radius clamp.
- Nearest-vertex hit-test: picks the closest within threshold, returns nil when none is within, breaks ties to the nearer, empty → nil.
- `DrawingVertexEditSession` lifecycle (begin / activeVertex grab+release / end) and the circle `[center, radiusHandle]` snapshot.

```
xcodebuild test -project OmniTAK.xcodeproj -scheme OmniTAKMobile \
  -destination 'platform=iOS Simulator,name=iPhone 17' \
  -only-testing:OmniTAKTests/DrawingVertexEditTests
# Executed 12 tests, with 0 failures — ** TEST SUCCEEDED **
```

`DrawingMoveTests` (the #81 suite this extends) still green — 24/24 with the new suite. **Build**: `xcodebuild ... build` green (Debug, iPhone 17 sim).

**Needs a human device/visual pass** (build- + unit-verified, not yet exercised on-device):
- The actual drag feel on both engines — grabbing a handle and dragging it with the camera locked, the vertex tracking the finger at various zooms/pitches.
- **Cesium vertex picking specifically** — the native-side hit-test on the drag-origin globe point at grazing camera angles, and the handle points re-rendering live during the drag. This is the part #81 flagged as the larger surface; it's wired end-to-end and the geometry/hit-test is unit-verified, but the on-globe touch→pick→render loop wants a real device.
- The radius-handle resize on a circle (2D + 3D) and the Cancel round-trip restoring the original radius.
- The vertex-edit HUD banner layout over the live map on both engines, and engine-toggle-mid-edit cancelling cleanly.

Recommend the usual iOS+Android side-by-side screenshot once it's on a device.

Closes #84