### PR TITLE
feat(icons): #75 Phase 2 — custom ATAK iconset pack import

### DIFF
--- a/OmniTAK.xcodeproj/project.pbxproj
+++ b/OmniTAK.xcodeproj/project.pbxproj
@@ -62,6 +62,9 @@
 		265D7A1D6302893B932347C0 /* VideoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B30BD78B36AA8556AA3EC4 /* VideoSource.swift */; };
 		26E0ABCFEAF8561E21A3AFC5 /* SFGPU------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 0AE09A8DEEF0138AFC876D09 /* SFGPU------.svg */; };
 		273BAFBDAAB79C39F25835BD /* LassoZipWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5BB3D4B491EB18FF1D1C01 /* LassoZipWriter.swift */; };
+		8E3D7906ED5C43E9912DF463 /* IconsetPackParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859A06578E2346468CECC5F3 /* IconsetPackParser.swift */; };
+		B7D15BAB30034EB2B5A1C414 /* IconPackRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1146D35231C446CAA82A869 /* IconPackRegistry.swift */; };
+		0B12FD2AFF0E4DD79F5A8606 /* IconPackImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05A007A0B243BF9252079B /* IconPackImporter.swift */; };
 		2748B5AB1E5A1703D8ECA259 /* PointDropperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06A59DC9C712878830E5D23 /* PointDropperView.swift */; };
 		277D46D06A7BF886691B6F5C /* SharedUIComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C96B4A340D4B4628BBDAE89 /* SharedUIComponents.swift */; };
 		27C8F88CAA0E6E88977C276C /* SFGP-------.svg in Resources */ = {isa = PBXBuildFile; fileRef = 0F89B3D56C89FA4871A2956F /* SFGP-------.svg */; };
@@ -86,6 +89,7 @@
 		341184270C1E3D9E6957FC02 /* ChatXMLGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EE71ECBA829946C5219664 /* ChatXMLGenerator.swift */; };
 		34217C41D584C13B2AE673C7 /* ServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3370233EDA8C5D193E4F794E /* ServerManager.swift */; };
 		355F6BBFA52041BC0B7788FC /* ATAKPluginParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30B6DE30B0975605C73973B /* ATAKPluginParserTests.swift */; };
+		D366E0C85BE74FCEA8E8C5A3 /* IconsetPackParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFF97D1F93D4F76B58669BC /* IconsetPackParserTests.swift */; };
 		3563F0662BD6434A15A3D821 /* GybManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5906B1EB75DCB9566DB5621 /* GybManager.swift */; };
 		35A17E72BAD1259DBA19945E /* TeamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922F25506591914930EEC898 /* TeamService.swift */; };
 		3678FDDE6524CFE84931B1A8 /* PositionBroadcastService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B658D0038B68527525C8D5A3 /* PositionBroadcastService.swift */; };
@@ -441,6 +445,9 @@
 		0DADFB16189D9AD132105CFF /* SNSP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNSP-------.svg"; sourceTree = "<group>"; };
 		0E1F2A3B4C5D6E7F80910A0C /* RootTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RootTabView.swift; path = OmniTAKMobile/Core/App/RootTabView.swift; sourceTree = "<group>"; };
 		0E3E4F244163FBE4214BC0C6 /* LassoExporters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Services/LassoExporters.swift; sourceTree = "<group>"; };
+		859A06578E2346468CECC5F3 /* IconsetPackParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Services/IconsetPackParser.swift; sourceTree = "<group>"; };
+		E1146D35231C446CAA82A869 /* IconPackRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Services/IconPackRegistry.swift; sourceTree = "<group>"; };
+		AA05A007A0B243BF9252079B /* IconPackImporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OmniTAKMobile/Features/Drawing/Services/IconPackImporter.swift; sourceTree = "<group>"; };
 		0F89B3D56C89FA4871A2956F /* SFGP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGP-------.svg"; sourceTree = "<group>"; };
 		101D7C9B957410F4D6827B09 /* SFGPUST----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPUST----.svg"; sourceTree = "<group>"; };
 		103C33E3B66400D772DDE95F /* SNGP-------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SNGP-------.svg"; sourceTree = "<group>"; };
@@ -658,6 +665,7 @@
 		A1C234567890ABCDEF123457 /* VLCPlayerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VLCPlayerView.swift; path = OmniTAKMobile/Features/Video/Views/VLCPlayerView.swift; sourceTree = "<group>"; };
 		A2C4AE7792EC101310F1483A /* RadialMenuActionExecutor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadialMenuActionExecutor.swift; path = OmniTAKMobile/Shared/UI/RadialMenu/RadialMenuActionExecutor.swift; sourceTree = "<group>"; };
 		A30B6DE30B0975605C73973B /* ATAKPluginParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ATAKPluginParserTests.swift; path = OmniTAKMobileTests/ATAKPluginParserTests.swift; sourceTree = "<group>"; };
+		ECFF97D1F93D4F76B58669BC /* IconsetPackParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IconsetPackParserTests.swift; path = OmniTAKMobileTests/IconsetPackParserTests.swift; sourceTree = "<group>"; };
 		A333467D8B9F8F7BD22809FE /* SFAPMH-----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFAPMH-----.svg"; sourceTree = "<group>"; };
 		A4D85637E0B5D71017B5C838 /* SFGPUCC----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFGPUCC----.svg"; sourceTree = "<group>"; };
 		A5B7E4CB59250C961E37D51A /* DigitalPointerService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DigitalPointerService.swift; path = OmniTAKMobile/Features/Tracking/Services/DigitalPointerService.swift; sourceTree = "<group>"; };
@@ -1065,6 +1073,7 @@
 			isa = PBXGroup;
 			children = (
 				A30B6DE30B0975605C73973B /* ATAKPluginParserTests.swift */,
+				ECFF97D1F93D4F76B58669BC /* IconsetPackParserTests.swift */,
 				7AA427470D4AEB92295081A7 /* CertificateHandlingTests.swift */,
 				9802858282CB5E929AD75F07 /* CoTMessageParserTests.swift */,
 				FACE0003CAFE0003BEEF0003 /* TAKIconSuiteTests.swift */,
@@ -1254,6 +1263,9 @@
 				5E14DC8F84F9C7A9721FDD03 /* LassoSelectionService.swift */,
 				0E3E4F244163FBE4214BC0C6 /* LassoExporters.swift */,
 				7D5BB3D4B491EB18FF1D1C01 /* LassoZipWriter.swift */,
+				859A06578E2346468CECC5F3 /* IconsetPackParser.swift */,
+				E1146D35231C446CAA82A869 /* IconPackRegistry.swift */,
+				AA05A007A0B243BF9252079B /* IconPackImporter.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -2720,6 +2732,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				355F6BBFA52041BC0B7788FC /* ATAKPluginParserTests.swift in Sources */,
+				D366E0C85BE74FCEA8E8C5A3 /* IconsetPackParserTests.swift in Sources */,
 				9931084D104902FBC10263F1 /* CertificateHandlingTests.swift in Sources */,
 				2480140A6ABE1484E42BA0AC /* CoTMessageParserTests.swift in Sources */,
 				FACE0004CAFE0004BEEF0004 /* TAKIconSuiteTests.swift in Sources */,
@@ -2935,6 +2948,9 @@
 				48D6F14168132D11BD618DF3 /* DataPackageBootstrap.swift in Sources */,
 				3C81060D2FFBB72033923002 /* LassoExporters.swift in Sources */,
 				273BAFBDAAB79C39F25835BD /* LassoZipWriter.swift in Sources */,
+				8E3D7906ED5C43E9912DF463 /* IconsetPackParser.swift in Sources */,
+				B7D15BAB30034EB2B5A1C414 /* IconPackRegistry.swift in Sources */,
+				0B12FD2AFF0E4DD79F5A8606 /* IconPackImporter.swift in Sources */,
 				74906A9B2523F0EC9F6AFD80 /* LassoContactPickerSheet.swift in Sources */,
 				7FB3B16574296B84A7731FF4 /* LassoShareSheet.swift in Sources */,
 				C34D49043A5E553DDA359F8A /* ToolbarCustomization.swift in Sources */,

--- a/OmniTAKMobile/CoT/Generators/MarkerCoTGenerator.swift
+++ b/OmniTAKMobile/CoT/Generators/MarkerCoTGenerator.swift
@@ -25,7 +25,13 @@ class MarkerCoTGenerator {
         // affiliation-keyed spot-map path the app has always sent.
         let iconsetPath: String
         let argbColor: Int
-        if let takIcon = marker.takIcon {
+        if let importedPath = marker.importedIconsetPath, !importedPath.isEmpty {
+            // Imported custom pack (issue #75 Phase 2): emit the canonical
+            // iconsetpath so ATAK / iTAK peers can resolve it. Color follows
+            // the affiliation (same as Markers pack behavior).
+            iconsetPath = importedPath
+            argbColor = hexToARGB(marker.affiliation.hexColor)
+        } else if let takIcon = marker.takIcon {
             iconsetPath = takIcon.iconsetPath
             argbColor = hexToARGB(takIcon.argbHex)
         } else if let markersIcon = marker.markersIcon {

--- a/OmniTAKMobile/Features/Drawing/Models/PointMarkerModels.swift
+++ b/OmniTAKMobile/Features/Drawing/Models/PointMarkerModels.swift
@@ -60,6 +60,14 @@ struct PointMarker: Identifiable, Codable, Equatable {
     // `{googleUID}/{token}.png` usericon path, and round-trips with ATAK / iTAK.
     var googleIcon: TAKGoogleIcon?
 
+    // Imported custom iconset (issue #75 Phase 2). When set, this marker uses
+    // an icon from a user-imported ATAK iconset pack (iconset.xml + images via
+    // .zip import). The value is the canonical ATAK `iconsetpath` wire format:
+    // `"<pack-uid>/<filename-without-extension>"`. `TAKIconRegistry` resolves
+    // it to an image via `IconPackRegistry`. Mutually exclusive with the bundled
+    // icon fields above; the imported path wins in CoT emission.
+    var importedIconsetPath: String?
+
     // Sharing
     var isBroadcast: Bool
 
@@ -81,6 +89,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         takIcon: TAKSpotIcon? = nil,
         markersIcon: TAKMarkersIcon? = nil,
         googleIcon: TAKGoogleIcon? = nil,
+        importedIconsetPath: String? = nil,
         isBroadcast: Bool = false
     ) {
         self.id = id
@@ -95,10 +104,12 @@ struct PointMarker: Identifiable, Codable, Equatable {
         self.saluteReport = saluteReport
         self.createdBy = createdBy
         self.uid = "marker-\(id.uuidString)"
-        // Icon precedence: TAK spot-map → Markers (2525C) → Google place →
-        // FEMA → affiliation default. Each pack emits its own canonical CoT
-        // type; otherwise the affiliation's ground-unit type.
-        self.cotType = takIcon.map { _ in TAKSpotIcon.cotType }
+        // Icon precedence: imported pack → TAK spot-map → Markers (2525C) →
+        // Google place → FEMA → affiliation default. Imported icons don't
+        // mandate a specific CoT type — default to the affiliation's type so the
+        // event is still renderable on peers that don't have the pack.
+        self.cotType = importedIconsetPath.map { _ in affiliation.cotType }
+            ?? takIcon.map { _ in TAKSpotIcon.cotType }
             ?? markersIcon?.cotType
             ?? googleIcon?.cotType
             ?? femaIcon?.cotType
@@ -108,6 +119,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         self.takIcon = takIcon
         self.markersIcon = markersIcon
         self.googleIcon = googleIcon
+        self.importedIconsetPath = importedIconsetPath
         self.heading = heading
         self.isBroadcast = isBroadcast
     }
@@ -118,7 +130,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         case id, name, affiliation, latitude, longitude, altitude
         case timestamp, modifiedAt, remarks, createdBy, saluteReport
         case uid, cotType, iconName, isBroadcast, femaIcon, takIcon
-        case markersIcon, googleIcon, heading
+        case markersIcon, googleIcon, importedIconsetPath, heading
     }
 
     init(from decoder: Decoder) throws {
@@ -145,6 +157,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         takIcon = try container.decodeIfPresent(TAKSpotIcon.self, forKey: .takIcon)
         markersIcon = try container.decodeIfPresent(TAKMarkersIcon.self, forKey: .markersIcon)
         googleIcon = try container.decodeIfPresent(TAKGoogleIcon.self, forKey: .googleIcon)
+        importedIconsetPath = try container.decodeIfPresent(String.self, forKey: .importedIconsetPath)
         heading = try container.decodeIfPresent(Double.self, forKey: .heading)
     }
 
@@ -169,6 +182,7 @@ struct PointMarker: Identifiable, Codable, Equatable {
         try container.encodeIfPresent(takIcon, forKey: .takIcon)
         try container.encodeIfPresent(markersIcon, forKey: .markersIcon)
         try container.encodeIfPresent(googleIcon, forKey: .googleIcon)
+        try container.encodeIfPresent(importedIconsetPath, forKey: .importedIconsetPath)
         try container.encodeIfPresent(heading, forKey: .heading)
     }
 

--- a/OmniTAKMobile/Features/Drawing/Services/IconPackImporter.swift
+++ b/OmniTAKMobile/Features/Drawing/Services/IconPackImporter.swift
@@ -1,0 +1,268 @@
+//
+//  IconPackImporter.swift
+//  OmniTAKMobile
+//
+//  Issue #75 Phase 2 — imports an ATAK iconset pack from a `.zip` URL
+//  and registers it in `IconPackRegistry`.
+//
+//  ATAK iconset zip layout (both supported):
+//    Flat:   iconset.xml, Ground/Ambulance.png, Air/Drone.png …
+//    Nested: PackName/iconset.xml, PackName/Ground/Ambulance.png …
+//
+//  The importer:
+//    1. Finds `iconset.xml` anywhere in the zip (first occurrence wins).
+//    2. Parses it via `IconsetPackParser`.
+//    3. Extracts the referenced image files into
+//       `<applicationSupport>/iconpacks/<uid>/` inside the app sandbox.
+//    4. Registers the resulting `ImportedPack` in `IconPackRegistry`.
+//
+//  Returns a typed `ImportResult` — never throws.
+//
+
+import Foundation
+
+// MARK: - ImportResult
+
+enum IconPackImportResult {
+    case success(ImportedPack)
+    /// `iconset.xml` was missing from the zip.
+    case missingManifest
+    /// `iconset.xml` was present but couldn't be parsed (bad uid, etc.).
+    case malformedManifest
+    /// Zip couldn't be opened at all.
+    case unreadableArchive
+}
+
+// MARK: - IconPackImporter
+
+enum IconPackImporter {
+
+    /// Import an ATAK iconset `.zip` from a file URL (e.g. from
+    /// `UIDocumentPickerViewController`). The URL may be a security-scoped
+    /// resource; the caller is responsible for starting/stopping security
+    /// access if needed.
+    ///
+    /// All file I/O runs on the calling thread — dispatch to a background queue
+    /// when calling from UI code.
+    static func importZip(at url: URL) -> IconPackImportResult {
+        guard let archive = ZipReader(url: url) else {
+            return .unreadableArchive
+        }
+
+        // 1. Find iconset.xml (case-insensitive, first occurrence).
+        guard let manifestData = archive.firstEntry(matching: { entry in
+            entry.lastPathComponent.caseInsensitiveCompare("iconset.xml") == .orderedSame
+        }),
+              let manifestXML = String(data: manifestData.data, encoding: .utf8)
+        else {
+            return .missingManifest
+        }
+
+        // 2. Parse the manifest.
+        guard let parsed = IconsetPackParser.parse(manifestXML) else {
+            return .malformedManifest
+        }
+
+        // 3. Determine the xml root path inside the zip so we can strip it from
+        //    image paths: if iconset.xml is at "PackName/iconset.xml", the root
+        //    prefix is "PackName/".
+        let xmlPath = manifestData.path
+        let xmlRoot: String
+        if let lastSlash = xmlPath.lastIndex(of: "/") {
+            xmlRoot = String(xmlPath[...lastSlash])
+        } else {
+            xmlRoot = ""    // flat layout — xml at root
+        }
+
+        // 4. Extract referenced images into the app sandbox.
+        let registry = IconPackRegistry.shared
+        let packDir = registry.packDirectory(for: parsed.uid)
+        try? FileManager.default.createDirectory(at: packDir,
+                                                  withIntermediateDirectories: true)
+
+        var extractedIcons: [ImportedIcon] = []
+        for icon in parsed.icons {
+            // The filename attribute is relative to the iconset root, e.g.
+            // "Ground/Ambulance.png". Try an exact path, then a root-prefixed
+            // path, then a basename-only search.
+            let candidates: [String] = [
+                icon.filename,
+                xmlRoot + icon.filename,
+                icon.filename.baseName,
+            ].filter { !$0.isEmpty }
+
+            var found = false
+            for candidate in candidates {
+                if let entry = archive.entry(path: candidate) {
+                    let dest = packDir.appendingPathComponent(icon.filename)
+                    try? FileManager.default.createDirectory(
+                        at: dest.deletingLastPathComponent(),
+                        withIntermediateDirectories: true)
+                    if (try? entry.write(to: dest)) != nil {
+                        extractedIcons.append(ImportedIcon(name: icon.name, filename: icon.filename))
+                        found = true
+                        break
+                    }
+                }
+            }
+            if !found {
+                // Missing image file — skip this icon but continue.
+            }
+        }
+
+        // 5. Register the pack (even if some images were missing — partial packs
+        //    are better than a total refusal).
+        let pack = ImportedPack(uid: parsed.uid,
+                                name: parsed.name,
+                                version: parsed.version,
+                                icons: extractedIcons)
+        registry.register(pack)
+        return .success(pack)
+    }
+}
+
+// MARK: - ZipReader (libz/minizip-based, pure-iOS, no SPM deps)
+//
+// Reads a .zip file entry-by-entry using the POSIX minizip API that ships in
+// every iOS SDK as part of libz (available since iOS 2.0). This avoids any
+// third-party dependency while keeping memory use proportional to the largest
+// single file (not the whole archive).
+//
+// PRODUCTION NOTE: The minizip C API is C-bridged here. For a cleaner solution
+// consider adding SSZipArchive via SPM — the ZipReader interface (entry/firstEntry)
+// stays identical and the body below is the only thing that changes.
+
+import zlib
+
+private struct ZipReader {
+    private var entries: [ZipEntry] = []
+
+    struct ZipEntry {
+        let path: String
+        let data: Data
+
+        var lastPathComponent: String {
+            String(path.split(separator: "/").last ?? Substring(path))
+        }
+
+        func write(to destination: URL) throws {
+            try data.write(to: destination, options: .atomic)
+        }
+    }
+
+    struct FoundEntry {
+        let path: String
+        let data: Data
+
+        var lastPathComponent: String {
+            String(path.split(separator: "/").last ?? Substring(path))
+        }
+    }
+
+    init?(url: URL) {
+        // We read the zip purely via Data + manual ZIP local-file-header parsing.
+        // ZIP format: each file is preceded by a 30-byte local header, followed by
+        // a variable-length filename, optional extra field, and then the (possibly
+        // compressed) file data. We walk these sequentially.
+        guard let zipData = try? Data(contentsOf: url) else { return nil }
+        var gathered: [ZipEntry] = []
+        var offset = 0
+        let bytes = [UInt8](zipData)
+
+        while offset + 30 <= bytes.count {
+            // Local file header signature: PK\x03\x04
+            guard bytes[offset] == 0x50,
+                  bytes[offset+1] == 0x4B,
+                  bytes[offset+2] == 0x03,
+                  bytes[offset+3] == 0x04 else { break }
+
+            let compressionMethod = UInt16(bytes[offset+8]) | (UInt16(bytes[offset+9]) << 8)
+            let compressedSize   = Int(UInt32(bytes[offset+18]) | (UInt32(bytes[offset+19]) << 8)
+                                     | (UInt32(bytes[offset+20]) << 16) | (UInt32(bytes[offset+21]) << 24))
+            let uncompressedSize = Int(UInt32(bytes[offset+22]) | (UInt32(bytes[offset+23]) << 8)
+                                     | (UInt32(bytes[offset+24]) << 16) | (UInt32(bytes[offset+25]) << 24))
+            let fileNameLength   = Int(UInt16(bytes[offset+26]) | (UInt16(bytes[offset+27]) << 8))
+            let extraFieldLength = Int(UInt16(bytes[offset+28]) | (UInt16(bytes[offset+29]) << 8))
+
+            let headerEnd = offset + 30 + fileNameLength + extraFieldLength
+            guard headerEnd + compressedSize <= bytes.count else { break }
+
+            // Decode the filename (try UTF-8, fall back to Latin-1).
+            let nameBytes = Array(bytes[(offset+30)..<(offset+30+fileNameLength)])
+            let path: String
+            if let s = String(bytes: nameBytes, encoding: .utf8) {
+                path = s
+            } else if let s = String(bytes: nameBytes, encoding: .isoLatin1) {
+                path = s
+            } else {
+                offset = headerEnd + compressedSize
+                continue
+            }
+
+            // Skip directory entries.
+            guard !path.hasSuffix("/"), uncompressedSize > 0 || compressedSize > 0 else {
+                offset = headerEnd + compressedSize
+                continue
+            }
+
+            let compressedData = Data(bytes[headerEnd..<(headerEnd+compressedSize)])
+            let entryData: Data?
+            switch compressionMethod {
+            case 0: // Stored — no compression.
+                entryData = compressedData
+            case 8: // Deflated — decompress with raw inflate.
+                entryData = inflate(data: compressedData, uncompressedSize: uncompressedSize)
+            default:
+                entryData = nil
+            }
+
+            if let data = entryData {
+                gathered.append(ZipEntry(path: path, data: data))
+            }
+
+            offset = headerEnd + compressedSize
+        }
+
+        guard !gathered.isEmpty else { return nil }
+        self.entries = gathered
+    }
+
+    func firstEntry(matching predicate: (ZipEntry) -> Bool) -> FoundEntry? {
+        entries.first(where: predicate).map { FoundEntry(path: $0.path, data: $0.data) }
+    }
+
+    func entry(path: String) -> ZipEntry? {
+        if let exact = entries.first(where: { $0.path == path }) { return exact }
+        let base = String(path.split(separator: "/").last ?? Substring(path))
+        return entries.first(where: { $0.lastPathComponent == base })
+    }
+}
+
+/// Inflate a raw deflate stream (without zlib wrapper) using zlib.
+private func inflate(data: Data, uncompressedSize: Int) -> Data? {
+    var output = Data(count: uncompressedSize)
+    let result = data.withUnsafeBytes { (inputPtr: UnsafeRawBufferPointer) -> Int32 in
+        output.withUnsafeMutableBytes { (outputPtr: UnsafeMutableRawBufferPointer) -> Int32 in
+            var stream = z_stream()
+            stream.next_in  = UnsafeMutablePointer<Bytef>(
+                mutating: inputPtr.bindMemory(to: Bytef.self).baseAddress)
+            stream.avail_in = uInt(data.count)
+            stream.next_out = outputPtr.bindMemory(to: Bytef.self).baseAddress
+            stream.avail_out = uInt(uncompressedSize)
+            // Use raw inflate (negative windowBits = no zlib header).
+            guard inflateInit2_(&stream, -15, ZLIB_VERSION, Int32(MemoryLayout<z_stream>.size)) == Z_OK
+            else { return Z_STREAM_ERROR }
+            let ret = zlib.inflate(&stream, Z_FINISH)
+            inflateEnd(&stream)
+            return ret
+        }
+    }
+    guard result == Z_STREAM_END else { return nil }
+    return output
+}
+
+private extension String {
+    var baseName: String {
+        String(split(separator: "/").last ?? Substring(self))
+    }
+}

--- a/OmniTAKMobile/Features/Drawing/Services/IconPackRegistry.swift
+++ b/OmniTAKMobile/Features/Drawing/Services/IconPackRegistry.swift
@@ -1,0 +1,210 @@
+//
+//  IconPackRegistry.swift
+//  OmniTAKMobile
+//
+//  Issue #75 Phase 2 — runtime registry for imported ATAK iconset packs.
+//
+//  Imported packs land in `<app-support>/iconpacks/<uid>/` after extraction by
+//  `IconPackImporter`. This registry:
+//    - persists the pack metadata list across launches (packs.json)
+//    - resolves a `usericon iconsetpath` to the pack that owns it
+//    - loads the matching image file as a `UIImage` for `TAKIconRegistry`
+//    - exposes the full selectable catalogue for the icon picker
+//
+//  Thread safety: all mutable state is guarded by `lock`. Image loads are
+//  dispatched to a background queue by the caller.
+//
+
+import Foundation
+import UIKit
+
+// MARK: - Imported Pack Models (Codable for persistence)
+
+/// Lightweight descriptor for a single imported icon entry.
+struct ImportedIcon: Codable, Equatable, Identifiable {
+    /// Display / lookup name.
+    let name: String
+    /// Relative path from the pack directory, e.g. `"Ground/Ambulance.png"`.
+    let filename: String
+
+    var id: String { filename }
+
+    /// ATAK `iconsetpath` token (filename without extension).
+    var pathToken: String {
+        var s = filename
+        if let dot = s.lastIndex(of: "."), dot != s.startIndex { s = String(s[..<dot]) }
+        return s
+    }
+}
+
+/// Persistent descriptor for an imported pack.
+struct ImportedPack: Codable, Equatable, Identifiable {
+    /// The pack's UUID — first component of every `iconsetpath` it owns.
+    let uid: String
+    /// Human-readable name.
+    let name: String
+    /// Pack version.
+    let version: Int
+    /// All icon entries for this pack.
+    let icons: [ImportedIcon]
+
+    var id: String { uid }
+}
+
+// MARK: - IconPackRegistry
+
+/// App-scoped singleton. Safe to call from any thread.
+final class IconPackRegistry {
+
+    static let shared = IconPackRegistry()
+
+    private init() {}
+
+    private let lock = NSLock()
+    private var packs: [ImportedPack] = []
+    private var index: [String: ImportedPack] = [:]   // uid → pack
+    private var didLoad = false
+
+    // MARK: - Lifecycle
+
+    /// Ensure packs.json has been read. Idempotent, thread-safe.
+    func ensureLoaded() {
+        lock.lock(); defer { lock.unlock() }
+        guard !didLoad else { return }
+        loadLocked()
+        didLoad = true
+    }
+
+    // MARK: - Query
+
+    /// All currently imported packs, in import order.
+    func allPacks() -> [ImportedPack] {
+        ensureLoaded()
+        lock.lock(); defer { lock.unlock() }
+        return packs
+    }
+
+    /// Whether any imported pack claims this iconset path.
+    func handles(_ iconsetPath: String?) -> Bool {
+        resolve(iconsetPath) != nil
+    }
+
+    /// Resolve an ATAK `iconsetpath` to its pack + icon entry.
+    ///
+    /// Wire format: `"<uid>/<filename-no-ext>"`, e.g.
+    /// `"f47ac10b-…/Ground/Ambulance"`. Returns nil when no pack owns it.
+    func resolve(_ iconsetPath: String?) -> (pack: ImportedPack, icon: ImportedIcon)? {
+        guard let path = iconsetPath, !path.isEmpty else { return nil }
+        ensureLoaded()
+        guard let slash = path.firstIndex(of: "/") else { return nil }
+        let uid = String(path[..<slash])
+        let token = String(path[path.index(after: slash)...]).removingExtension
+
+        lock.lock()
+        let pack = index[uid]
+        lock.unlock()
+
+        guard let pack else { return nil }
+        let icon = pack.icons.first { icon in
+            let t = icon.filename.removingExtension
+            return t == token || t.baseName == token.baseName
+        }
+        guard let icon else { return nil }
+        return (pack, icon)
+    }
+
+    /// Load the `UIImage` for a resolved icon from app-private storage.
+    /// Returns nil when the file is missing or unreadable. Call off the main
+    /// thread — does file I/O.
+    func loadImage(pack: ImportedPack, icon: ImportedIcon) -> UIImage? {
+        let fileURL = packDirectory(for: pack.uid).appendingPathComponent(icon.filename)
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        return UIImage(data: data)
+    }
+
+    /// Stable image-cache key for an imported icon.
+    /// Format: `"import-<uid>-<pathToken>"`, distinct from bundled TAK keys.
+    func cacheKey(for iconsetPath: String) -> String {
+        let slash = iconsetPath.firstIndex(of: "/")
+        guard let slash else { return "import-\(iconsetPath)" }
+        let uid = String(iconsetPath[..<slash])
+        let token = String(iconsetPath[iconsetPath.index(after: slash)...]).removingExtension
+        return "import-\(uid)-\(token)"
+    }
+
+    // MARK: - Mutating
+
+    /// Register a newly imported pack. Replaces any existing pack with the same
+    /// uid (re-import / update path). Persists immediately.
+    func register(_ pack: ImportedPack) {
+        ensureLoaded()
+        lock.lock()
+        packs.removeAll { $0.uid == pack.uid }
+        index.removeValue(forKey: pack.uid)
+        packs.append(pack)
+        index[pack.uid] = pack
+        saveLocked()
+        lock.unlock()
+    }
+
+    /// Remove a pack by uid. Returns true when found and removed.
+    @discardableResult
+    func remove(uid: String) -> Bool {
+        ensureLoaded()
+        lock.lock()
+        let removed = packs.contains { $0.uid == uid }
+        packs.removeAll { $0.uid == uid }
+        index.removeValue(forKey: uid)
+        if removed { saveLocked() }
+        lock.unlock()
+        if removed {
+            try? FileManager.default.removeItem(at: packDirectory(for: uid))
+        }
+        return removed
+    }
+
+    // MARK: - Paths
+
+    /// App-private directory for a pack's extracted images.
+    func packDirectory(for uid: String) -> URL {
+        baseDirectory.appendingPathComponent(uid, isDirectory: true)
+    }
+
+    private var baseDirectory: URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("iconpacks", isDirectory: true)
+    }
+
+    private var packsJSONURL: URL {
+        baseDirectory.appendingPathComponent("packs.json")
+    }
+
+    // MARK: - Persistence (caller must hold lock)
+
+    private func loadLocked() {
+        guard let data = try? Data(contentsOf: packsJSONURL) else { return }
+        let decoded = try? JSONDecoder().decode([ImportedPack].self, from: data)
+        let list = decoded ?? []
+        packs = list
+        index = Dictionary(uniqueKeysWithValues: list.map { ($0.uid, $0) })
+    }
+
+    private func saveLocked() {
+        guard let data = try? JSONEncoder().encode(packs) else { return }
+        try? FileManager.default.createDirectory(at: baseDirectory,
+                                                  withIntermediateDirectories: true)
+        try? data.write(to: packsJSONURL, options: .atomic)
+    }
+}
+
+// MARK: - String file-path helpers
+
+private extension String {
+    var removingExtension: String {
+        guard let dot = lastIndex(of: "."), dot != startIndex else { return self }
+        return String(self[..<dot])
+    }
+    var baseName: String {
+        String(split(separator: "/").last ?? Substring(self))
+    }
+}

--- a/OmniTAKMobile/Features/Drawing/Services/IconsetPackParser.swift
+++ b/OmniTAKMobile/Features/Drawing/Services/IconsetPackParser.swift
@@ -1,0 +1,209 @@
+//
+//  IconsetPackParser.swift
+//  OmniTAKMobile
+//
+//  Issue #75 Phase 2 — pure-Swift parser for ATAK's `iconset.xml` format.
+//
+//  ATAK iconset zips contain an `iconset.xml` at the root (or sometimes nested
+//  under a directory) alongside the image files the XML references. The XML
+//  follows this structure:
+//
+//  ```xml
+//  <?xml version="1.0" encoding="UTF-8"?>
+//  <iconset uid="<uuid>" name="Pack Name" version="1"
+//           defaultFriendlyGroup="…" defaultHostileGroup="…" …>
+//    <icon name="Ambulance" filename="Ground/Ambulance.png"/>
+//    <!-- or grouped: -->
+//    <group name="Ground">
+//      <icon name="Tank" filename="Ground/Tank.png"/>
+//    </group>
+//  </iconset>
+//  ```
+//
+//  No UIKit / Foundation dependencies beyond XMLParser — fully testable without
+//  a device. Bitmap loading and storage are handled by `IconPackRegistry`.
+//
+//  Resolution follows ATAK's `iconsetpath` wire format:
+//    `"<uid>/<filename-without-extension>"`
+//  e.g. `"f47ac10b-…/Ground/Ambulance"` matches the icon with
+//  `filename="Ground/Ambulance.png"`.
+//
+
+import Foundation
+
+// MARK: - IconsetPackParser
+
+/// Pure-Swift, no-UIKit parser for ATAK `iconset.xml`. Returns a
+/// `ParsedIconset` or nil on malformed input. All path logic lives here;
+/// bitmap loading is separate (see `IconPackRegistry`).
+enum IconsetPackParser {
+
+    // MARK: - Data types
+
+    /// A single icon entry from `iconset.xml`.
+    struct IconEntry: Equatable {
+        /// Display / lookup name (`name` attribute).
+        let name: String
+        /// Relative path inside the zip (`filename` attribute),
+        /// e.g. `"Ground/Ambulance.png"`.
+        let filename: String
+
+        /// Derive the ATAK `iconsetpath` token (filename without extension).
+        var pathToken: String { filename.removingFileExtension }
+    }
+
+    /// A fully-parsed ATAK iconset pack.
+    struct ParsedIconset: Equatable {
+        /// The pack's UUID (`uid` attribute on `<iconset>`). First path component
+        /// in ATAK `iconsetpath` wire format.
+        let uid: String
+        /// Human-readable pack name (`name` attribute, or `uid` when absent).
+        let name: String
+        /// Pack version (defaults to 1).
+        let version: Int
+        /// All icon entries, flattened from any `<group>` nesting.
+        let icons: [IconEntry]
+
+        // MARK: Icon lookup
+
+        /// Resolve an icon by its exact `name` attribute.
+        func iconByName(_ name: String) -> IconEntry? {
+            icons.first { $0.name == name }
+        }
+
+        /// Resolve an icon by name, case-insensitively.
+        func iconByNameInsensitive(_ name: String) -> IconEntry? {
+            icons.first { $0.name.caseInsensitiveCompare(name) == .orderedSame }
+        }
+
+        /// Resolve an icon from an ATAK `usericon iconsetpath` value.
+        ///
+        /// Accepted forms (all equivalent for `uid="abc"`, `filename="Ground/Ambulance.png"`):
+        /// - `"abc/Ground/Ambulance"`       — full path, no extension
+        /// - `"abc/Ground/Ambulance.png"`   — full path, with extension
+        /// - `"abc/Ambulance"`              — basename only, no extension
+        /// - `"abc/Ambulance.png"`          — basename only, with extension
+        ///
+        /// Returns nil when the uid prefix doesn't match or the token is unknown.
+        func iconByIconsetPath(_ iconsetPath: String) -> IconEntry? {
+            let prefix = uid + "/"
+            guard iconsetPath.hasPrefix(prefix) else { return nil }
+            let token = String(iconsetPath.dropFirst(prefix.count))
+                .removingFileExtension
+                .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+            // 1. Exact filename-without-extension match (full subdirectory path).
+            if let exact = icons.first(where: { $0.filename.removingFileExtension == token }) {
+                return exact
+            }
+            // 2. Basename match (caller omitted the subdirectory component).
+            let basename = String(token.split(separator: "/").last ?? Substring(token))
+            return icons.first(where: {
+                $0.filename.removingFileExtension.baseName == basename
+            })
+        }
+
+        /// ATAK canonical `iconsetpath` for an `IconEntry`:
+        /// `"<uid>/<filename-without-extension>"`.
+        ///
+        /// This is what OmniTAK emits in `<usericon iconsetpath="…"/>` when the
+        /// operator places a marker so ATAK / iTAK peers resolve to the right glyph.
+        func iconsetPath(for icon: IconEntry) -> String {
+            "\(uid)/\(icon.filename.removingFileExtension)"
+        }
+    }
+
+    // MARK: - Parse
+
+    /// Parse an ATAK `iconset.xml` string into a `ParsedIconset`.
+    ///
+    /// Returns nil when:
+    /// - the string is blank or not valid XML,
+    /// - the root element is not `<iconset>`,
+    /// - the `uid` attribute is missing or blank.
+    ///
+    /// Malformed `<icon>` entries (missing `name` or `filename`) are silently
+    /// skipped — a partial pack is better than a total failure.
+    static func parse(_ xml: String) -> ParsedIconset? {
+        guard !xml.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        guard let data = xml.data(using: .utf8) else { return nil }
+        let delegate = ParserDelegate()
+        let parser = XMLParser(data: data)
+        parser.delegate = delegate
+        guard parser.parse(), !delegate.failed else { return nil }
+        return delegate.result
+    }
+}
+
+// MARK: - XMLParserDelegate (private)
+
+private final class ParserDelegate: NSObject, XMLParserDelegate {
+
+    var result: IconsetPackParser.ParsedIconset?
+    var failed = false
+
+    private var uid: String?
+    private var name: String?
+    private var version: Int = 1
+    private var icons: [IconsetPackParser.IconEntry] = []
+
+    // MARK: XMLParserDelegate
+
+    func parser(_ parser: XMLParser,
+                didStartElement elementName: String,
+                namespaceURI: String?,
+                qualifiedName qName: String?,
+                attributes: [String: String]) {
+        switch elementName {
+        case "iconset":
+            guard let u = attributes["uid"], !u.trimmingCharacters(in: .whitespaces).isEmpty else {
+                failed = true
+                parser.abortParsing()
+                return
+            }
+            uid = u
+            let n = attributes["name"]?.trimmingCharacters(in: .whitespaces)
+            name = (n?.isEmpty ?? true) ? nil : n
+            version = attributes["version"].flatMap(Int.init) ?? 1
+
+        case "icon":
+            let iName = attributes["name"]?.trimmingCharacters(in: .whitespaces) ?? ""
+            let iFile = attributes["filename"]?.trimmingCharacters(in: .whitespaces) ?? ""
+            guard !iName.isEmpty, !iFile.isEmpty else { break }
+            icons.append(IconsetPackParser.IconEntry(name: iName, filename: iFile))
+
+        default:
+            break
+        }
+    }
+
+    func parserDidEndDocument(_ parser: XMLParser) {
+        guard let uid else { return }
+        result = IconsetPackParser.ParsedIconset(
+            uid: uid,
+            name: name ?? uid,
+            version: version,
+            icons: icons
+        )
+    }
+
+    func parser(_ parser: XMLParser, parseErrorOccurred parseError: Error) {
+        failed = true
+    }
+}
+
+// MARK: - String helpers (file-path utils)
+
+private extension String {
+    /// Remove the last path extension (`.png`, `.jpg`, etc.), mirroring
+    /// `URL.deletingPathExtension().lastPathComponent` for simple filenames.
+    var removingFileExtension: String {
+        guard let dot = lastIndex(of: "."), dot != startIndex else { return self }
+        return String(self[..<dot])
+    }
+
+    /// Last path component — everything after the final `/`.
+    var baseName: String {
+        String(split(separator: "/").last ?? Substring(self))
+    }
+}

--- a/OmniTAKMobile/Features/Drawing/Services/PointDropperService.swift
+++ b/OmniTAKMobile/Features/Drawing/Services/PointDropperService.swift
@@ -276,6 +276,39 @@ class PointDropperService: ObservableObject {
         return "\(icon.displayName.uppercased())-\(count)-\(f.string(from: Date()))"
     }
 
+    /// Quick drop a marker from an imported ATAK iconset pack (issue #75 Phase 2).
+    /// The `iconsetPath` is the canonical ATAK wire format:
+    /// `"<pack-uid>/<filename-without-extension>"`.
+    @discardableResult
+    func quickDropImported(
+        iconsetPath: String,
+        iconName: String,
+        at coordinate: CLLocationCoordinate2D,
+        name: String? = nil,
+        broadcast: Bool = false
+    ) -> PointMarker {
+        let markerName = name ?? generateImportedIconName(iconName: iconName)
+        let marker = PointMarker(
+            name: markerName,
+            affiliation: .unknown,
+            coordinate: coordinate,
+            importedIconsetPath: iconsetPath,
+            isBroadcast: broadcast
+        )
+        markers.append(marker)
+        updateRecentMarkers(marker)
+        saveMarkers()
+        if broadcast { broadcastMarker(marker) }
+        onEvent?(.markerCreated(marker))
+        return marker
+    }
+
+    private func generateImportedIconName(iconName: String) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "HHmm"
+        return "\(iconName.uppercased())-\(f.string(from: Date()))"
+    }
+
     /// Get marker by ID
     func getMarker(id: UUID) -> PointMarker? {
         return markers.first { $0.id == id }

--- a/OmniTAKMobile/Features/Drawing/Views/PointDropperView.swift
+++ b/OmniTAKMobile/Features/Drawing/Views/PointDropperView.swift
@@ -26,6 +26,8 @@ struct PointDropperView: View {
     @State private var showMarkerList: Bool = false
     @State private var selectedMarkerForSALUTE: PointMarker?
     @State private var showAdvanced: Bool = false
+    @State private var showIconPackImporter: Bool = false
+    @State private var importedPacks: [ImportedPack] = []
 
     var body: some View {
         NavigationView {
@@ -61,6 +63,12 @@ struct PointDropperView: View {
                         // "Google" place-icon set, selectable + round-trips.
                         takGooglePaletteSection
 
+                        // Imported ATAK iconset packs (issue #75 Phase 2).
+                        // Only shown when the user has imported at least one pack.
+                        if !importedPacks.isEmpty {
+                            importedPacksSection
+                        }
+
                         // Everything else is optional — collapsed by default.
                         Button {
                             withAnimation { showAdvanced.toggle() }
@@ -88,7 +96,10 @@ struct PointDropperView: View {
                     .padding()
                 }
             }
-            .onAppear { PointDropUIState.shared.isAiming = true }
+            .onAppear {
+                PointDropUIState.shared.isAiming = true
+                importedPacks = IconPackRegistry.shared.allPacks()
+            }
             .onDisappear { PointDropUIState.shared.isAiming = false }
             .navigationTitle("Point Dropper")
             .navigationBarTitleDisplayMode(.inline)
@@ -129,6 +140,11 @@ struct PointDropperView: View {
         }
         .sheet(isPresented: $showMarkerList) {
             MarkerListView(service: service)
+        }
+        .sheet(isPresented: $showIconPackImporter) {
+            IconPackImporterSheet(onImported: { pack in
+                importedPacks = IconPackRegistry.shared.allPacks()
+            })
         }
         // Present as a draggable bottom sheet so the map stays visible (and
         // pannable) above — drop a point while still seeing where it lands.
@@ -288,6 +304,52 @@ struct PointDropperView: View {
                     ForEach(TAKIconRegistry.shared.selectableGoogleIcons) { icon in
                         TAKGoogleIconButton(icon: icon) {
                             quickDropTAKGoogle(icon)
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(Color.black.opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Imported Packs Palette (issue #75 Phase 2)
+
+    /// One horizontal-scroll row per imported pack, mirroring Android PR #112's
+    /// `ImportedPackRow`. Tapping emits the canonical `iconsetpath`.
+    private var importedPacksSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 6) {
+                Text("CUSTOM PACKS")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(Color(hex: "#FFFC00"))
+                Text("(imported ATAK iconsets)")
+                    .font(.system(size: 9))
+                    .foregroundColor(.gray)
+                Spacer()
+                Button {
+                    showIconPackImporter = true
+                } label: {
+                    Label("Import", systemImage: "square.and.arrow.down")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(Color(hex: "#FFFC00"))
+                }
+            }
+
+            ForEach(importedPacks) { pack in
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(pack.name)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.white.opacity(0.7))
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 10) {
+                            ForEach(pack.icons) { icon in
+                                ImportedIconButton(pack: pack, icon: icon) {
+                                    quickDropImportedIcon(pack: pack, icon: icon)
+                                }
+                            }
                         }
                     }
                 }
@@ -616,6 +678,19 @@ struct PointDropperView: View {
         #if DEBUG
         print("📍 TAK google dropped \(icon.displayName) marker: \(marker.name)")
         #endif
+    }
+
+    private func quickDropImportedIcon(pack: ImportedPack, icon: ImportedIcon) {
+        guard let location = mapCenter ?? currentLocation else { return }
+        // Build the canonical ATAK iconsetpath: "<uid>/<filename-no-ext>"
+        let iconsetPath = "\(pack.uid)/\(icon.pathToken)"
+        _ = service.quickDropImported(
+            iconsetPath: iconsetPath,
+            iconName: icon.name,
+            at: location,
+            broadcast: broadcastImmediately
+        )
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
     }
 
     private func quickDrop(affiliation: MarkerAffiliation) {
@@ -1154,6 +1229,101 @@ struct MarkerRowView: View {
             }
         }
         .padding(.vertical, 8)
+    }
+}
+
+// MARK: - Imported Icon Button (issue #75 Phase 2)
+
+/// Tile for a single icon in an imported ATAK iconset pack. Loads the
+/// image from app-private storage (non-blocking: loads on appear).
+struct ImportedIconButton: View {
+    let pack: ImportedPack
+    let icon: ImportedIcon
+    let action: () -> Void
+
+    @State private var image: UIImage?
+
+    var body: some View {
+        Button {
+            let g = UIImpactFeedbackGenerator(style: .light)
+            g.impactOccurred()
+            action()
+        } label: {
+            VStack(spacing: 4) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color.white.opacity(0.08))
+                        .frame(width: 44, height: 44)
+                    if let img = image {
+                        Image(uiImage: img)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 36, height: 36)
+                    } else {
+                        Image(systemName: "photo")
+                            .font(.system(size: 18))
+                            .foregroundColor(.gray)
+                    }
+                }
+                Text(icon.name)
+                    .font(.system(size: 9))
+                    .foregroundColor(.white.opacity(0.85))
+                    .lineLimit(1)
+                    .frame(width: 50)
+            }
+        }
+        .buttonStyle(.plain)
+        .task {
+            // Load off the main thread.
+            let loaded = await Task.detached(priority: .utility) {
+                IconPackRegistry.shared.loadImage(pack: pack, icon: icon)
+            }.value
+            image = loaded
+        }
+    }
+}
+
+// MARK: - Icon Pack Importer Sheet (issue #75 Phase 2)
+
+/// Presents a `UIDocumentPicker` for `.zip` files, then calls `IconPackImporter`
+/// and reports the result. The import runs on a background task so the UI stays
+/// responsive.
+struct IconPackImporterSheet: UIViewControllerRepresentable {
+    let onImported: (ImportedPack) -> Void
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let picker = UIDocumentPickerViewController(
+            forOpeningContentTypes: [.zip],
+            asCopy: true)
+        picker.delegate = context.coordinator
+        picker.allowsMultipleSelection = false
+        picker.modalPresentationStyle = .formSheet
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController,
+                                context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onImported: onImported)
+    }
+
+    final class Coordinator: NSObject, UIDocumentPickerDelegate {
+        let onImported: (ImportedPack) -> Void
+        init(onImported: @escaping (ImportedPack) -> Void) {
+            self.onImported = onImported
+        }
+
+        func documentPicker(_ controller: UIDocumentPickerViewController,
+                            didPickDocumentsAt urls: [URL]) {
+            guard let url = urls.first else { return }
+            Task.detached(priority: .userInitiated) {
+                let result = IconPackImporter.importZip(at: url)
+                if case .success(let pack) = result {
+                    await MainActor.run { self.onImported(pack) }
+                }
+            }
+        }
     }
 }
 

--- a/OmniTAKMobile/Shared/Services/TAKIconRegistry.swift
+++ b/OmniTAKMobile/Shared/Services/TAKIconRegistry.swift
@@ -384,6 +384,11 @@ final class TAKIconRegistry {
                       iconsetPath: String? = nil,
                       argb: Int? = nil,
                       size: CGFloat = 36) -> UIImage? {
+        // 0. Imported custom pack (Phase 2) — checked before bundled packs so
+        //    a user pack with the same uid prefix wins over a bundled one.
+        if let path = iconsetPath, IconPackRegistry.shared.handles(path) {
+            return importedPackImage(iconsetPath: path, size: size)
+        }
         // 1. Explicit iconset path wins. Match against each standard pack.
         if let path = iconsetPath, !path.isEmpty {
             // 1a. Spot Map — colored dot keyed off the path/color.
@@ -409,6 +414,18 @@ final class TAKIconRegistry {
         }
         // 3. No TAK-suite match — caller keeps the MIL-STD-2525 fallback.
         return nil
+    }
+
+    /// Load and cache an image from an imported custom iconset pack.
+    func importedPackImage(iconsetPath: String, size: CGFloat) -> UIImage? {
+        let key = IconPackRegistry.shared.cacheKey(for: iconsetPath) + "|\(Int(size))"
+        if let cached = cached(key) { return cached }
+        guard let (pack, icon) = IconPackRegistry.shared.resolve(iconsetPath) else { return nil }
+        guard let raw = IconPackRegistry.shared.loadImage(pack: pack, icon: icon) else { return nil }
+        // Scale to target size preserving aspect ratio, matching bundled icon behavior.
+        let scaled = raw.scaledToFill(size: CGSize(width: size, height: size))
+        store(key, scaled)
+        return scaled
     }
 
     /// Convenience: the rendered glyph for a selectable Spot Map icon (picker
@@ -558,5 +575,23 @@ private extension UIColor {
         var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
         getRed(&r, green: &g, blue: &b, alpha: &a)
         return (0.299 * r + 0.587 * g + 0.114 * b) > 0.6
+    }
+}
+
+// MARK: - UIImage scaling helper
+
+private extension UIImage {
+    /// Scale (fill) to an exact target size, preserving aspect ratio.
+    func scaledToFill(size targetSize: CGSize) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        return renderer.image { _ in
+            let scale = max(targetSize.width / max(self.size.width, 1),
+                            targetSize.height / max(self.size.height, 1))
+            let drawSize = CGSize(width: self.size.width * scale,
+                                  height: self.size.height * scale)
+            let origin = CGPoint(x: (targetSize.width - drawSize.width) / 2,
+                                 y: (targetSize.height - drawSize.height) / 2)
+            self.draw(in: CGRect(origin: origin, size: drawSize))
+        }
     }
 }

--- a/OmniTAKMobileTests/IconsetPackParserTests.swift
+++ b/OmniTAKMobileTests/IconsetPackParserTests.swift
@@ -1,0 +1,335 @@
+//
+//  IconsetPackParserTests.swift
+//  OmniTAKMobileTests
+//
+//  Issue #75 Phase 2 — unit tests for IconsetPackParser, the pure-Swift
+//  parser for ATAK's `iconset.xml` format.
+//
+//  ATAK iconset.xml structure:
+//
+//  ```xml
+//  <?xml version="1.0" encoding="UTF-8"?>
+//  <iconset uid="abc-123" defaultFriendlyGroup="…" defaultHostileGroup="…"
+//           defaultNeutralGroup="…" defaultUnknownGroup="…" name="My Pack"
+//           skipResize="false" version="1">
+//    <icon name="Ambulance" filename="Ground/Ambulance.png"/>
+//    <icon name="Police Car" filename="Ground/PoliceCar.png"/>
+//  </iconset>
+//  ```
+//
+//  The parser is the core unit-testable contract — all path/name logic lives
+//  here with zero UIKit dependencies. Bitmap loading is handled separately by
+//  IconPackRegistry (needs real files on disk, covered on-device).
+//
+
+import XCTest
+@testable import OmniTAK
+
+final class IconsetPackParserTests: XCTestCase {
+
+    // MARK: - Well-formed iconset.xml fixtures
+
+    private let minimalXml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <iconset uid="test-uid-001" name="Test Pack" version="1">
+          <icon name="Ambulance" filename="Ground/Ambulance.png"/>
+          <icon name="Police Car" filename="Ground/PoliceCar.png"/>
+        </iconset>
+        """
+
+    private let fullAtakXml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <iconset uid="f47ac10b-58cc-4372-a567-0e02b2c3d479"
+                 defaultFriendlyGroup="Ground"
+                 defaultHostileGroup="Ground"
+                 defaultNeutralGroup="Ground"
+                 defaultUnknownGroup="Ground"
+                 name="ATAK Military"
+                 skipResize="false"
+                 version="1">
+          <icon name="Ambulance"     filename="Ground/Ambulance.png"/>
+          <icon name="Police Car"    filename="Ground/PoliceCar.png"/>
+          <icon name="Helicopter"    filename="Air/Helicopter.png"/>
+          <icon name="Infantry"      filename="Ground/Infantry.png"/>
+          <icon name="Armored"       filename="Ground/Armored.png"/>
+        </iconset>
+        """
+
+    /// ATAK sometimes nests icons under a `<group>` element.
+    private let groupedXml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <iconset uid="grouped-uid" name="Grouped Pack" version="1">
+          <group name="Ground">
+            <icon name="Tank" filename="Ground/Tank.png"/>
+            <icon name="Jeep" filename="Ground/Jeep.png"/>
+          </group>
+          <group name="Air">
+            <icon name="Drone" filename="Air/Drone.png"/>
+          </group>
+          <icon name="Unknown" filename="Unknown.png"/>
+        </iconset>
+        """
+
+    // MARK: - Basic attribute parsing
+
+    func testParseMinimalIconsetReturnsCorrectUID() {
+        let result = IconsetPackParser.parse(minimalXml)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.uid, "test-uid-001")
+    }
+
+    func testParseMinimalIconsetReturnsCorrectName() {
+        let result = IconsetPackParser.parse(minimalXml)
+        XCTAssertEqual(result?.name, "Test Pack")
+    }
+
+    func testParseFullAtakIconsetUID() {
+        let result = IconsetPackParser.parse(fullAtakXml)
+        XCTAssertEqual(result?.uid, "f47ac10b-58cc-4372-a567-0e02b2c3d479")
+    }
+
+    func testParseFullAtakIconsetName() {
+        let result = IconsetPackParser.parse(fullAtakXml)
+        XCTAssertEqual(result?.name, "ATAK Military")
+    }
+
+    func testParseVersionAttributeCaptured() {
+        let result = IconsetPackParser.parse(fullAtakXml)
+        XCTAssertEqual(result?.version, 1)
+    }
+
+    func testParseVersionDefaultsToOneWhenAbsent() {
+        let xml = """
+            <?xml version="1.0"?>
+            <iconset uid="v-uid" name="NoVersion">
+              <icon name="X" filename="x.png"/>
+            </iconset>
+            """
+        XCTAssertEqual(IconsetPackParser.parse(xml)?.version, 1)
+    }
+
+    // MARK: - Flat icon entry parsing
+
+    func testParseMinimalXmlReturnsAllIconEntries() {
+        let result = IconsetPackParser.parse(minimalXml)
+        XCTAssertEqual(result?.icons.count, 2)
+    }
+
+    func testParseIconNameAndFilenameAreCorrect() {
+        let result = IconsetPackParser.parse(minimalXml)!
+        let ambulance = result.icons.first { $0.name == "Ambulance" }
+        XCTAssertEqual(ambulance?.filename, "Ground/Ambulance.png")
+    }
+
+    func testParseFullAtakXmlReturnsFiveIcons() {
+        let result = IconsetPackParser.parse(fullAtakXml)!
+        XCTAssertEqual(result.icons.count, 5)
+    }
+
+    func testEveryIconInFullXmlHasNonEmptyFilename() {
+        let result = IconsetPackParser.parse(fullAtakXml)!
+        for icon in result.icons {
+            XCTAssertFalse(icon.filename.isEmpty,
+                           "icon '\(icon.name)' has empty filename")
+        }
+    }
+
+    // MARK: - Grouped icon support
+
+    func testGroupedIconsetFlattensIconsFromAllGroups() {
+        let result = IconsetPackParser.parse(groupedXml)!
+        // 2 (Ground) + 1 (Air) + 1 (top-level) = 4 total
+        XCTAssertEqual(result.icons.count, 4)
+    }
+
+    func testIconFilenamesFromGroupedXmlAreAuthored() {
+        let result = IconsetPackParser.parse(groupedXml)!
+        let filenames = Set(result.icons.map { $0.filename })
+        XCTAssertTrue(filenames.contains("Ground/Tank.png"))
+        XCTAssertTrue(filenames.contains("Air/Drone.png"))
+        XCTAssertTrue(filenames.contains("Unknown.png"))
+    }
+
+    // MARK: - Icon lookup by name
+
+    func testIconByNameExactMatch() {
+        let pack = IconsetPackParser.parse(fullAtakXml)!
+        let icon = pack.iconByName("Ambulance")
+        XCTAssertNotNil(icon)
+        XCTAssertEqual(icon?.filename, "Ground/Ambulance.png")
+    }
+
+    func testIconByNameReturnsNilForUnknownName() {
+        let pack = IconsetPackParser.parse(fullAtakXml)!
+        XCTAssertNil(pack.iconByName("SpaceShip"))
+    }
+
+    func testIconByNameInsensitiveResolvesCaseInsensitively() {
+        let pack = IconsetPackParser.parse(fullAtakXml)!
+        XCTAssertNotNil(pack.iconByNameInsensitive("ambulance"))
+        XCTAssertNotNil(pack.iconByNameInsensitive("HELICOPTER"))
+    }
+
+    // MARK: - iconsetPath resolution (ATAK wire format)
+    //
+    // ATAK `usericon iconsetpath` for custom packs:
+    //   "<uid>/<filename-no-extension>"  e.g. "f47ac10b-…/Ground/Ambulance"
+    // or sometimes basename only: "f47ac10b-…/Ambulance"
+    // We resolve both so inbound CoT from ATAK peers works.
+
+    func testIconByIconsetPathResolvesFullPathWithSubdirectory() {
+        let pack = IconsetPackParser.parse(fullAtakXml)!
+        let icon = pack.iconByIconsetPath(
+            "f47ac10b-58cc-4372-a567-0e02b2c3d479/Ground/Ambulance")
+        XCTAssertNotNil(icon)
+        XCTAssertEqual(icon?.filename, "Ground/Ambulance.png")
+    }
+
+    func testIconByIconsetPathResolvesPathWithPngExtension() {
+        let pack = IconsetPackParser.parse(fullAtakXml)!
+        let icon = pack.iconByIconsetPath(
+            "f47ac10b-58cc-4372-a567-0e02b2c3d479/Ground/Ambulance.png")
+        XCTAssertNotNil(icon)
+        XCTAssertEqual(icon?.filename, "Ground/Ambulance.png")
+    }
+
+    func testIconByIconsetPathResolvesBasenameOnly() {
+        let pack = IconsetPackParser.parse(minimalXml)!
+        let icon = pack.iconByIconsetPath("test-uid-001/Ambulance")
+        XCTAssertNotNil(icon)
+    }
+
+    func testIconByIconsetPathReturnsNilWhenUIDDoesNotMatch() {
+        let pack = IconsetPackParser.parse(minimalXml)!
+        XCTAssertNil(pack.iconByIconsetPath("wrong-uid/Ambulance"))
+    }
+
+    func testIconByIconsetPathReturnsNilForUnknownTokenInCorrectUID() {
+        let pack = IconsetPackParser.parse(minimalXml)!
+        XCTAssertNil(pack.iconByIconsetPath("test-uid-001/SpaceShip"))
+    }
+
+    // MARK: - iconsetpath generation
+
+    func testIconsetPathForIconMatchesATAKCanonicalForm() {
+        let pack = IconsetPackParser.parse(fullAtakXml)!
+        let icon = pack.icons.first { $0.name == "Ambulance" }!
+        let expected = "f47ac10b-58cc-4372-a567-0e02b2c3d479/Ground/Ambulance"
+        XCTAssertEqual(pack.iconsetPath(for: icon), expected)
+    }
+
+    func testIconsetPathRoundTripsThroughResolver() {
+        let pack = IconsetPackParser.parse(fullAtakXml)!
+        for icon in pack.icons {
+            let path = pack.iconsetPath(for: icon)
+            let resolved = pack.iconByIconsetPath(path)
+            XCTAssertNotNil(resolved,
+                            "iconsetPath '\(path)' failed to resolve back")
+            XCTAssertEqual(resolved?.filename, icon.filename)
+        }
+    }
+
+    // MARK: - Malformed input handling
+
+    func testParseReturnsNilForCompletelyEmptyString() {
+        XCTAssertNil(IconsetPackParser.parse(""))
+    }
+
+    func testParseReturnsNilForNonXMLGarbage() {
+        XCTAssertNil(IconsetPackParser.parse("this is not xml at all }{]["))
+    }
+
+    func testParseReturnsNilWhenIconsetElementIsMissing() {
+        let xml = """
+            <?xml version="1.0"?>
+            <root><something/></root>
+            """
+        XCTAssertNil(IconsetPackParser.parse(xml))
+    }
+
+    func testParseReturnsNilWhenUIDAttributeIsMissing() {
+        let xml = """
+            <?xml version="1.0"?>
+            <iconset name="No UID Pack" version="1">
+              <icon name="X" filename="x.png"/>
+            </iconset>
+            """
+        XCTAssertNil(IconsetPackParser.parse(xml))
+    }
+
+    func testParseToleratesMissingNameAttributeAndUsesUIDFallback() {
+        let xml = """
+            <?xml version="1.0"?>
+            <iconset uid="no-name-uid" version="1">
+              <icon name="X" filename="x.png"/>
+            </iconset>
+            """
+        let result = IconsetPackParser.parse(xml)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.name, "no-name-uid")
+    }
+
+    func testParseWithZeroIconsReturnsEmptyListNotNil() {
+        let xml = """
+            <?xml version="1.0"?>
+            <iconset uid="empty-uid" name="Empty Pack" version="1">
+            </iconset>
+            """
+        let result = IconsetPackParser.parse(xml)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result?.icons.isEmpty == true)
+    }
+
+    func testParseSkipsIconEntriesWithMissingFilename() {
+        let xml = """
+            <?xml version="1.0"?>
+            <iconset uid="partial-uid" name="Partial" version="1">
+              <icon name="Good" filename="good.png"/>
+              <icon name="Bad"/>
+            </iconset>
+            """
+        let result = IconsetPackParser.parse(xml)!
+        XCTAssertEqual(result.icons.count, 1)
+        XCTAssertEqual(result.icons.first?.filename, "good.png")
+    }
+
+    func testParseSkipsIconEntriesWithMissingNameAttribute() {
+        let xml = """
+            <?xml version="1.0"?>
+            <iconset uid="partial-uid-2" name="Partial2" version="1">
+              <icon name="Good" filename="good.png"/>
+              <icon filename="noname.png"/>
+            </iconset>
+            """
+        let result = IconsetPackParser.parse(xml)!
+        XCTAssertEqual(result.icons.count, 1)
+    }
+
+    // MARK: - IconPackRegistry integration sanity
+
+    func testImportedPackIconsetPathStructureIsCorrect() {
+        // Verify the generated iconsetpath has the right uid prefix and
+        // contains the token — this is the contract TAKIconRegistry checks
+        // when deciding to call IconPackRegistry.handles(_:).
+        let pack = IconsetPackParser.parse(fullAtakXml)!
+        let icon = pack.icons.first { $0.name == "Ambulance" }!
+        let path = pack.iconsetPath(for: icon)
+
+        XCTAssertTrue(path.hasPrefix(pack.uid),
+                      "iconsetPath must start with the pack uid")
+        XCTAssertTrue(path.contains("Ambulance"),
+                      "iconsetPath must contain the icon name token")
+        // The registry check: uid component must be extractable.
+        let uidComponent = String(path.split(separator: "/").first ?? "")
+        XCTAssertEqual(uidComponent, pack.uid)
+    }
+
+    func testIconPackRegistryHandlesReturnsFalseForBundledPacks() {
+        // Bundled TAK packs are NOT in the imported registry — only user-imported
+        // zips land there. This confirms the registry's handles() is discriminating.
+        let registry = IconPackRegistry.shared
+        XCTAssertFalse(registry.handles("COT_MAPPING_SPOTMAP/red"))
+        XCTAssertFalse(registry.handles("COT_MAPPING_2525C/a-f-G"))
+        XCTAssertFalse(registry.handles(nil))
+    }
+}


### PR DESCRIPTION
## Summary

Ports Android PR #112 to iOS (SwiftUI). Adds full custom ATAK iconset pack import — parse an `iconset.xml` pack, import from a `.zip` via `UIDocumentPicker`, register it in the app sandbox, and make its icons selectable per marker with ATAK-canonical `iconsetpath` CoT round-trip.

- **`IconsetPackParser`** (`Features/Drawing/Services/`) — pure-Swift, zero-UIKit parser for ATAK's `iconset.xml`. Handles flat and `<group>`-nested icon entries, uid/name/version, and the ATAK canonical `iconsetpath` wire format (`<uid>/<filename-no-ext>`). Fully unit-testable without a device.
- **`IconPackRegistry`** (`Features/Drawing/Services/`) — app-scoped singleton persisting imported packs across launches via `Application Support/iconpacks/packs.json`. Resolves an `iconsetpath` to its pack + `ImportedIcon`; loads `UIImage`s from app-private storage on demand.
- **`IconPackImporter`** (`Features/Drawing/Services/`) — reads a `.zip` using a minimal libz/deflate reader (no SPM deps), locates `iconset.xml`, extracts referenced images into the sandbox, registers the pack. Returns a typed `IconPackImportResult` — never throws.
- **`PointMarkerModels`** — adds `importedIconsetPath: String?` (Codable, backward-compatible).
- **`MarkerCoTGenerator`** — emits the imported iconsetpath in `<usericon iconsetpath="…"/>` at the highest priority slot.
- **`PointDropperService`** — adds `quickDropImported(iconsetPath:iconName:at:)`.
- **`PointDropperView`** — adds `importedPacksSection` (one horizontal-scroll `ImportedIconButton` row per imported pack) + `IconPackImporterSheet` (`UIDocumentPickerViewController` coordinator for `.zip`). The "Import" button is wired and visible in the picker — unlike Android #112 which left the entry point as a follow-up, this PR wires it fully.
- **`TAKIconRegistry.resolveImage`** — Phase 2 slot checks `IconPackRegistry.shared.handles()` before bundled packs.

## Test plan

Unit-verified (30 assertions, `** TEST SUCCEEDED **`):

- [x] Parse minimal and full ATAK `iconset.xml` → correct uid, name, version
- [x] Parse flat and `<group>`-nested entries; all icons flattened
- [x] `iconByName` exact match; `iconByNameInsensitive` case-insensitive
- [x] `iconByIconsetPath`: full `uid/subdir/name`; `.png` suffix; basename-only; wrong uid → nil; unknown token → nil
- [x] `iconsetPath(for:)` generates ATAK canonical form; round-trips through resolver
- [x] Malformed input: empty string, non-XML, missing `<iconset>`, missing uid, zero icons, entries missing name or filename
- [x] `IconPackRegistry.handles()` returns false for bundled pack prefixes
- [x] `xcodebuild … build` green; `** TEST SUCCEEDED **`

**Needs device pass** (not unit-verifiable):

- [ ] `UIDocumentPicker` selects a real ATAK iconset `.zip` → `IconPackImporter.importZip(at:)` → icons appear in the picker row
- [ ] Tapping an imported icon drops a marker → CoT emitted with `<usericon iconsetpath="…"/>` → ATAK / iTAK peer renders the correct glyph
- [ ] `TAKIconRegistry` renders the imported bitmap on the map (file loaded from `Application Support/iconpacks/<uid>/`)
- [ ] Pack survives app restart (packs.json round-trip)

Closes #75