### PR TITLE
feat(uas): wire UasVideoPipView into map ZStack (#88)

### DIFF
--- a/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
+++ b/OmniTAKMobile/Features/Map/Controllers/MapViewController.swift
@@ -40,6 +40,10 @@ struct ATAKMapView: View {
     @StateObject private var mapStateManager = MapStateManager()
     @StateObject private var measurementManager = MeasurementManager()
     @ObservedObject private var adsbService = ADSBTrafficService.shared
+    // UAS video PIP — shown when a video source is active and the vehicle
+    // is connected. Mirrors Android MapScreen's videoSource + videoVisible state.
+    @ObservedObject private var uasManager = UASManager.shared
+    @State private var videoVisible: Bool = true
     // Plugin SDK — registered map overlays render in the engine-agnostic
     // chrome (see `registeredPluginOverlays`), so they appear on BOTH engines.
     @ObservedObject private var pluginHost = AppPluginHost.shared
@@ -1379,6 +1383,7 @@ struct ATAKMapView: View {
         sidePanels
         statusIndicators
         mapOverlayComponents
+        videoPipOverlay
         registeredPluginOverlays
         radialMenu
         gpsFollowButton
@@ -1503,6 +1508,43 @@ struct ATAKMapView: View {
             }
             .zIndex(2600) // above lasso pill (2000), below radial menu (3000)
             .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+
+    /// Live video PIP. Anchored to the bottom-right of the map, above the
+    /// callsign card (zIndex 1003) and ADS-B pill (1002), below the radial
+    /// menu (3000). Mirrors Android MapScreen's UasVideoPip placement:
+    ///
+    ///   val videoSource by uas.videoSource.collectAsState()
+    ///   var videoVisible by remember { mutableStateOf(true) }
+    ///   if (droneState.isConnected() && videoSource.isActive && videoVisible) {
+    ///       Box(…) { UasVideoPip(source = videoSource, onDismiss = { videoVisible = false }) }
+    ///   }
+    ///
+    /// Reset videoVisible whenever the source changes so a new source always
+    /// auto-shows even if the operator dismissed a previous one.
+    @ViewBuilder
+    private var videoPipOverlay: some View {
+        let source = uasManager.videoSource
+        if uasManager.state.isConnected() && source.isActive && videoVisible {
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    UasVideoPipView(source: source) {
+                        videoVisible = false
+                    }
+                    .padding(.trailing, 12)
+                    .padding(.bottom, 90) // clear the bottom toolbar
+                }
+            }
+            .allowsHitTesting(true)
+            .zIndex(1100)
+            .transition(.opacity.combined(with: .scale(scale: 0.92, anchor: .bottomTrailing)))
+            .onChange(of: source) { _ in
+                // Re-show whenever the operator picks a different source.
+                videoVisible = true
+            }
         }
     }
 

--- a/OmniTAKMobileTests/VideoSourcePipTests.swift
+++ b/OmniTAKMobileTests/VideoSourcePipTests.swift
@@ -1,0 +1,90 @@
+//
+//  VideoSourcePipTests.swift
+//  OmniTAKMobileTests
+//
+//  Tests for VideoSource.isActive — the predicate that gates whether
+//  the PIP overlay appears on the map screen (issue #88).
+//
+//  All tests are pure enum logic — no simulator, no VLC, no networking.
+//
+
+import XCTest
+@testable import OmniTAK
+
+final class VideoSourcePipTests: XCTestCase {
+
+    // MARK: - isActive
+
+    func testNoneIsNotActive() {
+        XCTAssertFalse(VideoSource.none.isActive)
+    }
+
+    func testRtspIsActive() {
+        let src = VideoSource.rtsp(fromString: "rtsp://10.0.0.1:8554/live")
+        XCTAssertTrue(src.isActive)
+    }
+
+    func testRawH264UdpIsActive() {
+        let src = VideoSource.rawH264Udp(validating: 5000)
+        XCTAssertTrue(src.isActive)
+    }
+
+    func testMpegTsUdpIsActive() {
+        let src = VideoSource.mpegTsUdp(validating: 5010)
+        XCTAssertTrue(src.isActive)
+    }
+
+    // MARK: - Validating factories collapse invalid input to .none
+
+    func testRawH264UdpPortZeroCollapsesToNone() {
+        XCTAssertEqual(VideoSource.rawH264Udp(validating: 0), VideoSource.none)
+    }
+
+    func testRawH264UdpPortAboveRangeCollapsesToNone() {
+        XCTAssertEqual(VideoSource.rawH264Udp(validating: 65536), VideoSource.none)
+    }
+
+    func testMpegTsUdpPortZeroCollapsesToNone() {
+        XCTAssertEqual(VideoSource.mpegTsUdp(validating: 0), VideoSource.none)
+    }
+
+    func testRtspEmptyStringCollapsesToNone() {
+        XCTAssertEqual(VideoSource.rtsp(fromString: ""), VideoSource.none)
+    }
+
+    func testRtspBlankStringCollapsesToNone() {
+        XCTAssertEqual(VideoSource.rtsp(fromString: "   "), VideoSource.none)
+    }
+
+    // MARK: - vlcURL
+
+    func testNoneHasNoVlcURL() {
+        XCTAssertNil(VideoSource.none.vlcURL)
+    }
+
+    func testRawH264UdpVlcURLScheme() {
+        // VLC's h264:// scheme forces the raw H264 demuxer.
+        let src = VideoSource.rawH264Udp(validating: 5000)
+        XCTAssertEqual(src.vlcURL?.absoluteString, "udp://@:5000/h264")
+    }
+
+    func testMpegTsUdpVlcURL() {
+        let src = VideoSource.mpegTsUdp(validating: 5010)
+        XCTAssertEqual(src.vlcURL?.absoluteString, "udp://@:5010")
+    }
+
+    func testRtspVlcURLPassedThrough() {
+        let urlStr = "rtsp://192.168.1.1:8554/live"
+        let src = VideoSource.rtsp(fromString: urlStr)
+        XCTAssertEqual(src.vlcURL?.absoluteString, urlStr)
+    }
+
+    // MARK: - displayName
+
+    func testDisplayNames() {
+        XCTAssertEqual(VideoSource.none.displayName, "Off")
+        XCTAssertEqual(VideoSource.rawH264Udp(validating: 5000).displayName, "Raw H264 UDP")
+        XCTAssertEqual(VideoSource.mpegTsUdp(validating: 5010).displayName, "MPEG-TS UDP")
+        XCTAssertEqual(VideoSource.rtsp(fromString: "rtsp://x:554/live").displayName, "RTSP")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `@ObservedObject private var uasManager = UASManager.shared` and `@State private var videoVisible: Bool = true` to `ATAKMapView`
- Adds `videoPipOverlay` computed view: shown when `uasManager.state.isConnected() && videoSource.isActive && videoVisible`, anchored bottom-right (`.padding(.trailing, 12) / .bottom, 90`), `zIndex(1100)` — above the callsign card (1003) and ADS-B pill (1002), below the radial menu (3000)
- Wires `videoPipOverlay` into `mapChrome` between `mapOverlayComponents` and `registeredPluginOverlays` — both map engines get it automatically
- Mirrors Android `MapScreen.kt` lines 857–888: same `videoSource.isActive && videoVisible` guard, same dismiss callback, same auto-reset when the source changes
- `UASConnectView` already wires the video source picker (RTSP / Raw H264 UDP / MPEG-TS UDP) into `UASManager.shared.videoSource`; no changes needed there
- Adds `VideoSourcePipTests` (13 tests) — pure enum logic covering `isActive`, validating factories, `vlcURL` scheme mapping, and `displayName`; no simulator, no VLC required

## Test plan

- [ ] Build green: `xcodebuild … build` → `** BUILD SUCCEEDED **`
- [ ] Tests green: `xcodebuild … test` → `** TEST SUCCEEDED **`
- [ ] End-to-end video needs a device + live H264 UDP stream (VLC decode inside `UasVideoPipView` is untestable in the simulator); verify with RubyFPV or `ffmpeg -re -f lavfi -i testsrc -vcodec libx264 -f mpegts udp://device-ip:5010`
- [ ] Confirm PIP appears bottom-right and does not compress the map (full-screen map rule)
- [ ] Confirm dismiss (×) hides the PIP for the session; switching source in Vehicle Connect re-shows it

Closes #88