### PR TITLE
fix: exclude dropped markers from chat contacts, scrub stale participants on load

### DIFF
--- a/OmniTAK.xcodeproj/project.pbxproj
+++ b/OmniTAK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9C2486130A64424C8DA9EE7B /* MarkerLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7BF0F8036A4641AE333F42 /* MarkerLifecycleTests.swift */; };
 		00110BD286D75FD2DB51A9F8 /* MapContextMenus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F657BBEE985D0EA477B0233E /* MapContextMenus.swift */; };
 		009E60B0DFCDE840692E67BA /* GybBLEClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C274F219D8969E574394579 /* GybBLEClient.swift */; };
 		0123DD83F4B3A860CC2EF51E /* RemoteIdScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00CFB4EE06C47225356099DC /* RemoteIdScanner.swift */; };
@@ -421,6 +422,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3A7BF0F8036A4641AE333F42 /* MarkerLifecycleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MarkerLifecycleTests.swift; path = OmniTAKMobileTests/MarkerLifecycleTests.swift; sourceTree = "<group>"; };
 		0006B84C15765B63E17797BD /* MeshFrameworkDevicePickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshFrameworkDevicePickerView.swift; path = OmniTAKMobile/Features/MeshCore/Views/MeshFrameworkDevicePickerView.swift; sourceTree = "<group>"; };
 		00359DE8F222FE7021D1936A /* SFFPG------.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SFFPG------.svg"; sourceTree = "<group>"; };
 		00459F49871153410DCE6A67 /* SHGPUCI----.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "SHGPUCI----.svg"; sourceTree = "<group>"; };
@@ -1091,6 +1093,7 @@
 			2D9B234301E66FB09D2BE034 /* CesiumCameraSeedTests.swift */,
 				8D3A7C46FD7B29D70D019C18 /* TAKServiceTests.swift */,
 								CF000005A000000000000001 /* ConfigProfileTests.swift */,
+				3A7BF0F8036A4641AE333F42 /* MarkerLifecycleTests.swift */,
 				A99C500AFB1B09E55ABEDBBF /* Info.plist */,
 			);
 			name = OmniTAKMobileTests;
@@ -2752,6 +2755,7 @@
 				F831B10A1D135F2E88925F52 /* PluginSDKTests.swift in Sources */,
 				C5C06A972D151475A44BC316 /* MeshCoreFrameCodecTests.swift in Sources */,
 				CF000005B000000000000001 /* ConfigProfileTests.swift in Sources */,
+				9C2486130A64424C8DA9EE7B /* MarkerLifecycleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OmniTAKMobile/CoT/CoTEventHandler.swift
+++ b/OmniTAKMobile/CoT/CoTEventHandler.swift
@@ -197,12 +197,19 @@ class CoTEventHandler: ObservableObject {
         // Update participant info for chat, tagged with the source server so
         // the contact list + DM routing are server-aware (multi-server).
         //
-        // Skip detected drones (RID-{uasId}): they render on the map and
-        // federate to servers like any CoT contact, but they are not EUDs and
-        // can't receive DMs, so they must not pollute the "KNOWN CONTACTS"
-        // list / New-Chat sheet. The `RID-` prefix is assigned only by
-        // RemoteIdAppBridge for on-device + gyb-sensor drone detections.
-        if !event.uid.hasPrefix("RID-") {
+        // Skip detected drones (RID-{uasId}) and locally-dropped point markers
+        // (marker-{uuid}) from the participant/chat-contact feed.
+        //
+        // • RID- UIDs: drone detections from RemoteIdAppBridge / gyb sensor.
+        //   They appear on the map and federate to servers but cannot receive DMs.
+        //
+        // • marker- UIDs: user-dropped tactical point markers (PointMarker.uid).
+        //   They share the same CoT position-update pipeline when broadcast, but
+        //   are static map annotations, not chat-capable EUDs.  Feeding them into
+        //   ChatManager.participants causes them to appear in the Chat contact list
+        //   and the New-Chat sheet — field report: Patrick Coyle 2026-06-12
+        //   (Android #118 parity).
+        if !event.uid.hasPrefix("RID-") && !event.uid.isDroppedPointMarkerUID {
             // Map the parsed event straight onto a ChatParticipant — the
             // previous implementation serialized the event back to XML just
             // to re-parse it with ChatXMLParser (the two parsers shared no

--- a/OmniTAKMobile/CoT/CoTXMLBuilder.swift
+++ b/OmniTAKMobile/CoT/CoTXMLBuilder.swift
@@ -28,6 +28,19 @@ extension String {
             .replacingOccurrences(of: "\"", with: "&quot;")
             .replacingOccurrences(of: "'", with: "&apos;")
     }
+
+    /// Returns true when this CoT UID belongs to a locally-dropped point
+    /// marker.  All PointMarker instances set `uid = "marker-<UUID>"` in
+    /// their initialiser — that prefix is the canonical discriminant used
+    /// to distinguish user-dropped map markers from real EUDs (units that
+    /// can receive chat messages) and from drone detections (prefix "RID-").
+    ///
+    /// Used by CoTEventHandler to skip the participant-store feed, and by
+    /// ChatManager to scrub stale entries from the persisted participants
+    /// list on launch.
+    var isDroppedPointMarkerUID: Bool {
+        hasPrefix("marker-")
+    }
 }
 
 // MARK: - CoT XML Builder

--- a/OmniTAKMobile/Features/Chat/Managers/ChatManager.swift
+++ b/OmniTAKMobile/Features/Chat/Managers/ChatManager.swift
@@ -49,7 +49,14 @@ class ChatManager: ObservableObject {
             guard let self else { return }
             let loadedConversations = self.persistence.loadConversations()
             let loadedMessages      = self.persistence.loadMessages()
-            let loadedParticipants  = self.persistence.loadParticipants()
+            // Scrub any marker- or RID- UIDs that may have been persisted into
+            // participants.json before this fix landed.  These entries are
+            // harmless in cotEvents (map rendering) but must never appear in the
+            // chat contact list (Android #118/#119 parity; Patrick Coyle
+            // 2026-06-12).
+            let loadedParticipants  = ChatPersistence.scrubMarkerParticipants(
+                self.persistence.loadParticipants()
+            )
             DispatchQueue.main.async {
                 self.conversations = loadedConversations
                 self.messages      = loadedMessages
@@ -57,6 +64,22 @@ class ChatManager: ObservableObject {
                 print("ChatManager loaded: \(loadedConversations.count) conversations, \(loadedMessages.count) messages, \(loadedParticipants.count) participants")
                 self.setupDefaultConversations()
             }
+        }
+    }
+
+    // MARK: - Chat-capable contact filter
+
+    /// The subset of `participants` that are real EUDs capable of receiving a
+    /// GeoChat DM.  Excludes locally-dropped point markers (UID prefix
+    /// "marker-") and drone detections (UID prefix "RID-") — neither is a
+    /// chat endpoint.
+    ///
+    /// Use this list for the Chat contact picker and the "KNOWN CONTACTS"
+    /// section in ChatView instead of `participants` directly.
+    /// Bug fix: field report from Patrick Coyle 2026-06-12 (Android #118 parity).
+    var chatableParticipants: [ChatParticipant] {
+        participants.filter {
+            !$0.id.isDroppedPointMarkerUID && !$0.id.hasPrefix("RID-")
         }
     }
 

--- a/OmniTAKMobile/Features/Chat/Views/ChatView.swift
+++ b/OmniTAKMobile/Features/Chat/Views/ChatView.swift
@@ -43,7 +43,9 @@ struct ChatView: View {
                 .filter { !$0.isGroupChat }
                 .compactMap { $0.participants.first?.id }
         )
-        return chatManager.participants
+        // Use chatableParticipants (excludes dropped markers and drone UIDs)
+        // so static map annotations never appear as chat-able contacts.
+        return chatManager.chatableParticipants
             .filter { $0.id != chatManager.currentUserId && !existingUids.contains($0.id) }
             .sorted { $0.callsign < $1.callsign }
     }
@@ -306,7 +308,9 @@ struct NewChatView: View {
     @State private var selectedParticipant: ChatParticipant?
 
     var availableParticipants: [ChatParticipant] {
-        chatManager.participants.filter { $0.id != chatManager.currentUserId }
+        // chatableParticipants filters out dropped markers and drone UIDs so
+        // only real EUDs appear in the New Chat contact picker.
+        chatManager.chatableParticipants.filter { $0.id != chatManager.currentUserId }
     }
 
     var body: some View {

--- a/OmniTAKMobile/Storage/ChatPersistence.swift
+++ b/OmniTAKMobile/Storage/ChatPersistence.swift
@@ -137,6 +137,21 @@ class ChatPersistence {
         }
     }
 
+    // MARK: - Marker participant scrub
+
+    /// Remove stale entries left by pre-fix builds where locally-dropped point
+    /// markers (uid prefix "marker-") and drone detections (uid prefix "RID-")
+    /// were incorrectly stored in the chat participants list.
+    ///
+    /// Called at startup by ChatManager.init() so the Chat contact list is
+    /// clean on every launch even for users upgrading from an affected build.
+    /// Android #118/#119 parity — Patrick Coyle field report 2026-06-12.
+    static func scrubMarkerParticipants(_ participants: [ChatParticipant]) -> [ChatParticipant] {
+        participants.filter {
+            !$0.id.isDroppedPointMarkerUID && !$0.id.hasPrefix("RID-")
+        }
+    }
+
     // MARK: - Clear All Data
 
     func clearAllData() {

--- a/OmniTAKMobileTests/MarkerLifecycleTests.swift
+++ b/OmniTAKMobileTests/MarkerLifecycleTests.swift
@@ -1,0 +1,234 @@
+//
+//  MarkerLifecycleTests.swift
+//  OmniTAKMobileTests
+//
+//  TDD regression tests for two field-reported marker lifecycle bugs
+//  (Patrick Coyle, 2026-06-12):
+//
+//    Bug A — Dropped point-markers wrongly appear as contacts in the Chat menu
+//             (Android #118 parity)
+//    Bug B — Locally-dropped markers persist across app restart but marker-
+//             tainted participants from old sessions must be scrubbed at load
+//             (Android #119 parity)
+//
+//  Classification used throughout:
+//    • locally-dropped marker — UID starts with "marker-" (set by PointMarker.init)
+//    • real EUD (chat-able)   — any other UID (server PPLI, mesh node, etc.)
+//    • RID drone              — UID starts with "RID-" (already filtered pre-fix)
+//
+
+import XCTest
+@testable import OmniTAK
+
+// MARK: - Bug A: Chat contact filter
+
+final class MarkerChatFilterTests: XCTestCase {
+
+    // Helper — build a minimal CoT event with the given uid and type.
+    private func makeEvent(uid: String, type: String, callsign: String = "TEST") -> CoTEvent {
+        CoTEvent(
+            uid: uid,
+            type: type,
+            time: Date(),
+            point: CoTPoint(lat: 47.0, lon: -122.0, hae: 0, ce: 9999, le: 9999),
+            detail: CoTDetail(
+                callsign: callsign,
+                team: nil, teamRole: nil, speed: nil, course: nil,
+                remarks: nil, battery: nil, device: nil, platform: nil
+            )
+        )
+    }
+
+    // MARK: A-1: isDroppedPointMarker returns true for marker- UIDs
+
+    func testDroppedMarkerUIDIsDetected() {
+        let markerUID = "marker-550E8400-E29B-41D4-A716-446655440000"
+        XCTAssertTrue(
+            markerUID.isDroppedPointMarkerUID,
+            "UID starting with 'marker-' must be classified as a dropped point marker"
+        )
+    }
+
+    // MARK: A-2: Normal EUD UID is NOT classified as a dropped marker
+
+    func testRealEUDUIDIsNotDroppedMarker() {
+        let euds = [
+            "ANDROID-abc123",
+            "IOS-xyz456",
+            "ATAK-1234",
+            "marker",          // exact string "marker" without dash is not a marker UID
+        ]
+        for uid in euds {
+            XCTAssertFalse(
+                uid.isDroppedPointMarkerUID,
+                "'\(uid)' should NOT be classified as a dropped point marker"
+            )
+        }
+    }
+
+    // MARK: A-3: RID drone UID is not a dropped marker (separate exclusion path)
+
+    func testRIDUIDIsNotDroppedMarker() {
+        XCTAssertFalse(
+            "RID-DJI-ABC123".isDroppedPointMarkerUID,
+            "RID- UIDs are drone detections, not dropped markers — separate filter path"
+        )
+    }
+
+    // MARK: A-4: chatManager.participants excludes locally-dropped marker UIDs
+
+    func testChatParticipantsExcludeDroppedMarkers() {
+        let manager = ChatManager.shared
+
+        // Record initial state so we can restore it.
+        let originalParticipants = manager.participants
+        defer { manager.participants = originalParticipants }
+
+        // Inject a mix of real contacts and a marker-prefixed entry.
+        let realContact = ChatParticipant(id: "ANDROID-real-01", callsign: "ALPHA-1")
+        let markerContact = ChatParticipant(id: "marker-DEADBEEF-0000-0000-0000-000000000001", callsign: "HOS-1-1234")
+
+        manager.participants = [realContact, markerContact]
+
+        // The chat-visible participant list must exclude marker- UIDs.
+        let chatVisible = manager.chatableParticipants
+        XCTAssertTrue(
+            chatVisible.contains(where: { $0.id == realContact.id }),
+            "Real EUD '\(realContact.callsign)' must appear in chatableParticipants"
+        )
+        XCTAssertFalse(
+            chatVisible.contains(where: { $0.id == markerContact.id }),
+            "Dropped marker '\(markerContact.callsign)' must NOT appear in chatableParticipants"
+        )
+    }
+
+    // MARK: A-5: CoTEventHandler does NOT add a dropped marker as a participant
+
+    func testEventHandlerSkipsDroppedMarkerForParticipantFeed() {
+        // Simulate what CoTEventHandler.handlePositionUpdate does for a
+        // marker-prefixed UID.  The check lives inside the handler, so we
+        // test the predicate that gates the updateParticipant call.
+        let markerUID = "marker-550E8400-E29B-41D4-A716-446655440001"
+        let shouldFeedAsParticipant = !markerUID.isDroppedPointMarkerUID && !markerUID.hasPrefix("RID-")
+        XCTAssertFalse(
+            shouldFeedAsParticipant,
+            "CoTEventHandler must not feed marker- UIDs into the participant store"
+        )
+    }
+
+    // MARK: A-6: Broadcast-echoed marker UID is still excluded
+
+    func testBroadcastedMarkerEchoExcluded() {
+        // A marker that was broadcast to the server gets echoed back as a
+        // positionUpdate CoT event.  Its UID is unchanged ("marker-<uuid>"),
+        // so it must still be excluded from the participant feed.
+        let broadcastedMarkerUID = "marker-AABBCCDD-1111-2222-3333-444455556666"
+        let shouldFeed = !broadcastedMarkerUID.isDroppedPointMarkerUID && !broadcastedMarkerUID.hasPrefix("RID-")
+        XCTAssertFalse(
+            shouldFeed,
+            "A server-echoed dropped marker must remain excluded from chat participants"
+        )
+    }
+}
+
+// MARK: - Bug B: Marker-tainted participants scrubbed at load
+
+final class MarkerParticipantPersistenceTests: XCTestCase {
+
+    // MARK: B-1: loadParticipants strips marker- UIDs
+
+    func testLoadParticipantsScrubsMarkerUIDs() {
+        // Build a raw participants list that contains both valid contacts and
+        // stale marker entries (as would appear in participants.json from a
+        // build that predates this fix).
+        let valid1   = ChatParticipant(id: "IOS-unit-01", callsign: "BRAVO-1")
+        let valid2   = ChatParticipant(id: "ANDROID-unit-02", callsign: "CHARLIE-2")
+        let stale1   = ChatParticipant(id: "marker-00000000-0000-0000-0000-000000000001", callsign: "HOS-1-0800")
+        let stale2   = ChatParticipant(id: "marker-FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF", callsign: "FRD-2-1200")
+
+        let raw = [valid1, stale1, valid2, stale2]
+
+        // scrubMarkerParticipants is the new helper we added to ChatPersistence.
+        let scrubbed = ChatPersistence.scrubMarkerParticipants(raw)
+
+        XCTAssertEqual(scrubbed.count, 2,
+            "scrubMarkerParticipants must remove both stale marker entries")
+        XCTAssertTrue(scrubbed.contains(where: { $0.id == valid1.id }),
+            "Valid participant '\(valid1.callsign)' must survive scrubbing")
+        XCTAssertTrue(scrubbed.contains(where: { $0.id == valid2.id }),
+            "Valid participant '\(valid2.callsign)' must survive scrubbing")
+        XCTAssertFalse(scrubbed.contains(where: { $0.id == stale1.id }),
+            "Stale marker participant '\(stale1.callsign)' must be removed")
+        XCTAssertFalse(scrubbed.contains(where: { $0.id == stale2.id }),
+            "Stale marker participant '\(stale2.callsign)' must be removed")
+    }
+
+    // MARK: B-2: scrubMarkerParticipants is a no-op on clean data
+
+    func testScrubIsNoOpOnCleanData() {
+        let contacts = [
+            ChatParticipant(id: "IOS-unit-03", callsign: "DELTA-3"),
+            ChatParticipant(id: "MESH-abc123", callsign: "ECHO-4"),
+        ]
+        let result = ChatPersistence.scrubMarkerParticipants(contacts)
+        XCTAssertEqual(result.count, contacts.count,
+            "scrubMarkerParticipants must not remove valid participants")
+    }
+
+    // MARK: B-3: PointMarker round-trips through PointMarkerPersistence
+
+    func testPointMarkerPersistsAndLoads() {
+        let persistence = PointMarkerPersistence()
+        let marker = PointMarker(
+            name: "TEST-HOS-1",
+            affiliation: .hostile,
+            coordinate: .init(latitude: 47.0, longitude: -122.0),
+            remarks: "test persist"
+        )
+
+        // Save and immediately reload.
+        persistence.saveMarkers([marker])
+        let loaded = persistence.loadMarkers()
+
+        XCTAssertEqual(loaded.count, 1,
+            "Exactly one marker must survive a save/load cycle")
+        guard let reloaded = loaded.first else {
+            return XCTFail("No markers returned from loadMarkers()")
+        }
+        XCTAssertEqual(reloaded.id, marker.id,
+            "Marker UUID must survive round-trip")
+        XCTAssertEqual(reloaded.name, marker.name,
+            "Marker name must survive round-trip")
+        XCTAssertEqual(reloaded.affiliation, marker.affiliation,
+            "Marker affiliation must survive round-trip")
+        XCTAssertEqual(reloaded.uid, marker.uid,
+            "Marker UID ('marker-<uuid>') must survive round-trip")
+        XCTAssertTrue(
+            reloaded.uid.hasPrefix("marker-"),
+            "Reloaded marker UID must still carry the 'marker-' prefix"
+        )
+
+        // Cleanup — restore empty set so the test is hermetic.
+        persistence.saveMarkers([])
+    }
+
+    // MARK: B-4: Marker UID prefix is stable across encode/decode
+
+    func testMarkerUIDPrefixSurvivesCodec() throws {
+        let marker = PointMarker(
+            name: "CODEC-CHECK",
+            affiliation: .friendly,
+            coordinate: .init(latitude: 0, longitude: 0)
+        )
+        XCTAssertTrue(marker.uid.hasPrefix("marker-"),
+            "Fresh PointMarker must have uid starting with 'marker-'")
+
+        let data = try JSONEncoder().encode(marker)
+        let decoded = try JSONDecoder().decode(PointMarker.self, from: data)
+
+        XCTAssertEqual(decoded.uid, marker.uid,
+            "UID must be unchanged after JSON encode → decode")
+        XCTAssertTrue(decoded.uid.hasPrefix("marker-"),
+            "Decoded PointMarker uid must still start with 'marker-'")
+    }
+}


### PR DESCRIPTION
## Summary

Field report from Patrick Coyle (2026-06-12) — two related bugs in the locally-dropped-marker lifecycle. iOS parity for Android #118 and #119.

- **Bug A (#118 parity):** Locally-dropped point markers were appearing as selectable contacts in the Chat menu and the New-Chat sheet. Root cause: `CoTEventHandler.handlePositionUpdate` fed every non-RID, non-self CoT event into `ChatManager.participants`, including marker-prefixed UIDs emitted when a dropped marker is broadcast to the server and echoed back. Dropped markers are static map annotations — they cannot receive DMs.

- **Bug B (#119 parity):** Related persistence cleanup — any `marker-` or `RID-` prefixed UIDs that landed in `participants.json` before this fix (via Bug A) were reloaded on the next launch and re-appeared in the contact list. Fixed with a one-time scrub at `ChatManager.init` load time.

## Classification

The discriminant is the `UID prefix`:
- `marker-<UUID>` — locally-dropped `PointMarker`. Set unconditionally by `PointMarker.init` (`uid = "marker-\(id.uuidString)"`). Not a chat endpoint.
- `RID-<id>` — drone detection from `RemoteIdAppBridge` / gyb sensor. Already excluded pre-fix; now explicitly documented alongside the new filter.
- Anything else — real EUD (PPLI from a TAK server or mesh peer). Chat-capable.

## Changes

- `CoTXMLBuilder.swift` — adds `String.isDroppedPointMarkerUID` extension (canonical shared predicate, alongside existing `xmlEscaped`)
- `CoTEventHandler.swift` — extends the RID exclusion gate to also skip `marker-` UIDs from the participant-store feed
- `ChatManager.swift` — adds `chatableParticipants` computed property (filters `participants` to real EUDs only); scrubs stale marker entries at load time
- `ChatPersistence.swift` — adds `static func scrubMarkerParticipants(_:)` helper
- `ChatView.swift` — `contactStubs` and `NewChatView.availableParticipants` switch to `chatableParticipants`
- `MarkerLifecycleTests.swift` (new) — 10 TDD tests across `MarkerChatFilterTests` and `MarkerParticipantPersistenceTests`, wired into `OmniTAKTests` target

## Test plan

- [x] `MarkerChatFilterTests` (6 tests) — predicate correctness, chatableParticipants excludes marker UIDs, broadcast-echo still excluded
- [x] `MarkerParticipantPersistenceTests` (4 tests) — scrub removes stale entries, no-op on clean data, PointMarker round-trips through persistence, UID prefix survives JSON codec
- [x] All 10 tests pass: `xcodebuild test -only-testing OmniTAKTests/MarkerChatFilterTests -only-testing OmniTAKTests/MarkerParticipantPersistenceTests`
- [x] `xcodebuild build` — BUILD SUCCEEDED, no new errors
- [ ] Manual: drop a hostile marker → open Chat → confirm marker does not appear as a contact
- [ ] Manual: drop markers, force-quit, relaunch → confirm markers render on map, do not appear in Chat