### PR TITLE
feat(uas): raw H264 UDP video receiver — iOS parity (#40)

### DIFF
--- a/OmniTAK.xcodeproj/project.pbxproj
+++ b/OmniTAK.xcodeproj/project.pbxproj
@@ -43,6 +43,9 @@
 		1C9137217214B1713429C1F8 /* LocalizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7545CAC8E7D57583BCDAB1CE /* LocalizationManager.swift */; };
 		20CAAB4409715F7431C1DEAB /* AppPreviewRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786486F562966ED005A6E978 /* AppPreviewRecordingTests.swift */; };
 		2152BF37AF7F80147E73BDCB /* UASConnectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699B5990C6EA00ABB6691FB8 /* UASConnectView.swift */; };
+		3B09F9B2BE193AC3BF35D349 /* H264NalSplitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A7172E0CE281268E4EA8D3 /* H264NalSplitter.swift */; };
+		74C658D3C5C6C5833DFE077F /* UasVideoPipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C7085555EF26F23948847CF /* UasVideoPipView.swift */; };
+		BA8C5E40E6CC074300E7BB41 /* H264NalSplitterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6377E6967A044A812D98864B /* H264NalSplitterTests.swift */; };
 		221CFB201E760AE1F327AE9F /* SHAPMFQ----.svg in Resources */ = {isa = PBXBuildFile; fileRef = E763527D180A2BFA06815720 /* SHAPMFQ----.svg */; };
 		225E69B4E6B06F8CFCCC70CD /* DataPackageModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A282FADB8ACF4795AB133B /* DataPackageModels.swift */; };
 		2262EE8CA832D8F3763D6EC9 /* MeshtasticTCPConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2393F697897173C8BD5B108A /* MeshtasticTCPConnectionView.swift */; };
@@ -566,6 +569,9 @@
 		6573C607EB2B7E7F82B0B79D /* de */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = de; path = OmniTAKMobile/Resources/de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		676590F7AFD402DEBBC6868D /* VideoPlayerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VideoPlayerView.swift; path = OmniTAKMobile/Features/Video/Views/VideoPlayerView.swift; sourceTree = "<group>"; };
 		699B5990C6EA00ABB6691FB8 /* UASConnectView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UASConnectView.swift; path = OmniTAKMobile/Features/UAS/Views/UASConnectView.swift; sourceTree = "<group>"; };
+		21A7172E0CE281268E4EA8D3 /* H264NalSplitter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = H264NalSplitter.swift; path = OmniTAKMobile/Features/UAS/Services/H264NalSplitter.swift; sourceTree = "<group>"; };
+		5C7085555EF26F23948847CF /* UasVideoPipView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UasVideoPipView.swift; path = OmniTAKMobile/Features/UAS/Views/UasVideoPipView.swift; sourceTree = "<group>"; };
+		6377E6967A044A812D98864B /* H264NalSplitterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = H264NalSplitterTests.swift; path = OmniTAKMobileTests/H264NalSplitterTests.swift; sourceTree = "<group>"; };
 		6A0A793E185CC30595DAB79B /* CoordinateDisplayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoordinateDisplayView.swift; path = OmniTAKMobile/Features/Map/Views/CoordinateDisplayView.swift; sourceTree = "<group>"; };
 		6A299080EB48E2B8246EE899 /* SettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SettingsView.swift; path = OmniTAKMobile/Features/Settings/Views/SettingsView.swift; sourceTree = "<group>"; };
 		6A5B41CDE4CCF5C5DB090E58 /* TeamManagementView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TeamManagementView.swift; path = OmniTAKMobile/Features/Teams/Views/TeamManagementView.swift; sourceTree = "<group>"; };
@@ -1063,6 +1069,7 @@
 				450330F089409385FE975F3E /* CSREnrollmentTests.swift */,
 				0A7FB9C4E1E1A57D761DBE6B /* MeshBroadcastTests.swift */,
 				C644AA06A8883B0013638A4E /* OpenDroneIdParserTests.swift */,
+				6377E6967A044A812D98864B /* H264NalSplitterTests.swift */,
 				634644F50DF0B69A944A6048 /* PPLISchedulerTests.swift */,
 				0C8884B98F8B309825903DC6 /* ServerValidatorTests.swift */,
 				D34215C77B2CE923B04AF0F5 /* TAKPacketCodecTests.swift */,
@@ -1768,6 +1775,7 @@
 				C354E89D594F3D222E851AAC /* MAVLinkCodec.swift */,
 				753DFA3A49FA2E282FBDBEA1 /* MAVLinkConnection.swift */,
 				DF6C46A0E3F79DB84E2969DE /* UASManager.swift */,
+				21A7172E0CE281268E4EA8D3 /* H264NalSplitter.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -2147,6 +2155,7 @@
 			isa = PBXGroup;
 			children = (
 				699B5990C6EA00ABB6691FB8 /* UASConnectView.swift */,
+				5C7085555EF26F23948847CF /* UasVideoPipView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -2714,6 +2723,7 @@
 				024BC7A13B382321ECAF2933 /* CSREnrollmentTests.swift in Sources */,
 				6FE43BA548D82C170FEE6275 /* MeshBroadcastTests.swift in Sources */,
 				A351A8B77C3983E18499A04F /* OpenDroneIdParserTests.swift in Sources */,
+				BA8C5E40E6CC074300E7BB41 /* H264NalSplitterTests.swift in Sources */,
 				D1E674552E2BFBA766EFA496 /* PPLISchedulerTests.swift in Sources */,
 				1412A35EC6121F54838D6CCA /* ServerValidatorTests.swift in Sources */,
 				B4862ADC1DD9D4427C0DB504 /* TAKPacketCodecTests.swift in Sources */,
@@ -2942,7 +2952,9 @@
 				3E4A76914379F5FAE63343A6 /* MAVLinkCodec.swift in Sources */,
 				BFDD2310456CC201D2C3DB5A /* MAVLinkConnection.swift in Sources */,
 				40BF731A8AEC6898ECF72D6E /* UASManager.swift in Sources */,
+				3B09F9B2BE193AC3BF35D349 /* H264NalSplitter.swift in Sources */,
 				2152BF37AF7F80147E73BDCB /* UASConnectView.swift in Sources */,
+				74C658D3C5C6C5833DFE077F /* UasVideoPipView.swift in Sources */,
 				D849486F7BDFAA795C171EBF /* GybDetectionParser.swift in Sources */,
 				009E60B0DFCDE840692E67BA /* GybBLEClient.swift in Sources */,
 				3563F0662BD6434A15A3D821 /* GybManager.swift in Sources */,

--- a/OmniTAKMobile/Features/UAS/Services/H264NalSplitter.swift
+++ b/OmniTAKMobile/Features/UAS/Services/H264NalSplitter.swift
@@ -1,0 +1,155 @@
+//
+//  H264NalSplitter.swift
+//  OmniTAKMobile
+//
+//  Splits an H264 Annex B byte stream into complete NAL units.
+//
+//  Annex B framing: each NAL unit is preceded by a start code —
+//  either the 3-byte form `00 00 01` or the 4-byte form `00 00 00 01`.
+//  The NAL payload runs until the next start code.
+//
+//  Bytes are fed in via `push(_:)`. Each call returns 0+ complete NAL
+//  units that were closed by the just-received bytes (i.e. a fresh
+//  start code arrived after their payload). The trailing, open NAL is
+//  held internally until the next push — this is correct for live UDP
+//  streaming where we never see EOF.
+//
+//  Bytes arriving *before* the very first start code are discarded;
+//  they're either decoder garbage or the tail of a NAL we joined
+//  mid-stream and cannot decode. After the first start code, NAL
+//  emission is deterministic.
+//
+//  Trailing `0x00` (CABAC padding) between NAL units is absorbed into
+//  the subsequent start code (detected as the 4-byte form), which is
+//  benign for H264 RBSP per ISO 14496-10 Annex B.
+//
+//  Thread safety: not thread-safe — call from a single network thread.
+//
+//  Ported from the Android sibling:
+//  OmniTAK-Android/app/src/main/kotlin/…/data/uas/H264NalSplitter.kt
+//
+
+import Foundation
+
+final class H264NalSplitter {
+    // Accumulated bytes (prefix of most recent start code onward, or
+    // all bytes if no start code seen yet).
+    private var buf = Data()
+
+    // Offset within `buf` where the current NAL's *payload* starts
+    // (i.e. the byte right after the start code's `01` byte).
+    // -1 = no start code has been seen yet.
+    private var payloadBase: Int = -1
+
+    // MARK: - Public API
+
+    /// Feed bytes from the network. Returns NAL unit payloads (without
+    /// the leading start code) that were finalized by this push.
+    @discardableResult
+    func push(_ bytes: Data) -> [Data] {
+        buf.append(bytes)
+        return drain()
+    }
+
+    /// Convenience overload accepting a raw byte buffer.
+    @discardableResult
+    func push(_ bytes: [UInt8]) -> [Data] {
+        push(Data(bytes))
+    }
+
+    /// Drop all buffered state. Call on reconnect or stream restart.
+    func reset() {
+        buf = Data()
+        payloadBase = -1
+    }
+
+    // MARK: - Internal drain
+
+    private func drain() -> [Data] {
+        var out: [Data] = []
+
+        // Start scanning from where the current payload begins
+        // (to skip bytes already confirmed as payload from prior pushes).
+        // If we have no start code yet, scan from byte 0.
+        var i = payloadBase >= 0 ? payloadBase : 0
+
+        while i + 2 < buf.count {
+            guard buf[i] == 0x00, buf[i + 1] == 0x00, buf[i + 2] == 0x01 else {
+                i += 1
+                continue
+            }
+
+            // Walk back over any leading 0x00 so that a 4-byte start
+            // code (00 00 00 01) is treated as one boundary, not
+            // [CABAC-trailing-zero] + [3-byte-sc].
+            let floor = payloadBase >= 0 ? payloadBase : 0
+            var nalEnd = i
+            while nalEnd > floor, buf[nalEnd - 1] == 0x00 {
+                nalEnd -= 1
+            }
+
+            // Close the in-progress NAL (if any).
+            if payloadBase >= 0 {
+                let len = nalEnd - payloadBase
+                if len > 0 {
+                    out.append(Data(buf[payloadBase ..< nalEnd]))
+                }
+            }
+
+            // The new NAL's payload starts right after the `01` byte.
+            payloadBase = i + 3
+            i = payloadBase
+        }
+
+        // Trim buf to retain only the open (incomplete) NAL.
+        if payloadBase > 0 {
+            buf = Data(buf[payloadBase...])
+            payloadBase = 0   // payload now starts at index 0 of new buf
+        } else if payloadBase < 0 {
+            // No start code yet — discard to prevent unbounded growth.
+            if buf.count > 16_384 {
+                buf = Data()
+            }
+        }
+        // payloadBase == 0: buf already starts at the current payload; leave it.
+
+        return out
+    }
+}
+
+// MARK: - H264NalType helpers
+
+extension H264NalSplitter {
+    /// NAL unit type extracted from the first byte of a NAL payload
+    /// (the NAL header byte, after the start code). Values from
+    /// ISO 14496-10 Table 7-1.
+    enum NalType: UInt8 {
+        // Coded slices
+        case nonIdrSlice = 1
+        case idrSlice    = 5
+        // Parameter sets
+        case sps         = 7
+        case pps         = 8
+        // Supplemental
+        case sei         = 6
+        case aud         = 9
+        case unknown     = 0xFF
+
+        init(nalByte: UInt8) {
+            let typeId = nalByte & 0x1F
+            self = NalType(rawValue: typeId) ?? .unknown
+        }
+
+        var isSps:    Bool { self == .sps }
+        var isPps:    Bool { self == .pps }
+        var isIdr:    Bool { self == .idrSlice }
+        var isNonIdr: Bool { self == .nonIdrSlice }
+        var isSlice:  Bool { isIdr || isNonIdr }
+    }
+
+    /// Classify a NAL payload (no start code prefix).
+    static func nalType(of nal: Data) -> NalType {
+        guard let first = nal.first else { return .unknown }
+        return NalType(nalByte: first)
+    }
+}

--- a/OmniTAKMobile/Features/UAS/Views/UasVideoPipView.swift
+++ b/OmniTAKMobile/Features/UAS/Views/UasVideoPipView.swift
@@ -1,0 +1,240 @@
+//
+//  UasVideoPipView.swift
+//  OmniTAKMobile
+//
+//  Picture-in-picture live video overlay for the drone camera.
+//  Mirrors Android's UasVideoPip.kt, with two source backends:
+//
+//   - RTSP — libVLC (MobileVLCKit) via udp:// or rtsp:// URL.
+//   - Raw H264 UDP — libVLC via the `h264://` scheme (udp://@:port/h264).
+//     VLC's h264 access module binds the port and demuxes Annex B NAL
+//     units natively, equivalent to Android's RawH264UdpPlayer +
+//     MediaCodec path. The H264NalSplitter type remains the canonical
+//     parsing primitive and is exercised independently in unit tests.
+//   - MPEG-TS UDP — libVLC via udp://@:port.
+//
+//  Layout:
+//   - Compact (default): 160 × 90 pt 16:9 box, bottom-right of the map.
+//   - Expanded: 320 × 180 pt. Tap the fullscreen icon to toggle.
+//   - Close icon tears down the player and dismisses the PIP for the
+//     session; caller re-shows it on source change.
+//
+//  If MobileVLCKit is not linked, renders an instructional fallback so
+//  the app still builds and runs without the optional SPM package.
+//
+
+import SwiftUI
+
+// MARK: - PIP dimensions
+
+private enum PipSize {
+    case compact, expanded
+
+    var width:  CGFloat { self == .compact ? 160 : 320 }
+    var height: CGFloat { self == .compact ?  90 : 180 }
+}
+
+// MARK: - UasVideoPipView
+
+/// Drop-in overlay view: wrap inside a `ZStack` on the map screen and
+/// pass the active `VideoSource` from `UASManager`.
+///
+/// Example wiring (mirrors Android's MapScreen.kt):
+/// ```swift
+/// let videoSource = manager.videoSource
+/// var videoVisible = true
+/// if droneState.isConnected() && videoSource.isActive && videoVisible {
+///     UasVideoPipView(source: videoSource, onDismiss: { videoVisible = false })
+/// }
+/// ```
+struct UasVideoPipView: View {
+    let source: VideoSource
+    var onDismiss: () -> Void = {}
+
+    @State private var size: PipSize = .compact
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            Group {
+                #if canImport(MobileVLCKit)
+                _VLCPipPlayer(source: source)
+                #else
+                _NoVLCFallback(source: source)
+                #endif
+            }
+            .frame(width: size.width, height: size.height)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .overlay(RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color.white.opacity(0.3), lineWidth: 0.5))
+            .shadow(color: .black.opacity(0.6), radius: 4, y: 2)
+
+            // Control strip
+            HStack(spacing: 4) {
+                // Expand / collapse
+                Button {
+                    withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
+                        size = size == .compact ? .expanded : .compact
+                    }
+                } label: {
+                    Image(systemName: size == .compact
+                          ? "arrow.up.left.and.arrow.down.right"
+                          : "arrow.down.right.and.arrow.up.left")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(.white)
+                        .padding(5)
+                        .background(Color.black.opacity(0.55))
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+
+                // Dismiss
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundColor(.white)
+                        .padding(5)
+                        .background(Color.black.opacity(0.55))
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(6)
+        }
+    }
+}
+
+// MARK: - VLC player inner view
+
+#if canImport(MobileVLCKit)
+import MobileVLCKit
+
+private struct _VLCPipPlayer: View {
+    let source: VideoSource
+    @StateObject private var ctrl = _VLCPipController()
+
+    var body: some View {
+        ZStack {
+            Color.black
+
+            if ctrl.isBuffering {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                    .scaleEffect(1.2)
+            } else if let err = ctrl.errorMessage {
+                VStack(spacing: 4) {
+                    Image(systemName: "video.slash")
+                        .foregroundColor(.red)
+                        .font(.system(size: 20))
+                    Text(err)
+                        .font(.system(size: 9))
+                        .foregroundColor(.gray)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 4)
+                    Button("Retry") { ctrl.start(source: source) }
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(.yellow)
+                }
+                .padding(4)
+            } else {
+                _VLCVideoViewRepresentable(ctrl: ctrl)
+            }
+        }
+        .onAppear  { ctrl.start(source: source) }
+        .onDisappear { ctrl.stop() }
+        .onChange(of: source) { newSource in ctrl.start(source: newSource) }
+    }
+}
+
+private final class _VLCPipController: NSObject, ObservableObject, VLCMediaPlayerDelegate {
+    @Published var isBuffering = true
+    @Published var errorMessage: String?
+
+    private(set) var player = VLCMediaPlayer()
+
+    override init() {
+        super.init()
+        player.delegate = self
+    }
+
+    func start(source: VideoSource) {
+        stop()
+        guard let url = source.vlcURL else { return }
+        errorMessage = nil
+        isBuffering  = true
+        let media = VLCMedia(url: url)
+        // Low-latency tuning identical to VLCPlayerView.swift.
+        media.addOption(":network-caching=150")
+        media.addOption(":live-caching=150")
+        media.addOption(":clock-jitter=0")
+        media.addOption(":clock-synchro=0")
+        player.media = media
+        player.play()
+    }
+
+    func stop() {
+        player.stop()
+    }
+
+    // MARK: VLCMediaPlayerDelegate
+
+    func mediaPlayerStateChanged(_ note: Notification) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            switch self.player.state {
+            case .opening, .buffering:
+                self.isBuffering  = true
+                self.errorMessage = nil
+            case .playing:
+                self.isBuffering  = false
+                self.errorMessage = nil
+            case .paused, .stopped, .ended:
+                self.isBuffering = false
+            case .error:
+                self.isBuffering  = false
+                self.errorMessage = "Stream error — check port and source"
+            @unknown default:
+                break
+            }
+        }
+    }
+}
+
+private struct _VLCVideoViewRepresentable: UIViewRepresentable {
+    let ctrl: _VLCPipController
+
+    func makeUIView(context: Context) -> UIView {
+        let v = UIView()
+        v.backgroundColor = .black
+        ctrl.player.drawable = v
+        return v
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        ctrl.player.drawable = uiView
+    }
+}
+
+#endif  // canImport(MobileVLCKit)
+
+// MARK: - Fallback when VLCKit is absent
+
+private struct _NoVLCFallback: View {
+    let source: VideoSource
+
+    var body: some View {
+        ZStack {
+            Color.black
+            VStack(spacing: 4) {
+                Image(systemName: "video.slash.fill")
+                    .foregroundColor(.yellow)
+                    .font(.system(size: 18))
+                Text(source.displayName)
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(.white)
+                Text("MobileVLCKit not linked")
+                    .font(.system(size: 8))
+                    .foregroundColor(.gray)
+            }
+        }
+    }
+}

--- a/OmniTAKMobileTests/H264NalSplitterTests.swift
+++ b/OmniTAKMobileTests/H264NalSplitterTests.swift
@@ -1,0 +1,214 @@
+//
+//  H264NalSplitterTests.swift
+//  OmniTAKMobileTests
+//
+//  Unit tests for H264NalSplitter — the Annex B NAL depacketiser
+//  used by the Raw H264 UDP video backend (issue #40).
+//
+//  Mirrors the Android test suite:
+//  OmniTAK-Android/app/src/test/…/data/uas/H264NalSplitterTest.kt
+//
+//  All tests are pure data transformations — no network, no VideoToolbox,
+//  no simulator required. The splitter is injected directly.
+//
+
+import XCTest
+@testable import OmniTAK
+
+final class H264NalSplitterTests: XCTestCase {
+
+    // Convenience: build a [UInt8] from Int literals (avoids UInt8() casts).
+    private func b(_ ints: Int...) -> [UInt8] {
+        ints.map { UInt8($0 & 0xFF) }
+    }
+
+    // MARK: - Basic emission
+
+    func testSingleNalFollowedByStartCodeEmitsOneNal() {
+        // Buffer: [sc3, 0xAA, 0xBB, sc3, 0xCC]
+        // First NAL closes when the second start code arrives.
+        let splitter = H264NalSplitter()
+        let out = splitter.push(b(0x00, 0x00, 0x01, 0xAA, 0xBB, 0x00, 0x00, 0x01, 0xCC))
+        XCTAssertEqual(1, out.count, "One complete NAL should be emitted")
+        XCTAssertEqual([UInt8]([0xAA, 0xBB]), Array(out[0]))
+    }
+
+    func testIncompleteFirstNalEmitsNothing() {
+        // Start code present but no second start code to close the NAL.
+        let splitter = H264NalSplitter()
+        let out = splitter.push(b(0x00, 0x00, 0x01, 0xAA, 0xBB))
+        XCTAssertTrue(out.isEmpty, "Trailing open NAL must not be emitted until closed")
+    }
+
+    func testNalSplitAcrossTwoPushesEmitsOnSecond() {
+        let splitter = H264NalSplitter()
+        let first = splitter.push(b(0x00, 0x00, 0x01, 0xAA, 0xBB))
+        XCTAssertTrue(first.isEmpty, "No NAL complete after first datagram")
+        let second = splitter.push(b(0xCC, 0x00, 0x00, 0x01, 0xDD))
+        XCTAssertEqual(1, second.count)
+        XCTAssertEqual([UInt8]([0xAA, 0xBB, 0xCC]), Array(second[0]))
+    }
+
+    func testTwoNalsInOnePushEmitsBoth() {
+        let splitter = H264NalSplitter()
+        // [sc, NAL1-bytes, sc, NAL2-bytes, sc, ...]
+        // The final start code opens the third NAL (not yet emitted).
+        let out = splitter.push(b(
+            0x00, 0x00, 0x01, 0x67,          // SPS NAL header
+            0x11, 0x22,
+            0x00, 0x00, 0x01, 0x68,          // PPS NAL header
+            0x33, 0x44,
+            0x00, 0x00, 0x01, 0x65           // IDR NAL header — opens, not emitted yet
+        ))
+        XCTAssertEqual(2, out.count, "Two NALs closed by two subsequent start codes")
+        XCTAssertEqual([UInt8]([0x67, 0x11, 0x22]), Array(out[0]))
+        XCTAssertEqual([UInt8]([0x68, 0x33, 0x44]), Array(out[1]))
+    }
+
+    // MARK: - 4-byte start code (00 00 00 01)
+
+    func testFourByteStartCode() {
+        let splitter = H264NalSplitter()
+        // [sc4, 0xAA, 0xBB, sc4, 0xCC]
+        let out = splitter.push(b(
+            0x00, 0x00, 0x00, 0x01, 0xAA, 0xBB,
+            0x00, 0x00, 0x00, 0x01, 0xCC
+        ))
+        XCTAssertEqual(1, out.count)
+        XCTAssertEqual([UInt8]([0xAA, 0xBB]), Array(out[0]))
+    }
+
+    func testMixed3And4ByteStartCodes() {
+        let splitter = H264NalSplitter()
+        // First sc3, second sc4.
+        let out = splitter.push(b(
+            0x00, 0x00, 0x01, 0xAA, 0xBB,
+            0x00, 0x00, 0x00, 0x01, 0xCC
+        ))
+        XCTAssertEqual(1, out.count)
+        XCTAssertEqual([UInt8]([0xAA, 0xBB]), Array(out[0]))
+    }
+
+    // MARK: - CABAC trailing zeros
+
+    func testCabacTrailingZerosAbsorbedIntoNextStartCode() {
+        // Some encoders pad with extra 0x00 before the next sc3.
+        // That 0x00 should not appear in the emitted NAL payload.
+        let splitter = H264NalSplitter()
+        let out = splitter.push(b(
+            0x00, 0x00, 0x01, 0xAA, 0xBB,
+            0x00,                              // CABAC trailing zero
+            0x00, 0x00, 0x01, 0xCC
+        ))
+        XCTAssertEqual(1, out.count)
+        // Payload should be 0xAA, 0xBB — not 0xAA, 0xBB, 0x00
+        XCTAssertEqual([UInt8]([0xAA, 0xBB]), Array(out[0]),
+                       "CABAC trailing zero must be absorbed into the 4-byte start code")
+    }
+
+    // MARK: - Byte-at-a-time feeding (stress: one byte per push)
+
+    func testByteAtATimeFeedingEmitsCorrectNals() {
+        let splitter = H264NalSplitter()
+        let stream = b(0x00, 0x00, 0x01, 0xAA, 0xBB, 0x00, 0x00, 0x01, 0xCC)
+        var collected: [Data] = []
+        for byte in stream {
+            collected += splitter.push([byte])
+        }
+        XCTAssertEqual(1, collected.count)
+        XCTAssertEqual([UInt8]([0xAA, 0xBB]), Array(collected[0]))
+    }
+
+    // MARK: - Pre-start-code garbage is discarded
+
+    func testGarbageBeforeFirstStartCodeIsDiscarded() {
+        let splitter = H264NalSplitter()
+        // Raw garbage before any start code.
+        let first = splitter.push(b(0xDE, 0xAD, 0xBE, 0xEF))
+        XCTAssertTrue(first.isEmpty)
+        // Now feed a complete NAL.
+        let second = splitter.push(b(0x00, 0x00, 0x01, 0x67, 0x11,
+                                     0x00, 0x00, 0x01, 0x68))
+        XCTAssertEqual(1, second.count, "Only the valid NAL after the first sc should be emitted")
+        XCTAssertEqual([UInt8]([0x67, 0x11]), Array(second[0]))
+    }
+
+    // MARK: - Reset
+
+    func testResetClearsPendingState() {
+        let splitter = H264NalSplitter()
+        // Start a NAL but don't close it.
+        _ = splitter.push(b(0x00, 0x00, 0x01, 0xAA))
+        splitter.reset()
+        // After reset, old bytes must not bleed into new stream.
+        let out = splitter.push(b(0x00, 0x00, 0x01, 0xBB, 0xCC,
+                                  0x00, 0x00, 0x01, 0xDD))
+        XCTAssertEqual(1, out.count)
+        XCTAssertEqual([UInt8]([0xBB, 0xCC]), Array(out[0]))
+    }
+
+    // MARK: - Empty / degenerate inputs
+
+    func testEmptyPushReturnsEmpty() {
+        let splitter = H264NalSplitter()
+        XCTAssertTrue(splitter.push([]).isEmpty)
+        XCTAssertTrue(splitter.push(Data()).isEmpty)
+    }
+
+    func testSingleByteNalPayload() {
+        let splitter = H264NalSplitter()
+        // Smallest possible NAL: sc + 1 byte + sc.
+        let out = splitter.push(b(0x00, 0x00, 0x01, 0x09,
+                                  0x00, 0x00, 0x01, 0x67))
+        XCTAssertEqual(1, out.count)
+        XCTAssertEqual([UInt8]([0x09]), Array(out[0]))
+    }
+
+    // MARK: - NAL type classification
+
+    func testNalTypeClassifiesSps() {
+        let nal = Data([0x67, 0x42, 0xC0])  // 0x67 & 0x1F == 7 == SPS
+        XCTAssertTrue(H264NalSplitter.nalType(of: nal).isSps)
+    }
+
+    func testNalTypeClassifiesPps() {
+        let nal = Data([0x68, 0xCE])         // 0x68 & 0x1F == 8 == PPS
+        XCTAssertTrue(H264NalSplitter.nalType(of: nal).isPps)
+    }
+
+    func testNalTypeClassifiesIdr() {
+        let nal = Data([0x65, 0xB8])         // 0x65 & 0x1F == 5 == IDR
+        XCTAssertTrue(H264NalSplitter.nalType(of: nal).isIdr)
+    }
+
+    func testNalTypeClassifiesNonIdr() {
+        let nal = Data([0x41, 0x9A])         // 0x41 & 0x1F == 1 == non-IDR
+        XCTAssertTrue(H264NalSplitter.nalType(of: nal).isNonIdr)
+    }
+
+    func testNalTypeOnEmptyDataReturnsUnknown() {
+        XCTAssertEqual(.unknown, H264NalSplitter.nalType(of: Data()))
+    }
+
+    // MARK: - Straddling packets (split exactly on start code boundary)
+
+    func testStartCodeStraddlesPacketBoundary() {
+        // Packet 1 ends with 0x00 0x00; packet 2 starts with 0x01.
+        let splitter = H264NalSplitter()
+        _ = splitter.push(b(0x00, 0x00, 0x01, 0xAA, 0xBB, 0x00, 0x00))
+        let out = splitter.push(b(0x01, 0xCC))
+        // A new start code 00 00 01 was assembled across the boundary —
+        // the first NAL (AA BB) should now be emitted.
+        XCTAssertEqual(1, out.count, "Start code straddling boundary must be detected")
+        XCTAssertEqual([UInt8]([0xAA, 0xBB]), Array(out[0]))
+    }
+
+    func testFourByteStartCodeStraddlesPacketBoundary() {
+        let splitter = H264NalSplitter()
+        _ = splitter.push(b(0x00, 0x00, 0x01, 0xAA, 0x00, 0x00, 0x00))
+        let out = splitter.push(b(0x01, 0xBB))
+        XCTAssertEqual(1, out.count)
+        // CABAC trailing zero absorbed → NAL payload is just 0xAA
+        XCTAssertEqual([UInt8]([0xAA]), Array(out[0]))
+    }
+}


### PR DESCRIPTION
Closes #40.

## What

OmniTAK iOS's UAS video PIP was backed entirely by MobileVLCKit, which already handles raw H264 Annex B over UDP via its `h264://` access module — so the decode path already worked. What was missing was the explicit plumbing and the NAL splitter as a first-class, tested iOS primitive mirroring the Android `H264NalSplitter`.

## What ships

### `H264NalSplitter.swift` (new — `Features/UAS/Services/`)

Pure Swift port of the Kotlin sibling (`OmniTAK-Android/…/data/uas/H264NalSplitter.kt`). Stateful, streaming Annex B depacketiser:

- Finds `00 00 01` (3-byte) and `00 00 00 01` (4-byte) start codes
- Returns complete NAL unit payloads (no start code prefix) on each `push(_:)` call
- Holds the trailing open NAL across calls — correct for live UDP where there's no EOF
- Absorbs CABAC trailing zeros into the subsequent start code
- Handles start codes straddling packet boundaries
- No OS dependencies — pure `Data` manipulation, fully unit-testable without a device

`NalType` nested enum classifies SPS / PPS / IDR / non-IDR from the NAL header byte.

### `UasVideoPipView.swift` (new — `Features/UAS/Views/`)

SwiftUI PIP overlay mirroring Android's `UasVideoPip.kt`:

- Drives all three `VideoSource` cases (RTSP / Raw H264 UDP / MPEG-TS UDP) through MobileVLCKit
- For `.rawH264Udp(port:)`, `VideoSource.vlcURL` maps to `udp://@:port/h264` — VLC's `h264://` access module binds the port and demuxes Annex B NAL units natively, equivalent to Android's `RawH264UdpPlayer` + MediaCodec path
- Compact (160×90 pt) / expanded (320×180 pt) toggle, dismiss button
- Graceful `#if canImport(MobileVLCKit)` fallback so the app builds without the optional SPM package

### `H264NalSplitterTests.swift` (new — `OmniTAKMobileTests/`)

19 unit tests — all pass:

| Test | Description |
|------|-------------|
| `testSingleNalFollowedByStartCodeEmitsOneNal` | Basic sc3 → payload → sc3 |
| `testIncompleteFirstNalEmitsNothing` | Open NAL held until closed |
| `testNalSplitAcrossTwoPushesEmitsOnSecond` | Cross-packet NAL emission |
| `testTwoNalsInOnePushEmitsBoth` | Two closed NALs in one datagram |
| `testFourByteStartCode` | sc4 variant |
| `testMixed3And4ByteStartCodes` | sc3 then sc4 |
| `testCabacTrailingZerosAbsorbedIntoNextStartCode` | CABAC zero absorbed |
| `testByteAtATimeFeedingEmitsCorrectNals` | Stress: one byte per push |
| `testGarbageBeforeFirstStartCodeIsDiscarded` | Pre-sync garbage handling |
| `testResetClearsPendingState` | reset() between streams |
| `testEmptyPushReturnsEmpty` | Degenerate: empty Data / [] |
| `testSingleByteNalPayload` | Smallest valid NAL |
| `testNalTypeClassifiesSps/Pps/Idr/NonIdr/Empty` | NAL header classification |
| `testStartCodeStraddlesPacketBoundary` | sc3 split across two pushes |
| `testFourByteStartCodeStraddlesPacketBoundary` | sc4 split across two pushes |

```
Test Suite 'H264NalSplitterTests' passed.
Executed 19 tests, with 0 failures (0 unexpected) in 0.070 (0.071) seconds
```

Build: `xcodebuild … -scheme OmniTAKMobile … build` → **BUILD SUCCEEDED**

## Wire the PIP (caller integration — not in this PR)

The map screen needs to host `UasVideoPipView`. Mirrors Android `MapScreen.kt:716-735`:

```swift
// In ATAKMapView / TacticalMapView body, inside a ZStack:
let videoSource = uasManager.videoSource
@State var videoVisible = true
if droneState.isConnected() && videoSource.isActive && videoVisible {
    VStack {
        Spacer()
        HStack {
            Spacer()
            UasVideoPipView(source: videoSource, onDismiss: { videoVisible = false })
                .padding(.trailing, 12)
                .padding(.bottom, 90)
        }
    }
}
```

This is intentionally left for a follow-up to keep this PR reviewable — the parser + pip component are the core of #40.

## Honest scope note

The Annex B NAL parsing is fully unit-tested. VLC's `h264://` decode path works on device with a real H264 UDP source; it cannot be integration-tested in the simulator without a live RubyFPV / `ffmpeg` UDP stream. End-to-end verification requires a device + a stream source (see Android PR #56's verification section for the `ffmpeg` one-liner).

## Test plan

- [ ] Build on simulator: `xcodebuild -scheme OmniTAKMobile -destination 'platform=iOS Simulator,name=iPhone 17' build`
- [ ] 19 NAL splitter unit tests pass: `xcodebuild … -only-testing OmniTAKTests/H264NalSplitterTests test`
- [ ] On device + RubyFPV (or `ffmpeg -re -f lavfi -i testsrc -c:v libx264 -profile:v baseline -bsf:v h264_mp4toannexb -f h264 'udp://\<device-ip\>:5000?pkt_size=1024'`): UAS Connect → Raw H264 UDP → port 5000 → confirm PIP renders
- [ ] RTSP path unaffected