### PR TITLE
fix(settings): kill fake "ATAK v5.5.1.8" title + stale hard-coded values (UI review Tier 0)

### DIFF
--- a/OmniTAKMobile/Features/Settings/Views/AboutView.swift
+++ b/OmniTAKMobile/Features/Settings/Views/AboutView.swift
@@ -9,6 +9,14 @@ import SwiftUI
 
 struct AboutView: View {
     @Environment(\.dismiss) var dismiss
+    @Environment(\.openURL) private var openURL
+
+    // App version + build pulled from the bundle (never hard-code — it rots).
+    private var versionText: String {
+        let v = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        let b = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+        return "Version \(v) (Build \(b))"
+    }
 
     var body: some View {
         NavigationView {
@@ -24,7 +32,7 @@ struct AboutView: View {
                             .font(.system(size: 32, weight: .bold))
                             .foregroundColor(Color(hex: "#FFFC00"))
 
-                        Text("Version 1.3.4 (Build 3)")
+                        Text(versionText)
                             .font(.system(size: 14))
                             .foregroundColor(.gray)
                     }
@@ -102,7 +110,7 @@ struct AboutView: View {
                     // Links
                     VStack(spacing: 12) {
                         Button(action: {
-                            // Open website
+                            if let url = URL(string: "https://omnitak.engindearing.soy") { openURL(url) }
                         }) {
                             HStack {
                                 Image(systemName: "globe")
@@ -114,7 +122,7 @@ struct AboutView: View {
                         }
 
                         Button(action: {
-                            // Open documentation
+                            if let url = URL(string: "https://github.com/engindearing-projects/OmniTAK-iOS#readme") { openURL(url) }
                         }) {
                             HStack {
                                 Image(systemName: "book.fill")
@@ -126,7 +134,7 @@ struct AboutView: View {
                         }
 
                         Button(action: {
-                            // Open GitHub
+                            if let url = URL(string: "https://github.com/engindearing-projects/OmniTAK-iOS") { openURL(url) }
                         }) {
                             HStack {
                                 Image(systemName: "chevron.left.forwardslash.chevron.right")
@@ -147,7 +155,7 @@ struct AboutView: View {
                             .font(.system(size: 12, weight: .bold))
                             .foregroundColor(Color(hex: "#FFFC00"))
 
-                        Text("2024 All Rights Reserved")
+                        Text("© \(Calendar.current.component(.year, from: Date())) All Rights Reserved")
                             .font(.system(size: 10))
                             .foregroundColor(.gray)
                     }

--- a/OmniTAKMobile/Features/Settings/Views/NetworkPreferencesView.swift
+++ b/OmniTAKMobile/Features/Settings/Views/NetworkPreferencesView.swift
@@ -74,32 +74,16 @@ struct NetworkPreferencesView: View {
                                 description: "Enable connection health monitoring",
                                 isOn: $monitorServerConnections
                             )
-
-                            // Note: Additional settings (TrustStore, Client Certs, Network, Datalink)
-                            // will be added here when implemented
                         }
                     }
                 }
             }
-            .navigationTitle("ATAK v5.5.1.8 (7f381e4d)")
+            .navigationTitle("Network Preferences")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItemGroup(placement: .navigationBarLeading) {
-                    Button(action: { dismiss() }) {
-                        HStack(spacing: 4) {
-                            Image(systemName: "chevron.left")
-                            Text("Settings/My Preferences")
-                                .font(.system(size: 14))
-                        }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
                         .foregroundColor(.white)
-                    }
-                }
-
-                ToolbarItemGroup(placement: .navigationBarTrailing) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "house.fill")
-                            .foregroundColor(.white)
-                    }
                 }
             }
         }


### PR DESCRIPTION
## What

J flagged the Network Preferences screen: a horrible UI with a hard-coded **"ATAK v5.5.1.8 (7f381e4d)"** nav title — OmniTAK is not ATAK, and that's a frozen ATAK build string + git hash sitting in our settings. Did a full UI/UX review of the Settings area; this PR is **Tier 0** — the safe, obvious correctness fixes. No design changes, no behavior changes beyond killing dead/fake values.

## NetworkPreferencesView
- ❌ Removed the fake `.navigationTitle("ATAK v5.5.1.8 (7f381e4d)")` → `"Network Preferences"`.
- ❌ Dropped redundant nav chrome — a leading "Settings / My Preferences" fake breadcrumb **and** a `house.fill` icon that *both* just called `dismiss()` → replaced with a single trailing **Done**.
- ❌ Removed a "will be added here when implemented" dead-code note.

## AboutView
- ❌ Hard-coded `Version 1.3.4 (Build 3)` (real app is 2.38.0) → now read from `Bundle.main` (`CFBundleShortVersionString` / `CFBundleVersion`), so it can't rot again.
- ❌ Copyright `2024` → computed current year.
- ❌ Three link buttons (Website / Documentation / Source Code) had **empty actions** → now open real URLs (omnitak.engindearing.soy + the GitHub repo).

## Verification
- `xcodebuild` clean for the simulator.
- On-device render-verified on the iOS sim: navigated Map → connection-status bar → Network Preferences; the fake ATAK title is **gone**, single clean Done button confirmed.

## Not in this PR (await J's call)
- **Tier 1**: the two Network toggles (`displayConnectionWidget`, `monitorServerConnections`) are write-only/dead — read nowhere. Implement or remove. Same for the disabled Block-Contact stub and the prefilled `public.opentakserver.io` default in SimpleEnrollView.
- **Tier 2**: delete dead code (SHARED_INTERFACES.swift, QuickStartGuide cluster, AsyncImageView, RouteQuickActionsView).
- **Tier 3**: the real design overhaul — design-token colors (Emerald/Indigo, not ATAK black+cyan), rebuild as a `Form`, one dismiss convention, Dynamic Type + a11y.

🤖 Generated with [Claude Code](https://claude.com/claude-code)